### PR TITLE
Preserve Short‑Form `format` When Generating YAML

### DIFF
--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemConverter.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemConverter.java
@@ -199,7 +199,7 @@ public class YamlItemConverter extends AbstractItemSerializer implements ItemPar
                 continue;
             }
 
-            if ("stateDescription".equals(namespace) && value.isBlank()) {
+            if ("stateDescription".equals(namespace) && (value == null || value.isBlank())) {
                 Map<String, Object> config = md.getConfiguration();
 
                 String defaultPattern = getDefaultStatePattern(item);
@@ -215,7 +215,7 @@ public class YamlItemConverter extends AbstractItemSerializer implements ItemPar
             }
 
             YamlMetadataDTO mdDto = new YamlMetadataDTO();
-            mdDto.value = value.isEmpty() ? null : value;
+            mdDto.value = value;
             Map<String, Object> configuration = new LinkedHashMap<>();
             for (ConfigParameter param : getConfigurationParameters(md)) {
                 configuration.put(param.name(), param.value());

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemConverter.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemConverter.java
@@ -110,14 +110,9 @@ public class YamlItemConverter extends AbstractItemSerializer implements ItemPar
         dto.name = item.getName();
 
         String label = item.getLabel();
-        boolean patternSet = false;
-        String defaultPattern = getDefaultStatePattern(item);
         if (label != null && !label.isEmpty()) {
             dto.label = item.getLabel();
         }
-        String patternToSet = stateFormatter != null && !stateFormatter.equals(defaultPattern) ? stateFormatter : null;
-        dto.format = patternToSet;
-        patternSet = patternToSet != null;
 
         dto.type = item.getType();
         String mainType = ItemUtil.getMainItemType(item.getType());
@@ -191,40 +186,42 @@ public class YamlItemConverter extends AbstractItemSerializer implements ItemPar
                 if (value != null && !value.isEmpty()) {
                     dto.autoupdate = Boolean.valueOf(value);
                 }
-            } else if ("unit".equals(namespace)) {
+                continue;
+            }
+
+            if ("unit".equals(namespace)) {
                 dto.unit = value; // When unit value is empty string, keep it as empty string
-            } else if ("expire".equals(namespace)) {
-                Map<String, Object> configuration = md.getConfiguration();
-                if (configuration.isEmpty()) {
-                    dto.expire = value; // When expire value is empty string, keep it as empty string
-                } else {
-                    YamlMetadataDTO mdDto = new YamlMetadataDTO();
-                    mdDto.value = value.isEmpty() ? null : value;
-                    mdDto.config = configuration;
-                    metadataDto.put(namespace, mdDto);
+                continue;
+            }
+
+            if ("expire".equals(namespace) && md.getConfiguration().isEmpty()) {
+                dto.expire = value; // When expire value is empty string, keep it as empty string
+                continue;
+            }
+
+            if ("stateDescription".equals(namespace) && value.isBlank()) {
+                Map<String, Object> config = md.getConfiguration();
+
+                String defaultPattern = getDefaultStatePattern(item);
+                if (config.isEmpty() && stateFormatter != null && !stateFormatter.equals(defaultPattern)) {
+                    dto.format = stateFormatter;
+                    continue;
                 }
-            } else {
-                YamlMetadataDTO mdDto = new YamlMetadataDTO();
-                mdDto.value = value.isEmpty() ? null : value;
-                Map<String, Object> configuration = new LinkedHashMap<>();
-                String statePattern = null;
-                for (ConfigParameter param : getConfigurationParameters(md)) {
-                    configuration.put(param.name(), param.value());
-                    if ("stateDescription".equals(namespace) && "pattern".equals(param.name())) {
-                        statePattern = param.value().toString();
-                    }
-                }
-                // Ignore state description in case it contains only a state pattern and state pattern was injected
-                // in field format or is the default pattern
-                if (!(statePattern != null && configuration.size() == 1
-                        && (patternSet || statePattern.equals(defaultPattern)))) {
-                    mdDto.config = configuration.isEmpty() ? null : configuration;
-                    metadataDto.put(namespace, mdDto);
-                    if (patternSet && statePattern != null) {
-                        dto.format = null;
-                    }
+
+                if (config.get("pattern") instanceof String pattern && !pattern.isBlank() && config.size() == 1) {
+                    dto.format = pattern;
+                    continue;
                 }
             }
+
+            YamlMetadataDTO mdDto = new YamlMetadataDTO();
+            mdDto.value = value.isEmpty() ? null : value;
+            Map<String, Object> configuration = new LinkedHashMap<>();
+            for (ConfigParameter param : getConfigurationParameters(md)) {
+                configuration.put(param.name(), param.value());
+            }
+            mdDto.config = configuration.isEmpty() ? null : configuration;
+            metadataDto.put(namespace, mdDto);
         }
         dto.metadata = metadataDto.isEmpty() ? null : metadataDto;
 

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemConverter.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemConverter.java
@@ -114,6 +114,11 @@ public class YamlItemConverter extends AbstractItemSerializer implements ItemPar
             dto.label = item.getLabel();
         }
 
+        String defaultPattern = getDefaultStatePattern(item);
+        if (stateFormatter != null && !stateFormatter.equals(defaultPattern)) {
+            dto.format = stateFormatter;
+        }
+
         dto.type = item.getType();
         String mainType = ItemUtil.getMainItemType(item.getType());
         String dimension = ItemUtil.getItemTypeExtension(item.getType());
@@ -180,6 +185,8 @@ public class YamlItemConverter extends AbstractItemSerializer implements ItemPar
         for (Metadata md : metadata) {
             String namespace = md.getUID().getNamespace();
             String value = md.getValue();
+            String adoptedPattern = null;
+
             if ("autoupdate".equals(namespace)) {
                 // When autoupdate value is an empty string, treat it as not set since dto.autoupdate only accepts
                 // true/false
@@ -199,27 +206,48 @@ public class YamlItemConverter extends AbstractItemSerializer implements ItemPar
                 continue;
             }
 
-            if ("stateDescription".equals(namespace) && (value == null || value.isBlank())) {
+            if ("stateDescription".equals(namespace)) {
                 Map<String, Object> config = md.getConfiguration();
+                boolean isValueEmpty = value == null || value.isEmpty();
 
-                String defaultPattern = getDefaultStatePattern(item);
-                if (config.isEmpty() && stateFormatter != null && !stateFormatter.equals(defaultPattern)) {
-                    dto.format = stateFormatter;
-                    continue;
+                String pattern = config.get("pattern") instanceof String p && !p.isEmpty() ? p : null;
+                boolean hasPattern = pattern != null;
+                boolean hasOnlyPattern = hasPattern && config.size() == 1;
+
+                // Rule 1: Special early exit path when ONLY config.pattern is present
+                if (hasOnlyPattern && isValueEmpty) {
+                    if (!pattern.equals(defaultPattern)) {
+                        dto.format = pattern;
+                    } else {
+                        dto.format = null;
+                    }
+                    continue; // Skip adding to dto.metadata
                 }
 
-                if (config.get("pattern") instanceof String pattern && !pattern.isBlank() && config.size() == 1) {
-                    dto.format = pattern;
-                    continue;
+                // Rule 2: Note if we need to adopt dto.format before clearing it
+                if (!hasPattern) {
+                    adoptedPattern = dto.format;
                 }
+
+                // Rule 3: Clear dto.format (stateDescription metadata takes precedence)
+                dto.format = null;
+
+                // FALL THROUGH to common YamlMetadataDTO construction below...
             }
 
+            // --- Single shared YamlMetadataDTO creation block ---
             YamlMetadataDTO mdDto = new YamlMetadataDTO();
             mdDto.value = value;
             Map<String, Object> configuration = new LinkedHashMap<>();
             for (ConfigParameter param : getConfigurationParameters(md)) {
                 configuration.put(param.name(), param.value());
             }
+
+            // Inject adopted pattern if Rule 2 was triggered
+            if (adoptedPattern != null) {
+                configuration.put("pattern", adoptedPattern);
+            }
+
             mdDto.config = configuration.isEmpty() ? null : configuration;
             metadataDto.put(namespace, mdDto);
         }

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemConverterTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemConverterTest.java
@@ -34,6 +34,7 @@ import org.openhab.core.model.yaml.YamlModelRepository;
 import org.openhab.core.model.yaml.internal.items.YamlChannelLinkProvider;
 import org.openhab.core.model.yaml.internal.items.YamlItemDTO;
 import org.openhab.core.model.yaml.internal.items.YamlItemProvider;
+import org.openhab.core.model.yaml.internal.items.YamlMetadataDTO;
 import org.openhab.core.model.yaml.internal.items.YamlMetadataProvider;
 
 @NonNullByDefault
@@ -96,6 +97,29 @@ public class YamlItemConverterTest {
         YamlItemDTO dto = convertWithMetadata(unit, "Number");
         assertEquals("", dto.unit);
         assertNull(dto.metadata);
+    }
+
+    @Test
+    public void testStateDescriptionMetadataConvertedToShortForm() {
+        Metadata expireMetadata = new Metadata(new MetadataKey("stateDescription", "item_name"), "", Map.of("pattern", "%d"));
+        YamlItemDTO dto = convertWithMetadata(expireMetadata, "Number");
+        assertEquals("%d", dto.format);
+        assertNull(dto.metadata);
+    }
+
+    @Test
+    public void testStateDescriptionMetadataWithOtherConfigStaysInMetadata() {
+        Metadata expireMetadata = new Metadata(new MetadataKey("stateDescription", "item_name"), "",
+                Map.of("pattern", "%d", "min", 0, "max", 100));
+        YamlItemDTO dto = convertWithMetadata(expireMetadata, "Number");
+        assertNull(dto.format);
+        assertNotNull(dto.metadata);
+        YamlMetadataDTO stateDescDto = dto.metadata.get("stateDescription");
+        assertNotNull(stateDescDto);
+        assertEquals("", stateDescDto.getValue());
+        assertEquals("%d", stateDescDto.config.get("pattern"));
+        assertEquals(0, stateDescDto.config.get("min"));
+        assertEquals(100, stateDescDto.config.get("max"));
     }
 
     private YamlItemDTO convertWithMetadata(Metadata metadata, String itemType) {

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemConverterTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemConverterTest.java
@@ -101,18 +101,18 @@ public class YamlItemConverterTest {
 
     @Test
     public void testStateDescriptionMetadataConvertedToShortForm() {
-        Metadata expireMetadata = new Metadata(new MetadataKey("stateDescription", "item_name"), "",
+        Metadata stateDescriptionMetadata = new Metadata(new MetadataKey("stateDescription", "item_name"), "",
                 Map.of("pattern", "%d"));
-        YamlItemDTO dto = convertWithMetadata(expireMetadata, "Number");
+        YamlItemDTO dto = convertWithMetadata(stateDescriptionMetadata, "Number");
         assertEquals("%d", dto.format);
         assertNull(dto.metadata);
     }
 
     @Test
     public void testStateDescriptionMetadataWithOtherConfigStaysInMetadata() {
-        Metadata expireMetadata = new Metadata(new MetadataKey("stateDescription", "item_name"), "",
+        Metadata stateDescriptionMetadata = new Metadata(new MetadataKey("stateDescription", "item_name"), "",
                 Map.of("pattern", "%d", "min", 0, "max", 100));
-        YamlItemDTO dto = convertWithMetadata(expireMetadata, "Number");
+        YamlItemDTO dto = convertWithMetadata(stateDescriptionMetadata, "Number");
         assertNull(dto.format);
         assertNotNull(dto.metadata);
         YamlMetadataDTO stateDescDto = dto.metadata.get("stateDescription");

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemConverterTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemConverterTest.java
@@ -101,7 +101,8 @@ public class YamlItemConverterTest {
 
     @Test
     public void testStateDescriptionMetadataConvertedToShortForm() {
-        Metadata expireMetadata = new Metadata(new MetadataKey("stateDescription", "item_name"), "", Map.of("pattern", "%d"));
+        Metadata expireMetadata = new Metadata(new MetadataKey("stateDescription", "item_name"), "",
+                Map.of("pattern", "%d"));
         YamlItemDTO dto = convertWithMetadata(expireMetadata, "Number");
         assertEquals("%d", dto.format);
         assertNull(dto.metadata);

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemConverterTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemConverterTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.config.core.ConfigDescriptionRegistry;
 import org.openhab.core.items.Item;
@@ -99,28 +100,95 @@ public class YamlItemConverterTest {
         assertNull(dto.metadata);
     }
 
-    @Test
-    public void testStateDescriptionMetadataConvertedToShortForm() {
-        Metadata stateDescriptionMetadata = new Metadata(new MetadataKey("stateDescription", "item_name"), "",
-                Map.of("pattern", "%d"));
-        YamlItemDTO dto = convertWithMetadata(stateDescriptionMetadata, "Number");
-        assertEquals("%d", dto.format);
-        assertNull(dto.metadata);
-    }
+    @Nested
+    class StateDescriptionAndFormatTests {
 
-    @Test
-    public void testStateDescriptionMetadataWithOtherConfigStaysInMetadata() {
-        Metadata stateDescriptionMetadata = new Metadata(new MetadataKey("stateDescription", "item_name"), "",
-                Map.of("pattern", "%d", "min", 0, "max", 100));
-        YamlItemDTO dto = convertWithMetadata(stateDescriptionMetadata, "Number");
-        assertNull(dto.format);
-        assertNotNull(dto.metadata);
-        YamlMetadataDTO stateDescDto = dto.metadata.get("stateDescription");
-        assertNotNull(stateDescDto);
-        assertEquals("", stateDescDto.getValue());
-        assertEquals("%d", stateDescDto.config.get("pattern"));
-        assertEquals(0, stateDescDto.config.get("min"));
-        assertEquals(100, stateDescDto.config.get("max"));
+        @Test
+        public void testStateDescriptionMetadataConvertedToShortForm() {
+            Metadata stateDescriptionMetadata = new Metadata(new MetadataKey("stateDescription", "item_name"), "",
+                    Map.of("pattern", "%d"));
+            YamlItemDTO dto = convertWithMetadata(stateDescriptionMetadata, "Number");
+            assertEquals("%d", dto.format);
+            assertNull(dto.metadata);
+        }
+
+        @Test
+        public void testStateDescriptionMetadataWithOtherConfigStaysInMetadata() {
+            Metadata stateDescriptionMetadata = new Metadata(new MetadataKey("stateDescription", "item_name"), "",
+                    Map.of("pattern", "%d", "min", 0, "max", 100));
+            YamlItemDTO dto = convertWithMetadata(stateDescriptionMetadata, "Number");
+            assertNull(dto.format);
+            assertNotNull(dto.metadata);
+            YamlMetadataDTO stateDescDto = dto.metadata.get("stateDescription");
+            assertNotNull(stateDescDto);
+            assertEquals("", stateDescDto.getValue());
+            assertEquals("%d", stateDescDto.config.get("pattern"));
+            assertEquals(0, stateDescDto.config.get("min"));
+            assertEquals(100, stateDescDto.config.get("max"));
+        }
+
+        @Test
+        public void testStandaloneStateFormatterPreservedWithoutStateDescription() {
+            // Test standalone stateFormatter (e.g., extracted from item label or file-format API)
+            // when no stateDescription metadata exists.
+            YamlItemDTO dto = convertWithStateFormatterAndMetadata("Number", "%.2f %s", List.of());
+            assertEquals("%.2f %s", dto.format);
+            assertNull(dto.metadata);
+        }
+
+        @Test
+        public void testStandaloneStateFormatterWithStateDescriptionWithoutPattern() {
+            // Test when standalone stateFormatter is provided along with stateDescription metadata
+            // that has min/max config but NO pattern.
+            Metadata stateDescMeta = new Metadata(new MetadataKey("stateDescription", "item_name"), "",
+                    Map.of("min", 0, "max", 100));
+
+            YamlItemDTO dto = convertWithStateFormatterAndMetadata("Number", "%.1f °C", List.of(stateDescMeta));
+
+            // When stateDescription metadata exists with other params, dto.format should be cleared
+            // because stateDescription takes precedence, but stateDescription config will adopt or keep format
+            // parameters.
+            assertNull(dto.format);
+            assertNotNull(dto.metadata);
+            YamlMetadataDTO stateDescDto = dto.metadata.get("stateDescription");
+            assertNotNull(stateDescDto);
+            assertEquals("", stateDescDto.getValue());
+            assertEquals(0, stateDescDto.config.get("min"));
+            assertEquals(100, stateDescDto.config.get("max"));
+            // Verify adopted or preserved pattern in stateDescription config
+            assertEquals("%.1f °C", stateDescDto.config.get("pattern"));
+        }
+
+        @Test
+        public void testStateDescriptionPatternOverridesStandaloneStateFormatter() {
+            // Test when stateDescription metadata HAS a pattern and standalone stateFormatter is also provided.
+            // The stateDescription pattern should override/take precedence.
+            Metadata stateDescMeta = new Metadata(new MetadataKey("stateDescription", "item_name"), "",
+                    Map.of("pattern", "%d kWh"));
+
+            YamlItemDTO dto = convertWithStateFormatterAndMetadata("Number", "%.2f", List.of(stateDescMeta));
+
+            // Short-form format should reflect the stateDescription pattern (%d kWh),
+            // not the standalone stateFormatter (%.2f)
+            assertEquals("%d kWh", dto.format);
+            assertNull(dto.metadata);
+        }
+
+        @Test
+        public void testStateFormatterDslToYamlRoundTripInteraction() {
+            // Simulate DSL -> YAML conversion flow with a standalone stateFormatter and additional metadata
+            Metadata expireMeta = new Metadata(new MetadataKey("expire", "item_name"), "5m", Map.of());
+            Metadata unitMeta = new Metadata(new MetadataKey("unit", "item_name"), "°C", Map.of());
+
+            YamlItemDTO dto = convertWithStateFormatterAndMetadata("Number:Temperature", "%.1f %unit%",
+                    List.of(expireMeta, unitMeta));
+
+            // Standalone stateFormatter is converted to short-form format
+            assertEquals("%.1f %unit%", dto.format);
+            assertEquals("5m", dto.expire);
+            assertEquals("°C", dto.unit);
+            assertNull(dto.metadata);
+        }
     }
 
     private YamlItemDTO convertWithMetadata(Metadata metadata, String itemType) {
@@ -138,6 +206,31 @@ public class YamlItemConverterTest {
         when(item.getTags()).thenReturn(Set.of());
 
         converter.setItemsToBeSerialized("id", List.of(item), List.of(metadata), Map.of(), false);
+
+        List<YamlElement> elements = repository.getElements();
+        assertEquals(1, elements.size());
+        assertInstanceOf(YamlItemDTO.class, elements.getFirst());
+        return (YamlItemDTO) elements.getFirst();
+    }
+
+    private YamlItemDTO convertWithStateFormatterAndMetadata(String itemType, @Nullable String stateFormatter,
+            List<Metadata> metadataList) {
+        CapturingYamlModelRepository repository = new CapturingYamlModelRepository();
+        YamlItemConverter converter = new YamlItemConverter(repository, mock(YamlItemProvider.class),
+                mock(YamlMetadataProvider.class), mock(YamlChannelLinkProvider.class),
+                mock(ConfigDescriptionRegistry.class));
+
+        Item item = mock(Item.class);
+        when(item.getName()).thenReturn("item_name");
+        when(item.getLabel()).thenReturn(null);
+        when(item.getType()).thenReturn(itemType);
+        when(item.getCategory()).thenReturn(null);
+        when(item.getGroupNames()).thenReturn(List.of());
+        when(item.getTags()).thenReturn(Set.of());
+
+        Map<String, String> stateFormatters = stateFormatter != null ? Map.of("item_name", stateFormatter) : Map.of();
+
+        converter.setItemsToBeSerialized("id", List.of(item), metadataList, stateFormatters, false);
 
         List<YamlElement> elements = repository.getElements();
         assertEquals(1, elements.size());


### PR DESCRIPTION
Preserve Short‑Form `format` When Generating YAML

openHAB already supports the short‑form `format` syntax for Items in YAML. For example:

```yaml
items:
  itemname:
    format: '%d'
```

Internally, this is correctly translated into the equivalent metadata structure:

```yaml
items:
  itemname:
    metadata:
      stateDescription:
        value: ''
        config:
          pattern: '%d'
```

However, when exporting or regenerating YAML from this internal representation, the system currently does **not** restore the short‑form. Instead, it always emits the full metadata block, even when the only metadata present is the `pattern` value that corresponds directly to the `format` shorthand.

This PR updates the YAML generator so that:

- If the `stateDescription` metadata contains **only** a `pattern` value,  
  → the YAML generator emits the concise `format: '<pattern>'` form.
- If any **additional** `stateDescription` metadata is present,  
  → the generator falls back to the full metadata representation.

### ✔️ Benefits

- Restores symmetry between input and output YAML.
- Keeps generated YAML clean, readable, and consistent with user‑authored files.
- Avoids unnecessary verbosity when only the `format` shorthand is needed.


