### PR TITLE
script.model.ScriptInterpreter: emit what cannot be casted to what after a single evaluation of the cast

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/interpreter/ScriptInterpreter.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/interpreter/ScriptInterpreter.xtend
@@ -25,6 +25,7 @@ import org.openhab.core.model.script.scoping.StateAndCommandProvider
 import org.openhab.core.model.script.script.QuantityLiteral
 import org.eclipse.xtext.common.types.JvmField
 import org.eclipse.xtext.common.types.JvmIdentifiableElement
+import org.eclipse.xtext.common.types.JvmPrimitiveType
 import org.eclipse.xtext.naming.QualifiedName
 import org.eclipse.xtext.util.CancelIndicator
 import org.eclipse.xtext.xbase.XAbstractFeatureCall
@@ -33,9 +34,12 @@ import org.eclipse.xtext.xbase.XExpression
 import org.eclipse.xtext.xbase.XFeatureCall
 import org.eclipse.xtext.xbase.XMemberFeatureCall
 import org.eclipse.xtext.xbase.interpreter.IEvaluationContext
+import org.eclipse.xtext.xbase.interpreter.impl.EvaluationException
 import org.eclipse.xtext.xbase.interpreter.impl.XbaseInterpreter
 import org.eclipse.xtext.xbase.jvmmodel.IJvmModelAssociations
 import org.eclipse.xtext.xbase.typesystem.IBatchTypeResolver
+import org.eclipse.xtext.xbase.typesystem.references.StandardTypeReferenceOwner
+import org.eclipse.xtext.xbase.typesystem.util.CommonTypeComputationServices;
 
 /**
  * The script interpreter handles specific script components, which are not known
@@ -56,6 +60,9 @@ class ScriptInterpreter extends XbaseInterpreter {
 
     @Inject
     extension IJvmModelAssociations
+
+    @Inject
+    CommonTypeComputationServices services
 
     override protected _invokeFeature(JvmField jvmField, XAbstractFeatureCall featureCall, Object receiver,
         IEvaluationContext context, CancelIndicator indicator) {
@@ -146,21 +153,41 @@ class ScriptInterpreter extends XbaseInterpreter {
         return QuantityType.valueOf(literal.value + " " + literal.unit.value);
     }
 
-    override Object _doEvaluate(XCastedExpression castedExpression, IEvaluationContext context,
+    /**
+     * This is the same implementation as in XbaseInterpreter.java with the
+     * {@code "Could not cast (" + result.class + ")" + result + " to " + typeName }
+     * line being the only difference.  There is no other way to create an error message,
+     * stating what cannot be casted to what. See
+     * <a href="https://github.com/eclipse-xtext/xtext/issues/3595">github.com/eclipse-xtext/xtext/issues/3595</a>.
+     */
+    override protected _doEvaluate(XCastedExpression castedExpression, IEvaluationContext context,
         CancelIndicator indicator) {
-        try {
-            return super._doEvaluate(castedExpression, context, indicator)
-        } catch (RuntimeException e) {
-            if (e.cause instanceof ClassCastException) {
-                val Object result = internalEvaluate(castedExpression.getTarget(), context, indicator);
-                throw new ScriptExecutionException(new ScriptError(
-                    "Could not cast " + result + " to " + castedExpression.getType().getType().getQualifiedName(),
-                    castedExpression));
-                } else {
-                    throw e;
-                }
+        var result = internalEvaluate(castedExpression.target, context, indicator)
+        val owner = new StandardTypeReferenceOwner(services, castedExpression)
+        val targetType = owner.toLightweightTypeReference(castedExpression.type)
+        result = wrapOrUnwrapArray(result, targetType)
+        result = coerceArgumentType(result, castedExpression.type)
+        val castType = castedExpression.type.type
+        if (castType instanceof JvmPrimitiveType) {
+            if (result === null) {
+                throwNullPointerException(castedExpression, "Cannot cast null to primitive " + castType.identifier)
             }
+            return castToPrimitiveType(result, services.primitives.primitiveKind(castType))
         }
+        val typeName = castType.qualifiedName
+        var Class<?> expectedType = null
+        try {
+            expectedType = getJavaType(castType)
+        } catch (ClassNotFoundException e) {
+            throw new EvaluationException(new NoClassDefFoundError(typeName))
+        }
+        try {
+            expectedType.cast(result)
+        } catch (ClassCastException e) {
+            throw new EvaluationException(new ClassCastException(new ScriptError("Could not cast (" + result.class + ")" + result + " to " + typeName, castedExpression).message))
+        }
+        return result
+    }
 
     }
     


### PR DESCRIPTION
Before this change `internalEvaluate(castedExpression.getTarget(), context, indicator)` was invoked twice: once by `super._doEvaluate()` and once in the overridden method.  When on the first execution an error occured, the second execution was needed to create an error message, stating what cannot be casted to what.  However at the time `internalEvaluate` was called for a second time, internal states have changed, so there might be no more errors with casting, thus producing incorrect error message.

Except the line:

OLD:
> 
> ```java
> throw new ScriptExecutionException(new ScriptError(
>    "Could not cast (" + result.class + ")" + result + " to " +typeName,
>    castedExpression))
> ```

EDIT: the above change was changed, now the only difference is this line
```java
"Could not cast (" + result.class + ")" + result + " to " + typeName
```

the implementation is the same as in XbaseInterpreter.java, bur rewtiten in Xtend.


The problem has to be addressed in XBase, as it does not provide enough information about what cannot be casted to what — https://github.com/eclipse-xtext/xtext/issues/3595.

I geuess that `@Inject CommonTypeComputationServices services` is right.  I do not understand it, but the `super._doEvaluate(XCastedExpression, IEvaluationContext, CancelIndicator)` method uses `services` in the same way.

Closes https://github.com/openhab/openhab-core/issues/5323.

The error messages in the original report contained a string with a date value inside, and it was unclear if the object was a DateTimeType, a StringType or a String object. 

> 15:47:30.403 [ERROR] [l.handler.AbstractScriptModuleHandler] - Script execution of rule with UID 'datetime-1' failed: Could not cast 2026-02-02T15:47:30.400405676+0100 to org.openhab.core.library.types.DateTimeType; line 49, column 21, length 35 in datetime
> javax.script.ScriptException: Could not cast 2026-02-02T15:47:30.400405676+0100 to org.openhab.core.library.types.DateTimeType; line 49, column 21, length 35 in datetime

The error messages are generated now as:

> 2026-02-06 11:53:00.580 [ERROR] [.handler.AbstractScriptModuleHandler] - Script execution of rule with UID 'dt-1' failed: Could not cast (class org.openhab.core.types.UnDefType)NULL to org.openhab.core.library.types.DateTimeType; line 14, column 20, length 35 in dt

making clear not only the value, which cannot be casted, but also its class.