### PR TITLE
Adjust persistence REST HTTP response status code

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -184,7 +184,7 @@ public class PersistenceResource implements RESTResource {
     @Operation(operationId = "getPersistenceServiceConfiguration", summary = "Gets a persistence service configuration.", security = {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = PersistenceServiceConfigurationDTO.class))),
-                    @ApiResponse(responseCode = "404", description = "Service configuration not found.") })
+                    @ApiResponse(responseCode = "204", description = "No matching service configuration.") })
     public Response httpGetPersistenceServiceConfiguration(@Context HttpHeaders headers,
             @Parameter(description = "Id of the persistence service.") @PathParam("serviceId") String serviceId) {
         PersistenceServiceConfiguration configuration = persistenceServiceConfigurationRegistry.get(serviceId);
@@ -195,7 +195,7 @@ public class PersistenceResource implements RESTResource {
             configurationDTO.editable = managedPersistenceServiceConfigurationProvider.get(serviceId) != null;
             return JSONResponse.createResponse(Status.OK, configurationDTO, null);
         } else {
-            return Response.status(Status.NOT_FOUND).build();
+            return Response.noContent().build();
         }
     }
 


### PR DESCRIPTION
During the evolution of https://github.com/openhab/openhab-webui/pull/3766, it has been determined that the `getPersistenceServiceConfiguration` API endpoint should return 204 instead of 404 if no matching configuration exists. The reason is that there is no expectation that one should exist.

For a more detailed explanation, see this discussion in the PR, which is summed up here: https://github.com/openhab/openhab-webui/pull/3766#issuecomment-3861688565

I'm holding back updating the "alerts" in distro for #5236 in case this is accepted as well, so that these changes can all be listed together.