### PR TITLE
Delete model.rule.RulesClassFinder.forName(String,ClassLoader)

### DIFF
--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/scoping/RulesClassFinder.java
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/scoping/RulesClassFinder.java
@@ -57,9 +57,4 @@ public class RulesClassFinder extends ClassFinder {
             throw e;
         }
     }
-
-    @Override
-    protected Class<?> forName(String name, ClassLoader classLoader) throws ClassNotFoundException {
-        return Class.forName(name, false, classLoader);
-    }
 }


### PR DESCRIPTION
The method body is exactly the same as in the base class.