### PR TITLE
Add Yaml Model V2 to support short-form metadata namespace

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/fileformat/FileFormatResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/fileformat/FileFormatResource.java
@@ -141,7 +141,7 @@ public class FileFormatResource implements RESTResource {
             """;
 
     private static final String YAML_THINGS_EXAMPLE = """
-            version: 1
+            version: 2
             things:
               binding:typeBridge:idBridge:
                 isBridge: true
@@ -165,7 +165,7 @@ public class FileFormatResource implements RESTResource {
             """;
 
     private static final String YAML_ITEMS_EXAMPLE = """
-            version: 1
+            version: 2
             items:
               Group1:
                 type: Group
@@ -198,7 +198,7 @@ public class FileFormatResource implements RESTResource {
             """;
 
     private static final String YAML_ITEMS_AND_THINGS_EXAMPLE = """
-            version: 1
+            version: 2
             things:
               binding:typeBridge:idBridge:
                 isBridge: true

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -81,11 +81,13 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
  * @author Laurent Garnier - new parameters to retrieve errors and warnings when loading a file
  * @author Laurent Garnier - Added methods addElementsToBeGenerated, generateFileFormat, createIsolatedModel and
  *         removeIsolatedModel
+ * @author Jimmy Tanagra - Increase YAML model to version 2
  */
 @NonNullByDefault
 @Component(immediate = true)
 public class YamlModelRepositoryImpl implements WatchService.WatchEventListener, YamlModelRepository {
-    private static final int DEFAULT_MODEL_VERSION = 1;
+    private static final int DEFAULT_MODEL_VERSION = 2;
+
     private static final String VERSION = "version";
     private static final String READ_ONLY = "readOnly";
     private static final Set<String> KNOWN_ELEMENTS = Set.of( //

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemFileConverter.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemFileConverter.java
@@ -47,10 +47,10 @@ import org.openhab.core.model.yaml.YamlElement;
 import org.openhab.core.model.yaml.YamlModelRepository;
 import org.openhab.core.model.yaml.internal.items.YamlChannelLinkProvider;
 import org.openhab.core.model.yaml.internal.items.YamlGroupDTO;
-import org.openhab.core.model.yaml.internal.items.YamlItemDTO;
-import org.openhab.core.model.yaml.internal.items.YamlItemProvider;
-import org.openhab.core.model.yaml.internal.items.YamlMetadataDTO;
 import org.openhab.core.model.yaml.internal.items.YamlMetadataProvider;
+import org.openhab.core.model.yaml.internal.items.v2.YamlItemDTO;
+import org.openhab.core.model.yaml.internal.items.v2.YamlItemProvider;
+import org.openhab.core.model.yaml.internal.items.v2.YamlMetadataDTO;
 import org.openhab.core.types.State;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -60,6 +60,7 @@ import org.osgi.service.component.annotations.Reference;
  * {@link YamlItemFileConverter} is the YAML file converter for {@link Item} object.
  *
  * @author Laurent Garnier - Initial contribution
+ * @author Jimmy Tanagra - Upgrade to use version 2 DTOs
  */
 @NonNullByDefault
 @Component(immediate = true, service = { ItemFileGenerator.class, ItemFileParser.class })

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/v2/YamlItemDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/v2/YamlItemDTO.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.model.yaml.internal.items.v2;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.common.AbstractUID;
+import org.openhab.core.items.GroupItem;
+import org.openhab.core.items.ItemUtil;
+import org.openhab.core.items.MetadataKey;
+import org.openhab.core.model.yaml.YamlElement;
+import org.openhab.core.model.yaml.YamlElementName;
+import org.openhab.core.model.yaml.internal.items.YamlGroupDTO;
+import org.openhab.core.model.yaml.internal.util.YamlElementUtils;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.profiles.ProfileTypeUID;
+
+/**
+ * The {@link YamlItemDTO} is a data transfer object used to serialize an item in a YAML configuration file.
+ *
+ * @author Laurent Garnier - Initial contribution
+ * @author Jimmy Tanagra – Added Model V2 support including short‑form metadata syntax
+ */
+@YamlElementName("items")
+public class YamlItemDTO implements YamlElement, Cloneable {
+
+    private static final Pattern ICON_SEGMENT_PATTERN = Pattern.compile("[a-zA-Z0-9_][a-zA-Z0-9_-]*");
+
+    public String name;
+    public String type;
+    public String dimension;
+    public YamlGroupDTO group;
+    public String label;
+    public String icon;
+    public String format;
+    public String unit;
+    public Boolean autoupdate;
+    public List<@NonNull String> groups;
+    public Set<@NonNull String> tags;
+    public String channel;
+    public Map<@NonNull String, @NonNull Map<@NonNull String, @NonNull Object>> channels;
+    public Map<@NonNull String, @NonNull YamlMetadataDTO> metadata;
+
+    public YamlItemDTO() {
+    }
+
+    @Override
+    public @NonNull String getId() {
+        return name == null ? "" : name;
+    }
+
+    @Override
+    public void setId(@NonNull String id) {
+        name = id;
+    }
+
+    @Override
+    public YamlElement cloneWithoutId() {
+        YamlItemDTO copy;
+        try {
+            copy = (YamlItemDTO) super.clone();
+            copy.name = null;
+            return copy;
+        } catch (CloneNotSupportedException e) {
+            // Will never happen
+            return new YamlItemDTO();
+        }
+    }
+
+    @Override
+    public boolean isValid(@Nullable List<@NonNull String> errors, @Nullable List<@NonNull String> warnings) {
+        // Check that name is present
+        if (name == null || name.isBlank()) {
+            addToList(errors, "invalid item: name missing while mandatory");
+            return false;
+        }
+        boolean ok = true;
+        if (!ItemUtil.isValidItemName(name)) {
+            addToList(errors,
+                    "invalid item \"%s\": \"name\" must begin with a letter or underscore followed by alphanumeric characters and underscores, and must not contain any other symbols."
+                            .formatted(name));
+            ok = false;
+        }
+        List<String> subErrors = new ArrayList<>();
+        List<String> subWarnings = new ArrayList<>();
+        if (type == null || type.isBlank()) {
+            addToList(errors, "invalid item \"%s\": \"type\" field missing while mandatory".formatted(name));
+            ok = false;
+        } else if (GroupItem.TYPE.equalsIgnoreCase(type)) {
+            if (dimension != null) {
+                addToList(warnings, "item \"%s\": \"dimension\" field ignored as type is Group".formatted(name));
+            }
+            if (group != null) {
+                ok &= group.isValid(subErrors, subWarnings);
+                subErrors.forEach(error -> {
+                    addToList(errors, "invalid item \"%s\": %s".formatted(name, error));
+                });
+                subWarnings.forEach(warning -> {
+                    addToList(warnings, "item \"%s\": %s".formatted(name, warning));
+                });
+            }
+        } else {
+            if (group != null) {
+                addToList(warnings, "item \"%s\": \"group\" field ignored as type is not Group".formatted(name));
+            }
+            if (!YamlElementUtils.isValidItemType(type)) {
+                addToList(errors, "invalid item \"%s\": invalid value \"%s\" for \"type\" field".formatted(name, type));
+                ok = false;
+            } else if (YamlElementUtils.isNumberItemType(type)) {
+                if (!YamlElementUtils.isValidItemDimension(dimension)) {
+                    addToList(errors, "invalid item \"%s\": invalid value \"%s\" for \"dimension\" field"
+                            .formatted(name, dimension));
+                    ok = false;
+                }
+            } else if (dimension != null) {
+                addToList(warnings,
+                        "item \"%s\": \"dimension\" field ignored as type is not Number".formatted(name, dimension));
+            }
+        }
+        if (icon != null) {
+            subErrors.clear();
+            ok &= isValidIcon(icon, subErrors);
+            subErrors.forEach(error -> {
+                addToList(errors, "invalid item \"%s\": %s".formatted(name, error));
+            });
+        }
+        if (groups != null) {
+            for (String gr : groups) {
+                if (!ItemUtil.isValidItemName(gr)) {
+                    addToList(errors,
+                            "invalid item \"%s\": value \"%s\" in \"groups\" field must begin with a letter or underscore followed by alphanumeric characters and underscores, and must not contain any other symbols."
+                                    .formatted(name, gr));
+                    ok = false;
+                }
+            }
+        }
+        if (channel != null) {
+            subErrors.clear();
+            ok &= isValidChannel(channel, null, subErrors);
+            subErrors.forEach(error -> {
+                addToList(errors, "invalid item \"%s\": %s".formatted(name, error));
+            });
+        }
+        if (channels != null) {
+            for (String ch : channels.keySet()) {
+                subErrors.clear();
+                ok &= isValidChannel(ch, channels.get(ch), subErrors);
+                subErrors.forEach(error -> {
+                    addToList(errors, "invalid item \"%s\": %s".formatted(name, error));
+                });
+            }
+        }
+        if (metadata != null) {
+            for (String namespace : metadata.keySet()) {
+                try {
+                    new MetadataKey(namespace, name);
+                } catch (IllegalArgumentException e) {
+                    addToList(errors, "invalid item \"%s\": invalid metadata key (\"%s\", \"%s\"): %s".formatted(name,
+                            namespace, name, e.getMessage()));
+                    ok = false;
+                }
+            }
+            YamlMetadataDTO md = metadata.get("autoupdate");
+            if (md != null && autoupdate != null) {
+                addToList(warnings,
+                        "item \"%s\": \"autoupdate\" field is redundant with \"autoupdate\" metadata; value \"%s\" will be considered"
+                                .formatted(name, md.getValue()));
+            }
+            md = metadata.get("unit");
+            if (md != null && unit != null) {
+                addToList(warnings,
+                        "item \"%s\": \"unit\" field is redundant with \"unit\" metadata; value \"%s\" will be considered"
+                                .formatted(name, md.getValue()));
+            }
+            md = metadata.get("stateDescription");
+            Map<@NonNull String, @NonNull Object> mdConfig = md == null ? null : md.config;
+            Object pattern = mdConfig == null ? null : mdConfig.get("pattern");
+            if (pattern != null && format != null) {
+                addToList(warnings,
+                        "item \"%s\": \"format\" field is redundant with pattern in \"stateDescription\" metadata; \"%s\" will be considered"
+                                .formatted(name, pattern));
+            }
+        }
+        return ok;
+    }
+
+    private boolean isValidIcon(String icon, List<@NonNull String> errors) {
+        boolean ok = true;
+        String[] segments = icon.split(AbstractUID.SEPARATOR);
+        int nb = segments.length;
+        if (nb > 3) {
+            errors.add("too many segments in value \"%s\" for \"icon\" field; maximum 3 is expected".formatted(icon));
+            ok = false;
+            nb = 3;
+        }
+        for (int i = 0; i < nb; i++) {
+            String segment = segments[i];
+            if (!ICON_SEGMENT_PATTERN.matcher(segment).matches()) {
+                errors.add("segment \"%s\" in \"icon\" field not matching the expected syntax %s".formatted(segment,
+                        ICON_SEGMENT_PATTERN.pattern()));
+                ok = false;
+            }
+        }
+        return ok;
+    }
+
+    private boolean isValidChannel(String channelUID, @Nullable Map<@NonNull String, @NonNull Object> configuration,
+            List<@NonNull String> errors) {
+        boolean ok = true;
+        try {
+            new ChannelUID(channelUID);
+        } catch (IllegalArgumentException e) {
+            errors.add("invalid channel UID \"%s\": %s".formatted(channelUID, e.getMessage()));
+            ok = false;
+        }
+        if (configuration != null && configuration.containsKey("profile")
+                && configuration.get("profile") instanceof String profile) {
+            String[] splittedProfile = profile.split(AbstractUID.SEPARATOR, 2);
+            try {
+                if (splittedProfile.length == 1) {
+                    new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, profile);
+                } else {
+                    new ProfileTypeUID(splittedProfile[0], splittedProfile[1]);
+                }
+            } catch (IllegalArgumentException e) {
+                errors.add("invalid value \"%s\" for \"profile\" parameter of channel \"%s\": %s".formatted(profile,
+                        channelUID, e.getMessage()));
+                ok = false;
+            }
+        }
+        return ok;
+    }
+
+    private void addToList(@Nullable List<@NonNull String> list, String value) {
+        if (list != null) {
+            list.add(value);
+        }
+    }
+
+    public @Nullable String getType() {
+        return YamlElementUtils.getItemTypeWithDimension(type, dimension);
+    }
+
+    public @NonNull List<@NonNull String> getGroups() {
+        return groups == null ? List.of() : groups;
+    }
+
+    public @NonNull Set<@NonNull String> getTags() {
+        return tags == null ? Set.of() : tags;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, getType(), group, label, icon, format, unit, autoupdate, getGroups(), getTags(),
+                channel);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        YamlItemDTO other = (YamlItemDTO) obj;
+        return Objects.equals(name, other.name) && Objects.equals(getType(), other.getType())
+                && Objects.equals(group, other.group) && Objects.equals(label, other.label)
+                && Objects.equals(icon, other.icon) && Objects.equals(format, other.format)
+                && Objects.equals(unit, other.unit) && Objects.equals(autoupdate, other.autoupdate)
+                && Objects.equals(getGroups(), other.getGroups()) && Objects.equals(getTags(), other.getTags())
+                && Objects.equals(channel, other.channel) && equalsChannels(channels, other.channels)
+                && equalsMetadata(metadata, other.metadata);
+    }
+
+    private boolean equalsChannels(@Nullable Map<@NonNull String, @NonNull Map<@NonNull String, @NonNull Object>> first,
+            @Nullable Map<@NonNull String, @NonNull Map<@NonNull String, @NonNull Object>> second) {
+        if (first != null && second != null) {
+            if (first.size() != second.size()) {
+                return false;
+            } else {
+                return first.entrySet().stream()
+                        .allMatch(e -> YamlElementUtils.equalsConfig(e.getValue(), second.get(e.getKey())));
+            }
+        } else {
+            return first == null && second == null;
+        }
+    }
+
+    private boolean equalsMetadata(@Nullable Map<@NonNull String, @NonNull YamlMetadataDTO> first,
+            @Nullable Map<@NonNull String, @NonNull YamlMetadataDTO> second) {
+        if (first != null && second != null) {
+            if (first.size() != second.size()) {
+                return false;
+            } else {
+                return first.entrySet().stream().allMatch(e -> e.getValue().equals(second.get(e.getKey())));
+            }
+        } else {
+            return first == null && second == null;
+        }
+    }
+}

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/v2/YamlItemProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/v2/YamlItemProvider.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.model.yaml.internal.items;
+package org.openhab.core.model.yaml.internal.items.v2;
 
 import static org.openhab.core.model.yaml.YamlModelUtils.isIsolatedModel;
 
@@ -35,6 +35,10 @@ import org.openhab.core.items.dto.GroupFunctionDTO;
 import org.openhab.core.items.dto.ItemDTOMapper;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.model.yaml.YamlModelListener;
+import org.openhab.core.model.yaml.internal.items.YamlChannelLinkProvider;
+import org.openhab.core.model.yaml.internal.items.YamlGroupDTO;
+import org.openhab.core.model.yaml.internal.items.YamlMetadataDTO;
+import org.openhab.core.model.yaml.internal.items.YamlMetadataProvider;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -48,7 +52,7 @@ import org.slf4j.LoggerFactory;
  * These items are automatically exposed to the {@link org.openhab.core.items.ItemRegistry}.
  *
  * @author Laurent Garnier - Initial contribution
- * @author Jimmy Tanagra - Restricted this provider to v1 to avoid overlap with the new Model V2 provider.
+ * @author Jimmy Tanagra - Upgrade to version 2
  */
 @NonNullByDefault
 @Component(immediate = true, service = { ItemProvider.class, YamlItemProvider.class, YamlModelListener.class })
@@ -94,7 +98,7 @@ public class YamlItemProvider extends AbstractProvider<Item> implements ItemProv
 
     @Override
     public boolean isVersionSupported(int version) {
-        return version == 1;
+        return version >= 2;
     }
 
     @Override
@@ -260,13 +264,16 @@ public class YamlItemProvider extends AbstractProvider<Item> implements ItemProv
     }
 
     private void processMetadata(String modelName, String itemName, @Nullable YamlItemDTO itemDTO) {
+        // Convert V2 metadata (which supports short-form syntax) to V1 format for the shared metadata provider.
+        // The YamlMetadataProvider is shared between V1 and V2 item providers and expects V1 DTOs.
         Map<String, YamlMetadataDTO> metadata = new HashMap<>();
         if (itemDTO != null) {
             boolean hasAutoUpdateMetadata = false;
             boolean hasUnitMetadata = false;
             boolean hasStateDescriptionMetadata = false;
             if (itemDTO.metadata != null) {
-                for (Map.Entry<String, YamlMetadataDTO> entry : itemDTO.metadata.entrySet()) {
+                for (Map.Entry<String, org.openhab.core.model.yaml.internal.items.v2.YamlMetadataDTO> entry : itemDTO.metadata
+                        .entrySet()) {
                     if ("autoupdate".equals(entry.getKey())) {
                         hasAutoUpdateMetadata = true;
                     } else if ("unit".equals(entry.getKey())) {

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/v2/YamlMetadataDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/v2/YamlMetadataDTO.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.model.yaml.internal.items.v2;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.model.yaml.internal.util.YamlElementUtils;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * The {@link YamlMetadataDTO} is a data transfer object used to serialize a metadata for a particular namespace
+ * in a YAML configuration file.
+ *
+ * @author Laurent Garnier – Initial contribution
+ * @author Jimmy Tanagra – Added Model V2 support with short‑form scalar values
+ */
+@JsonDeserialize(using = YamlMetadataDTODeserializer.class)
+@JsonSerialize(using = YamlMetadataDTOSerializer.class)
+public class YamlMetadataDTO {
+
+    public String value;
+    public Map<@NonNull String, @NonNull Object> config;
+
+    public YamlMetadataDTO() {
+    }
+
+    public @NonNull String getValue() {
+        return value == null ? "" : value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getValue());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        YamlMetadataDTO other = (YamlMetadataDTO) obj;
+        return Objects.equals(getValue(), other.getValue()) && YamlElementUtils.equalsConfig(config, other.config);
+    }
+}

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/v2/YamlMetadataDTODeserializer.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/v2/YamlMetadataDTODeserializer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.model.yaml.internal.items.v2;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Custom deserializer for {@link YamlMetadataDTO} that converts any YAML scalar
+ * (string, integer, boolean, or float) into a metadata String {@code value} with an empty config.
+ *
+ * @author Jimmy Tanagra - Initial contribution
+ */
+public class YamlMetadataDTODeserializer extends JsonDeserializer<YamlMetadataDTO> {
+
+    @Override
+    public YamlMetadataDTO deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonToken token = p.currentToken();
+        if (token == JsonToken.VALUE_STRING || token == JsonToken.VALUE_NUMBER_INT
+                || token == JsonToken.VALUE_NUMBER_FLOAT || token == JsonToken.VALUE_TRUE
+                || token == JsonToken.VALUE_FALSE) {
+            YamlMetadataDTO dto = new YamlMetadataDTO();
+            dto.value = p.getValueAsString("");
+            return dto;
+        }
+
+        if (token == JsonToken.START_OBJECT) {
+            ObjectCodec codec = p.getCodec();
+            JsonNode node = codec.readTree(p);
+
+            YamlMetadataDTO dto = new YamlMetadataDTO();
+            JsonNode valueNode = node.get("value");
+            if (valueNode != null && !valueNode.isNull()) {
+                dto.value = valueNode.asText();
+            }
+
+            JsonNode configNode = node.get("config");
+            if (configNode != null && !configNode.isNull()) {
+                dto.config = codec.treeToValue(configNode, Map.class);
+            }
+            return dto;
+        }
+        return (YamlMetadataDTO) ctxt.handleUnexpectedToken(YamlMetadataDTO.class, p);
+    }
+
+    @Override
+    public YamlMetadataDTO getNullValue(DeserializationContext ctxt) {
+        return new YamlMetadataDTO();
+    }
+}

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/v2/YamlMetadataDTOSerializer.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/v2/YamlMetadataDTOSerializer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.model.yaml.internal.items.v2;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+/**
+ * Custom serializer for {@link YamlMetadataDTO} that writes the namespace as a scalar
+ * when its config is empty, otherwise writes as an object with value and config fields.
+ *
+ * @author Jimmy Tanagra - Initial contribution
+ */
+public class YamlMetadataDTOSerializer extends JsonSerializer<YamlMetadataDTO> {
+    @Override
+    public void serialize(YamlMetadataDTO value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        Map<?, ?> config = value.config;
+        boolean configIsEmpty = (config == null || config.isEmpty());
+        if (configIsEmpty) {
+            gen.writeString(value.getValue());
+        } else {
+            gen.writeStartObject();
+            gen.writeStringField("value", value.getValue());
+            gen.writeObjectField("config", value.config);
+            gen.writeEndObject();
+        }
+    }
+}

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/items/v2/YamlMetadataDTODeserializerTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/items/v2/YamlMetadataDTODeserializerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.model.yaml.internal.items.v2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+/**
+ * Tests for {@link YamlMetadataDTODeserializer}.
+ *
+ * @author Jimmy Tanagra - Initial contribution
+ */
+class YamlMetadataDTODeserializerTest {
+
+    private final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+
+    @ParameterizedTest
+    @ValueSource(strings = { "string value", "123", "45.67", "true", "false" })
+    void shouldDeserializeScalarAsValueWithEmptyConfig(String scalar) throws IOException {
+        String yaml = "ns: " + scalar;
+        YamlMetadataDTO dto = mapper.treeToValue(mapper.readTree(yaml).get("ns"), YamlMetadataDTO.class);
+        assertNotNull(dto);
+        assertEquals(scalar, dto.getValue());
+        assertNull(dto.config);
+    }
+
+    @Test
+    void shouldDeserializeObjectWithValueAndConfig() throws IOException {
+        String yaml = "ns: { value: bar, config: { a: 1, b: two } }";
+        YamlMetadataDTO dto = mapper.treeToValue(mapper.readTree(yaml).get("ns"), YamlMetadataDTO.class);
+        assertNotNull(dto);
+        assertEquals("bar", dto.getValue());
+        assertNotNull(dto.config);
+        assertEquals(1, dto.config.get("a"));
+        assertEquals("two", dto.config.get("b"));
+    }
+
+    @Test
+    void shouldDeserializeObjectWithValueAndNoConfig() throws IOException {
+        String yaml = "ns: { value: bar }";
+        YamlMetadataDTO dto = mapper.treeToValue(mapper.readTree(yaml).get("ns"), YamlMetadataDTO.class);
+        assertNotNull(dto);
+        assertEquals("bar", dto.getValue());
+        assertNull(dto.config);
+    }
+
+    @Test
+    void shouldDeserializeObjectWithNoValueAndConfig() throws IOException {
+        String yaml = "ns: { config: { a: 1, b: two } }";
+        YamlMetadataDTO dto = mapper.treeToValue(mapper.readTree(yaml).get("ns"), YamlMetadataDTO.class);
+        assertNotNull(dto);
+        assertEquals("", dto.getValue());
+        assertNotNull(dto.config);
+        assertEquals(1, dto.config.get("a"));
+        assertEquals("two", dto.config.get("b"));
+    }
+
+    @Test
+    void shouldDeserializeEmptyObjectAsEmptyDto() throws IOException {
+        String yaml = "ns: { }";
+        YamlMetadataDTO dto = mapper.treeToValue(mapper.readTree(yaml).get("ns"), YamlMetadataDTO.class);
+        assertNotNull(dto);
+        assertEquals("", dto.getValue());
+        assertNull(dto.config);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "null", "", "''" })
+    void shouldDeserializeNullAndEmptyStringAsEmptyDto(String scalar) throws IOException {
+        String yaml = "ns: " + scalar;
+        YamlMetadataDTO dto = mapper.treeToValue(mapper.readTree(yaml).get("ns"), YamlMetadataDTO.class);
+        assertNotNull(dto);
+        assertEquals("", dto.getValue());
+        assertNull(dto.config);
+    }
+}

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/items/v2/YamlMetadataDTOSerializerTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/items/v2/YamlMetadataDTOSerializerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.model.yaml.internal.items.v2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+/**
+ * Tests for {@link YamlMetadataDTOSerializer}.
+ *
+ * @author Jimmy Tanagra - Initial contribution
+ */
+class YamlMetadataDTOSerializerTest {
+    private final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+
+    @Test
+    void testSerializeScalarWhenConfigEmpty() throws Exception {
+        YamlMetadataDTO dto = new YamlMetadataDTO();
+        dto.value = "scalarValue";
+        dto.config = null;
+        String yaml = mapper.writeValueAsString(dto).trim();
+        assertEquals("--- \"scalarValue\"", yaml);
+    }
+
+    @Test
+    void testSerializeScalarWhenConfigEmptyMap() throws Exception {
+        YamlMetadataDTO dto = new YamlMetadataDTO();
+        dto.value = "scalarValue";
+        dto.config = new HashMap<>();
+        String yaml = mapper.writeValueAsString(dto).trim();
+        assertEquals("--- \"scalarValue\"", yaml);
+    }
+
+    @Test
+    void testSerializeObjectWhenConfigPresent() throws Exception {
+        YamlMetadataDTO dto = new YamlMetadataDTO();
+        dto.value = "objectValue";
+        Map<String, Object> config = new HashMap<>();
+        config.put("foo", "bar");
+        dto.config = config;
+        String yaml = mapper.writeValueAsString(dto).trim();
+        System.out.println("YAML output:\n" + yaml);
+        // Check for document start and all expected fields
+        assert yaml.startsWith("---");
+        assert yaml.contains("value: \"objectValue\"");
+        assert yaml.contains("config:");
+        assert yaml.contains("foo: \"bar\"");
+    }
+}


### PR DESCRIPTION
**Supersedes:** #5250

This PR introduces YAML Model V2 along with a new Items element provider (V2) that supports the short‑form metadata syntax.

## ✨ Summary

YAML Model V2 extends the metadata namespace definition so that a namespace may now be expressed as **either**:

- a **scalar** (short‑form), or  
- a **map** (existing long‑form)

If a scalar is provided, it is interpreted as the namespace’s `value` with no additional configuration.

A particularly useful case for this is ecosystem metadata such as **ga**, **alexa**, and **matter**, where most namespaces only require a simple value with no additional configuration. For example, with Model V2 you can write:

```yaml
items:
  itemname:
    metadata:
      ga: Light
      alexa: Light
```

instead of the more verbose Model V1 form:

```yaml
items:
  itemname:
    metadata:
      ga:
        value: Light
      alexa:
        value: Light
```

Additional updates included in this PR:

- The **file generator** now uses the new default model version (`version: 2`).
- A **serializer** has been added so that serialized YAML also uses the short‑form syntax when applicable, ensuring consistent round‑trip behavior.

## 🔄 Compatibility Notes

- Model V1 **does not** support the new short‑form syntax.
- openHAB **5.0 and 5.1** continue to use Model V1, so short‑form metadata cannot be used in those versions.
- To avoid breaking existing installations, this PR introduces **Model V2** rather than modifying Model V1.
- openHAB 5.2+ will support both Items Model V1 and V2 through independent providers.
- The original Items provider (V1) is retained to ensure full backwards compatibility with existing YAML Model V1 files.
- The other element providers (Thing, Tags) remain compatible with both Model V1 and Model V2, as their schemas have not changed.

## ✔️ Benefits

- Cleaner and more readable YAML for simple metadata.
- Consistent round‑trip behavior thanks to the updated serializer.
- Generators now default to Model V2, making the new syntax the natural choice going forward.
- No breaking changes to existing YAML files.
- Provides a clear versioning path for future YAML model enhancements.
