### PR TITLE
DSL: implicit RiemannType import

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImportSectionNamespaceScopeProvider.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImportSectionNamespaceScopeProvider.java
@@ -32,6 +32,8 @@ public class ScriptImportSectionNamespaceScopeProvider extends XImportSectionNam
     public static final QualifiedName CORE_ITEMS_PACKAGE = QualifiedName.create("org", "openhab", "core", "items");
     public static final QualifiedName CORE_PERSISTENCE_PACKAGE = QualifiedName.create("org", "openhab", "core",
             "persistence");
+    public static final QualifiedName CORE_PERSISTENCE_RIEMANNTYPE_CLASS = QualifiedName.create("org", "openhab",
+            "core", "persistence", "extensions", "PersistenceExtensions", "RiemannType");
     public static final QualifiedName MODEL_SCRIPT_ACTIONS_PACKAGE = QualifiedName.create("org", "openhab", "core",
             "model", "script", "actions");
     public static final QualifiedName TIME_PACKAGE = QualifiedName.create("java", "time");
@@ -46,6 +48,7 @@ public class ScriptImportSectionNamespaceScopeProvider extends XImportSectionNam
         implicitImports.add(doCreateImportNormalizer(CORE_LIBRARY_ITEMS_PACKAGE, true, false));
         implicitImports.add(doCreateImportNormalizer(CORE_ITEMS_PACKAGE, true, false));
         implicitImports.add(doCreateImportNormalizer(CORE_PERSISTENCE_PACKAGE, true, false));
+        implicitImports.add(doCreateImportNormalizer(CORE_PERSISTENCE_RIEMANNTYPE_CLASS, false, false));
         implicitImports.add(doCreateImportNormalizer(MODEL_SCRIPT_ACTIONS_PACKAGE, true, false));
         implicitImports.add(doCreateImportNormalizer(TIME_PACKAGE, true, false));
         implicitImports.add(doCreateImportNormalizer(CHRONOUNIT_CLASS, false, false));


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-core/issues/4784

https://github.com/openhab/openhab-core/pull/5334 already solved the issue of different behavior between file based and UI based rules.

The PR also imports RiemannType by default. The persistence extensions are always available and RiemannType would require a full qualified name or imports, which does not make much sense.
This PR brings the behaviour in line with the documentation and makes it similar to the what is in the helper libraries for other languages.