### PR TITLE
core.model.{rule,script}/bnd.bnd: reorder packages alphabetically

### DIFF
--- a/bundles/org.openhab.core.model.rule/bnd.bnd
+++ b/bundles/org.openhab.core.model.rule/bnd.bnd
@@ -12,6 +12,7 @@ Export-Package: org.openhab.core.model.rule,\
  org.openhab.core.model.rule.services,\
  org.openhab.core.model.rule.validation
 Import-Package: \
+ org.openhab.core.automation.module.script.rulesupport.shared,\
  org.openhab.core.common,\
  org.openhab.core.common.registry,\
  org.openhab.core.events,\
@@ -20,6 +21,10 @@ Import-Package: \
  org.openhab.core.library.items,\
  org.openhab.core.library.types,\
  org.openhab.core.library.unit,\
+ org.openhab.core.model.core,\
+ org.openhab.core.model.items,\
+ org.openhab.core.model.script,\
+ org.openhab.core.model.script.engine.action,\
  org.openhab.core.persistence,\
  org.openhab.core.persistence.extensions,\
  org.openhab.core.service,\
@@ -27,11 +32,6 @@ Import-Package: \
  org.openhab.core.thing.binding,\
  org.openhab.core.thing.events,\
  org.openhab.core.types,\
- org.openhab.core.model.core,\
- org.openhab.core.model.items,\
- org.openhab.core.model.script,\
- org.openhab.core.model.script.engine.action,\
- org.openhab.core.automation.module.script.rulesupport.shared,\
  com.google.common.base;version="14",\
  javax.measure,\
  javax.measure.quantity,\
@@ -45,10 +45,10 @@ Require-Bundle: org.antlr.runtime,\
  org.eclipse.emf.mwe2.launch;resolution:=optional,\
  org.openhab.core.model.item,\
  org.openhab.core.model.script,\
+ org.eclipse.xtext;visibility:=reexport,\
  org.eclipse.xtext.common.types,\
- org.eclipse.xtext.xtext.generator;resolution:=optional,\
  org.eclipse.xtext.util,\
  org.eclipse.xtext.xbase,\
  org.eclipse.xtext.xbase.lib;bundle-version="2.34.0",\
- org.eclipse.xtext;visibility:=reexport,\
+ org.eclipse.xtext.xtext.generator;resolution:=optional,\
  org.objectweb.asm;bundle-version="[9.0.0,10.0.0)";resolution:=optional

--- a/bundles/org.openhab.core.model.script/bnd.bnd
+++ b/bundles/org.openhab.core.model.script/bnd.bnd
@@ -19,16 +19,21 @@ Export-Package: org.openhab.core.model.script,\
  org.openhab.core.model.script.validation
 Import-Package: \
  org.openhab.core.audio,\
- org.openhab.core.common.registry,\
  org.openhab.core.automation.module.script.action,\
  org.openhab.core.automation.module.script.rulesupport.shared,\
+ org.openhab.core.common.registry,\
  org.openhab.core.ephemeris,\
  org.openhab.core.events,\
+ org.openhab.core.io.console,\
+ org.openhab.core.io.console.extensions,\
+ org.openhab.core.io.net.exec,\
+ org.openhab.core.io.net.http,\
  org.openhab.core.items,\
  org.openhab.core.items.events,\
  org.openhab.core.library.items,\
  org.openhab.core.library.types,\
  org.openhab.core.library.unit,\
+ org.openhab.core.model.core,\
  org.openhab.core.persistence,\
  org.openhab.core.persistence.extensions,\
  org.openhab.core.scheduler,\
@@ -42,11 +47,6 @@ Import-Package: \
  org.openhab.core.util,\
  org.openhab.core.voice,\
  org.openhab.core.voice.text,\
- org.openhab.core.io.console,\
- org.openhab.core.io.console.extensions,\
- org.openhab.core.io.net.exec,\
- org.openhab.core.io.net.http,\
- org.openhab.core.model.core,\
  com.google.common.*;version="14",\
  javax.measure,\
  javax.measure.quantity,\
@@ -61,11 +61,11 @@ Require-Bundle: org.antlr.runtime,\
  org.eclipse.emf.ecore,\
  org.eclipse.emf.mwe2.launch;resolution:=optional,\
  org.openhab.core.model.item,\
- org.eclipse.xtext.common.types,\
- org.eclipse.xtext.xtext.generator;resolution:=optional,\
- org.eclipse.xtext.util,\
- org.eclipse.xtext.xbase.lib;bundle-version="2.34.0",\
- org.eclipse.xtext.xbase;visibility:=reexport,\
  org.eclipse.xtext;visibility:=reexport,\
+ org.eclipse.xtext.common.types,\
+ org.eclipse.xtext.util,\
+ org.eclipse.xtext.xbase;visibility:=reexport,\
+ org.eclipse.xtext.xbase.lib;bundle-version="2.34.0",\
+ org.eclipse.xtext.xtext.generator;resolution:=optional,\
  org.objectweb.asm;bundle-version="[9.0.0,10.0.0)";resolution:=optional
 -includeresource: resources


### PR DESCRIPTION
So that both files can easily be compared.  This would have made resolving https://github.com/openhab/openhab-core/issues/4784 by https://github.com/openhab/openhab-core/pull/5334 easier.