### PR TITLE
Fix `Instant` deserialization for action inputs

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ActionInputsHelper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ActionInputsHelper.java
@@ -16,7 +16,6 @@ import java.math.BigDecimal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -299,27 +298,23 @@ public class ActionInputsHelper {
                         case "java.time.ZonedDateTime" -> {
                             /*
                              * Accepted format is one of:
-                             * - 2007-12-03T09:15:30Z
                              * - 2007-12-03T10:15:30
+                             * - 2007-12-03T09:15:30Z
                              * - 2007-12-03T10:15:30+01:00
                              * - 2007-12-03T10:15:30+01:00[Europe/Paris]
                              */
-                            if (valueString.endsWith("Z")) {
-                                yield Instant.parse(valueString).atZone(timeZoneProvider.getTimeZone());
-                            } else {
-                                TemporalAccessor dt = DateTimeFormatter.ISO_DATE_TIME.parseBest(valueString,
-                                        ZonedDateTime::from, LocalDateTime::from);
-                                if (dt instanceof ZonedDateTime zdt) {
-                                    yield zdt;
-                                }
-                                yield ((LocalDateTime) dt).atZone(timeZoneProvider.getTimeZone());
+                            TemporalAccessor dt = DateTimeFormatter.ISO_DATE_TIME.parseBest(valueString,
+                                    ZonedDateTime::from, LocalDateTime::from);
+                            if (dt instanceof ZonedDateTime zdt) {
+                                yield zdt;
                             }
+                            yield ((LocalDateTime) dt).atZone(timeZoneProvider.getTimeZone());
                         }
                         case "java.time.Instant" -> {
                             /*
                              * Accepted format is one of:
-                             * - 2007-12-03T09:15:30Z
                              * - 2007-12-03T10:15:30
+                             * - 2007-12-03T09:15:30Z
                              * - 2007-12-03T10:15:30+01:00
                              * - 2007-12-03T10:15:30+01:00[Europe/Paris]
                              */

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ActionInputHelperTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ActionInputHelperTest.java
@@ -428,7 +428,7 @@ public class ActionInputHelperTest {
     @Test
     public void testMapSerializedInputToActionInputWhenZonedDateTime() {
         String valAsString = "2007-12-03T09:15:30Z";
-        ZonedDateTime val = Instant.parse(valAsString).atZone(timeZoneProvider.getTimeZone());
+        ZonedDateTime val = ZonedDateTime.parse(valAsString, DateTimeFormatter.ISO_DATE_TIME);
         Input input = buildInput("java.time.ZonedDateTime");
         assertThat(helper.mapSerializedInputToActionInput(input, val), is(val));
         assertThat(helper.mapSerializedInputToActionInput(input, valAsString), is(val));


### PR DESCRIPTION
Also add support for `ZonedDateTime` format, as well as `Instant` format for `ZonedDateTime` action inputs.

This does not affect MainUI since it serializes user input into `LocalDateTime` format, but it makes the REST API support providing a serialized `Instant`. See https://github.com/openhab/openhab-core/issues/5285#issuecomment-3774451268. It also adds a few other formats, so that action inputs will accept the same input whether `ZonedDateTime` or `Instant`.

Resolves #5285 