### PR TITLE
Optimize `ZonedDateTime.now().toInstant()`

### DIFF
--- a/bundles/org.openhab.core.io.rest.log/src/main/java/org/openhab/core/io/rest/log/internal/LogHandler.java
+++ b/bundles/org.openhab.core.io.rest.log/src/main/java/org/openhab/core/io/rest/log/internal/LogHandler.java
@@ -13,7 +13,7 @@
 package org.openhab.core.io.rest.log.internal;
 
 import java.net.URL;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -140,7 +140,7 @@ public class LogHandler implements RESTResource {
             return Response.status(500)
                     .entity(String.format(TEMPLATE_INTERNAL_ERROR, LogConstants.LOG_HANDLE_ERROR, "ERROR")).build();
         }
-        logMessage.timestamp = ZonedDateTime.now().toInstant().toEpochMilli();
+        logMessage.timestamp = Instant.now().toEpochMilli();
 
         if (!doLog(logMessage)) {
             return Response.status(403).entity(String.format(TEMPLATE_INTERNAL_ERROR,

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/items/GenericItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/items/GenericItemTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Locale;
@@ -167,7 +168,7 @@ public class GenericItemTest {
         assertNull(item.getLastStateUpdate());
         item.setState(PercentType.HUNDRED);
         assertThat(item.getLastStateUpdate().toInstant().toEpochMilli() * 1.0,
-                is(closeTo(ZonedDateTime.now().toInstant().toEpochMilli(), 5)));
+                is(closeTo(Instant.now().toEpochMilli(), 5)));
     }
 
     @Test
@@ -175,20 +176,20 @@ public class GenericItemTest {
         TestItem item = new TestItem("member1");
         assertNull(item.getLastStateChange());
         item.setState(PercentType.HUNDRED);
-        ZonedDateTime initialChangeTime = ZonedDateTime.now();
+        Instant initialChangeTime = Instant.now();
         assertThat(item.getLastStateChange().toInstant().toEpochMilli() * 1.0,
-                is(closeTo(initialChangeTime.toInstant().toEpochMilli(), 5)));
+                is(closeTo(initialChangeTime.toEpochMilli(), 5)));
 
         Thread.sleep(50);
         item.setState(PercentType.HUNDRED);
         assertThat(item.getLastStateChange().toInstant().toEpochMilli() * 1.0,
-                is(closeTo(initialChangeTime.toInstant().toEpochMilli(), 5)));
+                is(closeTo(initialChangeTime.toEpochMilli(), 5)));
 
         Thread.sleep(50);
-        ZonedDateTime secondChangeTime = ZonedDateTime.now();
+        Instant secondChangeTime = Instant.now();
         item.setState(PercentType.ZERO);
         assertThat(item.getLastStateChange().toInstant().toEpochMilli() * 1.0,
-                is(closeTo(secondChangeTime.toInstant().toEpochMilli(), 5)));
+                is(closeTo(secondChangeTime.toEpochMilli(), 5)));
     }
 
     @Test

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/DayOfWeekConditionHandlerTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/DayOfWeekConditionHandlerTest.java
@@ -16,9 +16,8 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
-import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
-import java.util.Date;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -49,9 +48,10 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class DayOfWeekConditionHandlerTest extends BasicConditionHandlerTest {
 
+    private static final DateTimeFormatter DOW_FORMATTER = DateTimeFormatter.ofPattern("EEE", Locale.ENGLISH);
+
     private final Logger logger = LoggerFactory.getLogger(DayOfWeekConditionHandlerTest.class);
-    private SimpleDateFormat sdf = new SimpleDateFormat("EEE", Locale.ENGLISH);
-    private String dayOfWeek = sdf.format(Date.from(ZonedDateTime.now().toInstant())).toUpperCase();
+    private String dayOfWeek = ZonedDateTime.now().format(DOW_FORMATTER).toUpperCase(Locale.ENGLISH);
 
     public DayOfWeekConditionHandlerTest() {
         logger.info("Today is {}", dayOfWeek);


### PR DESCRIPTION
Creating a `ZonedDateTime` just to get its `Instant` is unnecessary.