### PR TITLE
Feature `openhab.tp-xtext`: don’t activate `org.eclipse.xtend.lib`

### DIFF
--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -245,8 +245,8 @@
 		<bundle dependency="true">mvn:org.eclipse.xtext/org.eclipse.xtext.xbase.lib/${xtext.version}</bundle>
 		<bundle dependency="true">mvn:org.eclipse.xtext/org.eclipse.xtext.smap/${xtext.version}</bundle>
 		<bundle dependency="true">mvn:org.eclipse.xtext/org.eclipse.xtext.util/${xtext.version}</bundle>
-		<bundle dependency="true">mvn:org.eclipse.xtext/org.eclipse.xtend.lib/${xtext.version}</bundle>
-		<bundle dependency="true">mvn:org.eclipse.xtext/org.eclipse.xtend.lib.macro/${xtext.version}</bundle>
+		<bundle dependency="true" start="false">mvn:org.eclipse.xtext/org.eclipse.xtend.lib/${xtext.version}</bundle>
+		<bundle dependency="true" start="false">mvn:org.eclipse.xtext/org.eclipse.xtend.lib.macro/${xtext.version}</bundle>
 
 		<bundle dependency="true">mvn:com.google.guava/failureaccess/1.0.3</bundle>
 		<bundle dependency="true">mvn:com.google.guava/guava/33.5.0-jre</bundle>


### PR DESCRIPTION
As discussed at https://github.com/eclipse-xtext/xtext/issues/3585 the XBase bundle declares that `org.eclipse.xtend.lib` and the transitive dependency xtend.lib.macro are required in theory, but in practice they are not needed at runtime.

By stopping openhab, cleaning the cache, changing in /usr/share/openhab/runtime/system/org/openhab/distro/distro-kar/5.1.1/distro-kar-5.1.1-features.xml and /usr/share/openhab/runtime/system/org/openhab/distro/distro/5.1.1/distro-5.1.1-features.xml the lines with `org.eclipse.xtend.lib/2.40.0` and `org.eclipse.xtend.lib.macro/2.40.0` to have `start="false"`and starting openhab, I observe that afterwards `bundle:list` shows:
```
START LEVEL 100 , List Threshold: 50
 ID │ State    │ Lvl │ Version               │ Name
────┼──────────┼─────┼───────────────────────┼─────────────────────────
140 │ Resolved │  80 │ 2.40.0.v20250825-0355 │ Xtend Runtime Library
141 │ Resolved │  80 │ 2.40.0.v20250825-0355 │ Xtend Macro Interfaces
```
and all my DSL rules run as expected.

* This change avoids activating `org.eclipse.xtend.lib` and `org.eclipse.xtend.lib.macro` bundles.