### PR TITLE
Restore model validation not to fail on diagnostic errors for rules and scripts

### DIFF
--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
@@ -331,10 +331,19 @@ public class ModelRepositoryImpl implements ModelRepository {
 
                 // Check for validation errors, but log them only
                 try {
+                    String modelType = name.substring(name.lastIndexOf(".") + 1);
                     final org.eclipse.emf.common.util.Diagnostic diagnostic = safeEmf
                             .call(() -> Diagnostician.INSTANCE.validate(resource.getContents().getFirst()));
                     for (org.eclipse.emf.common.util.Diagnostic d : diagnostic.getChildren()) {
-                        warnings.add(d.getMessage());
+                        if (d.getSeverity() == org.eclipse.emf.common.util.Diagnostic.ERROR
+                                && !"rules".equals(modelType) && !"script".equals(modelType)) {
+                            errors.add(d.getMessage());
+                        } else {
+                            warnings.add(d.getMessage());
+                        }
+                    }
+                    if (!errors.isEmpty()) {
+                        return false;
                     }
                 } catch (NullPointerException e) {
                     // see https://github.com/eclipse/smarthome/issues/3335

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
@@ -334,14 +334,7 @@ public class ModelRepositoryImpl implements ModelRepository {
                     final org.eclipse.emf.common.util.Diagnostic diagnostic = safeEmf
                             .call(() -> Diagnostician.INSTANCE.validate(resource.getContents().getFirst()));
                     for (org.eclipse.emf.common.util.Diagnostic d : diagnostic.getChildren()) {
-                        if (d.getSeverity() == org.eclipse.emf.common.util.Diagnostic.ERROR) {
-                            errors.add(d.getMessage());
-                        } else {
-                            warnings.add(d.getMessage());
-                        }
-                    }
-                    if (!errors.isEmpty()) {
-                        return false;
+                        warnings.add(d.getMessage());
                     }
                 } catch (NullPointerException e) {
                     // see https://github.com/eclipse/smarthome/issues/3335

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
@@ -131,7 +131,7 @@ public class ModelRepositoryImpl implements ModelRepository {
                 return false;
             }
             if (!newWarnings.isEmpty()) {
-                logger.warn("Validation issues found in DSL model '{}', using it anyway:\n{}", name,
+                logger.info("Validation issues found in DSL model '{}', using it anyway:\n{}", name,
                         String.join("\n", newWarnings));
             }
         } catch (IOException e) {

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
@@ -331,7 +331,7 @@ public class ModelRepositoryImpl implements ModelRepository {
 
                 // Check for validation errors, but log them only
                 try {
-                    String modelType = name.substring(name.lastIndexOf(".") + 1);
+                    String modelType = resource.getURI().fileExtension();
                     final org.eclipse.emf.common.util.Diagnostic diagnostic = safeEmf
                             .call(() -> Diagnostician.INSTANCE.validate(resource.getContents().getFirst()));
                     for (org.eclipse.emf.common.util.Diagnostic d : diagnostic.getChildren()) {

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
@@ -131,7 +131,7 @@ public class ModelRepositoryImpl implements ModelRepository {
                 return false;
             }
             if (!newWarnings.isEmpty()) {
-                logger.info("Validation issues found in DSL model '{}', using it anyway:\n{}", name,
+                logger.warn("Validation issues found in DSL model '{}', using it anyway:\n{}", name,
                         String.join("\n", newWarnings));
             }
         } catch (IOException e) {

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
@@ -336,7 +336,7 @@ public class ModelRepositoryImpl implements ModelRepository {
                             .call(() -> Diagnostician.INSTANCE.validate(resource.getContents().getFirst()));
                     for (org.eclipse.emf.common.util.Diagnostic d : diagnostic.getChildren()) {
                         if (d.getSeverity() == org.eclipse.emf.common.util.Diagnostic.ERROR
-                                && !"rules".equals(modelType) && !"script".equals(modelType)) {
+                                && !"rules".equalsIgnoreCase(modelType) && !"script".equalsIgnoreCase(modelType)) {
                             errors.add(d.getMessage());
                         } else {
                             warnings.add(d.getMessage());

--- a/itests/org.openhab.core.model.rule.tests/src/main/java/org/openhab/core/model/rule/runtime/DSLRuleProviderTest.java
+++ b/itests/org.openhab.core.model.rule.tests/src/main/java/org/openhab/core/model/rule/runtime/DSLRuleProviderTest.java
@@ -268,4 +268,26 @@ public class DSLRuleProviderTest extends JavaOSGiTest {
         Object x = context.getValue(QualifiedName.create("x"));
         assertThat(x, is(15));
     }
+
+    @Test
+    public void testRuleWithUntypedLambdaArgsDoesNotFailToLoad() {
+        Collection<Rule> rules = dslRuleProvider.getAll();
+        assertThat(rules.size(), is(0));
+
+        String model = """
+                var lambdaWithUntypedArgs = [ foo | foo ]
+                rule "RuleWithUntypedLambdaArgs"
+                when
+                   System started
+                then
+                   logInfo('Test', 'Test')
+                end
+                """;
+
+        modelRepository.addOrRefreshModel(TESTMODEL_NAME,
+                new ByteArrayInputStream(model.getBytes(StandardCharsets.UTF_8)));
+        Collection<Rule> actualRules = dslRuleProvider.getAll();
+
+        assertThat(actualRules.size(), is(1));
+    }
 }


### PR DESCRIPTION
Fixes a regression introduced in #4928

Problem reported in https://community.openhab.org/t/rules-dsl-in-5-1-is-now-unloading-rules-if-it-has-unreachable-expressions/168382