### PR TITLE
Allow empty or null metadata values via the REST API

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -748,7 +748,6 @@ public class ItemResource implements RESTResource {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = { //
                     @ApiResponse(responseCode = "200", description = "OK"), //
                     @ApiResponse(responseCode = "201", description = "Created"), //
-                    @ApiResponse(responseCode = "400", description = "Metadata value empty."), //
                     @ApiResponse(responseCode = "404", description = "Item not found."), //
                     @ApiResponse(responseCode = "405", description = "Metadata not editable.") })
     public Response addMetadata(@PathParam("itemname") @Parameter(description = "item name") String itemname,
@@ -761,8 +760,8 @@ public class ItemResource implements RESTResource {
         }
 
         String value = metadata.value;
-        if (value == null || value.isEmpty()) {
-            return Response.status(Status.BAD_REQUEST).build();
+        if (value == null) {
+            value = "";
         }
 
         MetadataKey key = new MetadataKey(namespace, itemname);


### PR DESCRIPTION
MainUI currently has to work around a limitation in the metadata API:  
when a metadata namespace value is unset or explicitly set to an empty string (`""`), the update fails unless the UI pads the value with a space.

This leads to brittle and awkward UI logic, and the same workaround would need to be duplicated in the new MainUI code editor. A blank metadata value should be a valid state, and the UI should not have to inject placeholder characters to make the update succeed.

This PR allows metadata namespace values to be `null` or an empty string.  
Accepting these values removes the need for UI-side hacks and makes metadata updates behave consistently across all editors.
