### PR TITLE
DSL Rule - allow using `org.openhab.core.persistence.extensions.PersistenceExtensions.RiemannType.TRAPEZOIDAL`

### DIFF
--- a/bundles/org.openhab.core.model.rule/bnd.bnd
+++ b/bundles/org.openhab.core.model.rule/bnd.bnd
@@ -21,6 +21,7 @@ Import-Package: \
  org.openhab.core.library.types,\
  org.openhab.core.library.unit,\
  org.openhab.core.persistence,\
+ org.openhab.core.persistence.extensions,\
  org.openhab.core.service,\
  org.openhab.core.thing,\
  org.openhab.core.thing.binding,\


### PR DESCRIPTION
This change permits writing in DSL Rules:
```
val m = org.openhab.core.persistence.extensions.PersistenceExtensions.RiemannType.TRAPEZOIDAL
```
Related to: https://github.com/openhab/openhab-core/issues/4784 