### PR TITLE
[YAML provider] Add INFO log for config TEXT param value not parsed a…

### DIFF
--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlThingProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlThingProvider.java
@@ -552,18 +552,20 @@ public class YamlThingProvider extends AbstractProvider<Thing>
             Object valueOut = valueIn;
             // For configuration parameter of type text only
             if (stringParameters.contains(name)) {
-                if (!(valueIn instanceof String)) {
+                if (valueIn != null && !(valueIn instanceof String)) {
                     logger.info(
-                            "\"{}\": the value of the configuration TEXT parameter \"{}\" is not interpreted as a string and will be automatically converted. Enclose your value in double quotes to prevent conversion,",
+                            "\"{}\": the value of the configuration TEXT parameter \"{}\" is not interpreted as a string and will be automatically converted. Enclose your value in double quotes to prevent conversion.",
                             uid, name);
                 }
                 // if the value in YAML is an unquoted number, the value resulting of the parsing can then be
-                // of type BigDecimal or BigInteger. If the value is of type BigDecimal, we convert it into
-                // a String. If there is no decimal, we convert it to an integer and return a String from that
-                // integer.
-                // Value 1 in YAML is converted into String "1"
-                // Value 1.0 in YAML is converted into String "1"
-                // Value 1.5 in YAML is converted into String "1.5"
+                // of type BigDecimal or BigInteger.
+                // If the value is of type BigDecimal, we convert it into a String. If there is no decimal,
+                // we convert it to an integer and return a String from that integer.
+                // - Value 1 in YAML is converted into String "1"
+                // - Value 1.0 in YAML is converted into String "1"
+                // - Value 1.5 in YAML is converted into String "1.5"
+                // If the value is not of type BigDecimal, it is kept unchanged. Conversion to a String will
+                // be applied at a next step during configuration normalization.
                 if (valueIn instanceof BigDecimal bigDecimalValue) {
                     try {
                         valueOut = bigDecimalValue.stripTrailingZeros().scale() <= 0


### PR DESCRIPTION
…s string

Related to openhab/openhab-webui#3696
Follow-up #5248

A log at level INFO is now displayed when a YAML file is loaded and contains a thing or channel configuration parameter of type TEXT whose value is not parsed as a string. This occurs when an unquoted number is provided. The log recommends enclosing the value in double quotes to prevent conversion.

For better consistency, the YAML provider is now also processing any BigDecimal value to convert it into a String type when the config paramater is of type TEXT.
