### PR TITLE
Add comment to ProgressCallback doc

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/ProgressCallback.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/ProgressCallback.java
@@ -105,11 +105,13 @@ public interface ProgressCallback {
      * Callback operation to update the percentage progress of the firmware update.
      * This method can be used to provide detailed progress information additional to the sequence or even without a
      * previous defined sequence.
+     * <br>
+     * Note that calling this method before the first call to next() will cause the iterator to be stepped to the first
+     * state!
      *
      * @param progress the progress between 0 and 100
      * @throws IllegalArgumentException if given progress is {@code < 0} or {@code > 100} or if given progress is
-     *             smaller than old
-     *             progress
+     *             smaller than old progress
      * @throws IllegalStateException if update is finished
      */
     void update(int progress);


### PR DESCRIPTION
`ProgressCallback` uses an iterator to step through the states, and there's no way to know the current state from the binding. The user is expected to call the `next` method to step the states, but the iterator is also stepped if `update` is called before the first call to `next`.

This doesn't feel very nice to me, and I would have preferred to handle this differently, but I didn't want to break the implementation in case others rely on this. Instead I've just added a note to the doc.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>
