### PR TITLE
Add extra fields support to oAuth AccessTokenResponse

### DIFF
--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthClientServiceImpl.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthClientServiceImpl.java
@@ -458,10 +458,13 @@ public class OAuthClientServiceImpl implements OAuthClientService {
      */
     @Override
     public void addExtraAuthField(String key, String value) {
-        if (extraAuthFields == null) {
-            extraAuthFields = new Fields();
+        Fields lcExtraAuthFields = extraAuthFields;
+        if (lcExtraAuthFields == null) {
+            lcExtraAuthFields = new Fields();
+            extraAuthFields = lcExtraAuthFields;
         }
-        extraAuthFields.add(key, value);
+
+        lcExtraAuthFields.add(key, value);
     }
 
     @Override

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
@@ -37,6 +37,7 @@ import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.util.Fields;
 import org.openhab.core.auth.client.oauth2.AccessTokenResponse;
+import org.openhab.core.auth.client.oauth2.AccessTokenResponseExtraFieldsAdapterFactory;
 import org.openhab.core.auth.client.oauth2.OAuthException;
 import org.openhab.core.auth.client.oauth2.OAuthResponseException;
 import org.openhab.core.io.net.http.HttpClientFactory;
@@ -120,7 +121,7 @@ public class OAuthConnector {
                     } catch (DateTimeParseException e) {
                         return LocalDateTime.parse(json.getAsString()).atZone(ZoneId.systemDefault()).toInstant();
                     }
-                }).create();
+                }).registerTypeAdapterFactory(new AccessTokenResponseExtraFieldsAdapterFactory()).create();
     }
 
     /**

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
@@ -90,7 +90,11 @@ public class OAuthConnector {
     public OAuthConnector(HttpClientFactory httpClientFactory, @Nullable Fields extraFields, GsonBuilder gsonBuilder) {
         this.httpClientFactory = httpClientFactory;
         this.extraFields = extraFields;
-        gson = gsonBuilder.setDateFormat(DateTimeType.DATE_PATTERN_JSON_COMPAT)
+        this.gson = getGson(gsonBuilder);
+    }
+
+    public static Gson getGson(GsonBuilder gsonBuilder) {
+        return gsonBuilder.setDateFormat(DateTimeType.DATE_PATTERN_JSON_COMPAT)
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                 .registerTypeAdapter(OAuthResponseException.class,
                         (JsonDeserializer<OAuthResponseException>) (json, typeOfT, context) -> {

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
@@ -93,7 +93,7 @@ public class OAuthConnector {
         this.gson = getGson(gsonBuilder);
     }
 
-    public static Gson getGson(GsonBuilder gsonBuilder) {
+    static Gson getGson(GsonBuilder gsonBuilder) {
         return gsonBuilder.setDateFormat(DateTimeType.DATE_PATTERN_JSON_COMPAT)
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                 .registerTypeAdapter(OAuthResponseException.class,

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
@@ -219,8 +219,8 @@ public class OAuthConnector {
      * @throws OAuthResponseException Error codes given by authorization provider, as in RFC 6749 section 5.2 Error
      *             Response
      */
-    public AccessTokenResponse grantTypeRefreshToken(String tokenUrl, String refreshToken, @Nullable String clientId,
-            @Nullable String clientSecret, @Nullable String scope, boolean supportsBasicAuth)
+    public AccessTokenResponse grantTypeRefreshToken(String tokenUrl, @Nullable String refreshToken,
+            @Nullable String clientId, @Nullable String clientSecret, @Nullable String scope, boolean supportsBasicAuth)
             throws OAuthResponseException, OAuthException, IOException {
         HttpClient httpClient = null;
         try {

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthStoreHandlerImpl.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthStoreHandlerImpl.java
@@ -252,7 +252,10 @@ public class OAuthStoreHandlerImpl implements OAuthStoreHandler {
         return dcrDecrypted;
     }
 
-    private @Nullable String encrypt(String token) throws GeneralSecurityException {
+    private @Nullable String encrypt(@Nullable String token) throws GeneralSecurityException {
+        if (token == null) {
+            return null;
+        }
         if (storageCipher.isEmpty()) {
             return token; // do nothing if no cipher
         } else {

--- a/bundles/org.openhab.core.auth.oauth2client/src/test/java/org/openhab/core/auth/oauth2client/internal/AccessTokenResponseExtraFieldTest.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/test/java/org/openhab/core/auth/oauth2client/internal/AccessTokenResponseExtraFieldTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth.oauth2client.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.auth.client.oauth2.AccessTokenResponse;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+/**
+ * JUnit tests for {@link AccessTokenResponseExtraField}
+ *
+ * @author Laurent Arnal - Initial contribution
+ */
+@NonNullByDefault
+class AccessTokenResponseExtraFieldTest {
+
+    @Test
+    public void testExtraFieldDeserialization() {
+        Gson gson = OAuthConnector.getGson(new GsonBuilder());
+
+        // \"created_on\":\"2026-02-26T15:10:49.965249200Z\"
+        String json = "{\"access_token\":\"AccessToken\",\"expires_in\":60,\"refresh_token\":\"RefreshToken\",\"app_client_id\":\"ApplicationClientId\"}";
+        AccessTokenResponse atr = gson.fromJson(json, AccessTokenResponse.class);
+
+        assertEquals(atr.getAccessToken(), "AccessToken");
+        assertEquals(atr.getExpiresIn(), 60);
+        assertEquals(atr.getRefreshToken(), "RefreshToken");
+
+        Map<String, String> extraFields = atr.getExtraFields();
+
+        assertEquals(extraFields.size(), 1);
+        assertEquals(extraFields.containsKey("app_client_id"), true);
+        assertEquals(extraFields.get("app_client_id"), "ApplicationClientId");
+    }
+}

--- a/bundles/org.openhab.core.auth.oauth2client/src/test/java/org/openhab/core/auth/oauth2client/internal/AccessTokenResponseExtraFieldTest.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/test/java/org/openhab/core/auth/oauth2client/internal/AccessTokenResponseExtraFieldTest.java
@@ -39,14 +39,16 @@ class AccessTokenResponseExtraFieldTest {
         String json = "{\"access_token\":\"AccessToken\",\"expires_in\":60,\"refresh_token\":\"RefreshToken\",\"app_client_id\":\"ApplicationClientId\"}";
         AccessTokenResponse atr = gson.fromJson(json, AccessTokenResponse.class);
 
-        assertEquals("AccessToken", atr.getAccessToken());
-        assertEquals(60, atr.getExpiresIn());
-        assertEquals("RefreshToken", atr.getRefreshToken());
+        if (atr != null) {
+            assertEquals("AccessToken", atr.getAccessToken());
+            assertEquals(60, atr.getExpiresIn());
+            assertEquals("RefreshToken", atr.getRefreshToken());
 
-        Map<String, String> extraFields = atr.getExtraFields();
+            Map<String, String> extraFields = atr.getExtraFields();
 
-        assertEquals(1, extraFields.size());
-        assertTrue(extraFields.containsKey("app_client_id"));
-        assertEquals("ApplicationClientId", extraFields.get("app_client_id"));
+            assertEquals(1, extraFields.size());
+            assertTrue(extraFields.containsKey("app_client_id"));
+            assertEquals("ApplicationClientId", extraFields.get("app_client_id"));
+        }
     }
 }

--- a/bundles/org.openhab.core.auth.oauth2client/src/test/java/org/openhab/core/auth/oauth2client/internal/AccessTokenResponseExtraFieldTest.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/test/java/org/openhab/core/auth/oauth2client/internal/AccessTokenResponseExtraFieldTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.core.auth.oauth2client.internal;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Map;
 
@@ -24,7 +24,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 /**
- * JUnit tests for {@link AccessTokenResponseExtraField}
+ * JUnit tests for {@link AccessTokenResponse}
  *
  * @author Laurent Arnal - Initial contribution
  */
@@ -39,14 +39,14 @@ class AccessTokenResponseExtraFieldTest {
         String json = "{\"access_token\":\"AccessToken\",\"expires_in\":60,\"refresh_token\":\"RefreshToken\",\"app_client_id\":\"ApplicationClientId\"}";
         AccessTokenResponse atr = gson.fromJson(json, AccessTokenResponse.class);
 
-        assertEquals(atr.getAccessToken(), "AccessToken");
-        assertEquals(atr.getExpiresIn(), 60);
-        assertEquals(atr.getRefreshToken(), "RefreshToken");
+        assertEquals("AccessToken", atr.getAccessToken());
+        assertEquals(60, atr.getExpiresIn());
+        assertEquals("RefreshToken", atr.getRefreshToken());
 
         Map<String, String> extraFields = atr.getExtraFields();
 
-        assertEquals(extraFields.size(), 1);
-        assertEquals(extraFields.containsKey("app_client_id"), true);
-        assertEquals(extraFields.get("app_client_id"), "ApplicationClientId");
+        assertEquals(1, extraFields.size());
+        assertTrue(extraFields.containsKey("app_client_id"));
+        assertEquals("ApplicationClientId", extraFields.get("app_client_id"));
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
@@ -19,6 +19,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
+import org.eclipse.jdt.annotation.NonNull;
+
 /**
  * This is the Access Token Response, a simple value-object that holds the result of the
  * from an Access Token Request, as listed in RFC 6749:
@@ -105,18 +107,33 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
     private Instant createdOn;
 
     /**
-     * Extra element that possibly pass in the token by specific oAuth implementation
-     *
-     *
+     * Extra elements that may be passed in the token response by a specific OAuth implementation.
+     * <p>
+     * These fields are provider-specific and are not restricted to standard OAuth fields. As such,
+     * they may contain sensitive information (for example, identifiers, metadata or other values
+     * that should not be logged or exposed).
+     * <p>
+     * Consumers of this value MUST treat all entries as potentially sensitive and avoid logging or
+     * otherwise exposing them unless they have explicitly verified that the data is safe to do so.
      */
-    private Map<String, String> extraFields = Collections.emptyMap();
 
-    public Map<String, String> getExtraFields() {
-        return extraFields;
+    private Map<@NonNull String, @NonNull String> extraFields = Collections.emptyMap();
+
+    /**
+     * Returns the additional provider-specific fields from the token response.
+     * <p>
+     * Note: the returned map may contain sensitive information in non-standard fields. Callers
+     * MUST take care not to log, persist, or expose these values without first ensuring that
+     * doing so is appropriate in their security context.
+     *
+     * @return a map of additional fields as provided by the authorization server
+     */
+    public Map<@NonNull String, @NonNull String> getExtraFields() {
+        return Collections.unmodifiableMap(extraFields);
     }
 
-    public void setExtraFields(Map<String, String> extraFields) {
-        this.extraFields = extraFields;
+    public void setExtraFields(Map<@NonNull String, @NonNull String> extraFields) {
+        this.extraFields = extraFields != null ? extraFields : Collections.emptyMap();
     }
 
     /**
@@ -201,7 +218,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(accessToken, tokenType, expiresIn, refreshToken, scope, state, createdOn);
+        return Objects.hash(accessToken, tokenType, expiresIn, refreshToken, scope, state, createdOn, extraFields);
     }
 
     @Override
@@ -220,7 +237,8 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
         return Objects.equals(this.accessToken, that.accessToken) && Objects.equals(this.tokenType, that.tokenType)
                 && Objects.equals(this.expiresIn, that.expiresIn)
                 && Objects.equals(this.refreshToken, that.refreshToken) && Objects.equals(this.scope, that.scope)
-                && Objects.equals(this.state, that.state) && Objects.equals(this.createdOn, that.createdOn);
+                && Objects.equals(this.state, that.state) && Objects.equals(this.createdOn, that.createdOn)
+                && Objects.equals(this.extraFields, that.extraFields);
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
@@ -15,6 +15,8 @@ package org.openhab.core.auth.client.oauth2;
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -101,6 +103,21 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
      * is produced at the server.
      */
     private Instant createdOn;
+
+    /**
+     * Extra element that possibly pass in the token by specific oAuth implementation
+     *
+     *
+     */
+    private Map<String, String> extraFields = Collections.emptyMap();
+
+    public Map<String, String> getExtraFields() {
+        return extraFields;
+    }
+
+    public void setExtraFields(Map<String, String> extraFields) {
+        this.extraFields = extraFields;
+    }
 
     /**
      * Calculate if the token is expired against the given time.

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
@@ -243,6 +243,10 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
     }
 
     @Override
+    /*
+     * warning : the toString() function may returns sensitive information that should not go into the log.
+     *
+     */
     public String toString() {
         return "AccessTokenResponse [accessToken=" + accessToken + ", tokenType=" + tokenType + ", expiresIn="
                 + expiresIn + ", refreshToken=" + refreshToken + ", scope=" + scope + ", state=" + state

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
@@ -19,8 +19,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
-import org.eclipse.jdt.annotation.NonNull;
-
 /**
  * This is the Access Token Response, a simple value-object that holds the result of the
  * from an Access Token Request, as listed in RFC 6749:
@@ -117,7 +115,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
      * otherwise exposing them unless they have explicitly verified that the data is safe to do so.
      */
 
-    private Map<@NonNull String, @NonNull String> extraFields = Collections.emptyMap();
+    private Map<String, String> extraFields = Collections.emptyMap();
 
     /**
      * Returns the additional provider-specific fields from the token response.
@@ -128,11 +126,11 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
      *
      * @return a map of additional fields as provided by the authorization server
      */
-    public Map<@NonNull String, @NonNull String> getExtraFields() {
+    public Map<String, String> getExtraFields() {
         return Collections.unmodifiableMap(extraFields);
     }
 
-    public void setExtraFields(Map<@NonNull String, @NonNull String> extraFields) {
+    public void setExtraFields(Map<String, String> extraFields) {
         this.extraFields = (extraFields == null || extraFields.isEmpty()) ? Collections.emptyMap()
                 : Map.copyOf(extraFields);
     }
@@ -244,7 +242,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
 
     @Override
     /*
-     * warning : the toString() function may returns sensitive information that should not go into the log.
+     * Warning: the toString() function may returns sensitive information that should not go into the log.
      *
      */
     public String toString() {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
@@ -157,7 +157,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
         return accessToken;
     }
 
-    public void setAccessToken(String accessToken) {
+    public void setAccessToken(@Nullable String accessToken) {
         this.accessToken = accessToken;
     }
 
@@ -181,7 +181,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
         return refreshToken;
     }
 
-    public void setRefreshToken(String refreshToken) {
+    public void setRefreshToken(@Nullable String refreshToken) {
         this.refreshToken = refreshToken;
     }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
@@ -133,7 +133,8 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
     }
 
     public void setExtraFields(Map<@NonNull String, @NonNull String> extraFields) {
-        this.extraFields = extraFields != null ? extraFields : Collections.emptyMap();
+        this.extraFields = (extraFields == null || extraFields.isEmpty()) ? Collections.emptyMap()
+                : Map.copyOf(extraFields);
     }
 
     /**
@@ -245,6 +246,6 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
     public String toString() {
         return "AccessTokenResponse [accessToken=" + accessToken + ", tokenType=" + tokenType + ", expiresIn="
                 + expiresIn + ", refreshToken=" + refreshToken + ", scope=" + scope + ", state=" + state
-                + ", createdOn=" + createdOn + "]";
+                + ", createdOn=" + createdOn + ", extraFields= " + extraFields + "]";
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
@@ -19,6 +19,9 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * This is the Access Token Response, a simple value-object that holds the result of the
  * from an Access Token Request, as listed in RFC 6749:
@@ -30,6 +33,7 @@ import java.util.Objects;
  * @author Michael Bock - Initial contribution
  * @author Gary Tse - Adaptation for Eclipse SmartHome
  */
+@NonNullByDefault
 public final class AccessTokenResponse implements Serializable, Cloneable {
 
     /**
@@ -48,14 +52,14 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
      * @see <a href="https://tools.ietf.org/html/rfc6749#section-1.4">rfc6749 section-1.4</a>
      * @see <a href="https://tools.ietf.org/html/rfc6749#section-10.3">rfc6749 section-10.3</a>
      */
-    private String accessToken;
+    private @Nullable String accessToken;
 
     /**
      * Token type. e.g. Bearer, MAC
      *
      * @see <a href="https://tools.ietf.org/html/rfc6749#section-7.1">rfc6749 section-7.1</a>
      */
-    private String tokenType;
+    private @Nullable String tokenType;
 
     /**
      * Number of seconds that this OAuthToken is valid for since the time it was created.
@@ -76,7 +80,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
      * @see <a href="https://tools.ietf.org/html/rfc6749#section-1.5">rfc6749 section-1.5</a>
      * @see <a href="https://tools.ietf.org/html/rfc6749#section-10.4">rfc6749 section-10.4</a>
      */
-    private String refreshToken;
+    private @Nullable String refreshToken;
 
     /**
      * A space-delimited case-sensitive un-ordered string. This may be used
@@ -85,7 +89,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
      *
      * @see <a href="https://tools.ietf.org/html/rfc6749#section-3.3">rfc6749 section-3.3</a>
      */
-    private String scope;
+    private @Nullable String scope;
 
     /**
      * If the {@code state} parameter was present in the access token request.
@@ -93,7 +97,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
      *
      * <a href="https://tools.ietf.org/html/rfc6749#section-4.2.2">rfc6749 section-4.2.2</a>
      */
-    private String state;
+    private @Nullable String state;
 
     /**
      * Created datetime of this access token. This is generated locally
@@ -102,7 +106,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
      * This should be slightly later than the actual time the access token
      * is produced at the server.
      */
-    private Instant createdOn;
+    private @Nullable Instant createdOn;
 
     /**
      * Extra elements that may be passed in the token response by a specific OAuth implementation.
@@ -131,8 +135,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
     }
 
     public void setExtraFields(Map<String, String> extraFields) {
-        this.extraFields = (extraFields == null || extraFields.isEmpty()) ? Collections.emptyMap()
-                : Map.copyOf(extraFields);
+        this.extraFields = (extraFields.isEmpty()) ? Collections.emptyMap() : Map.copyOf(extraFields);
     }
 
     /**
@@ -150,7 +153,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
                 || createdOn.plusSeconds(expiresIn).minusSeconds(tokenExpiresInBuffer).isBefore(givenTime);
     }
 
-    public String getAccessToken() {
+    public @Nullable String getAccessToken() {
         return accessToken;
     }
 
@@ -158,7 +161,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
         this.accessToken = accessToken;
     }
 
-    public String getTokenType() {
+    public @Nullable String getTokenType() {
         return tokenType;
     }
 
@@ -174,7 +177,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
         this.expiresIn = expiresIn;
     }
 
-    public String getRefreshToken() {
+    public @Nullable String getRefreshToken() {
         return refreshToken;
     }
 
@@ -182,7 +185,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
         this.refreshToken = refreshToken;
     }
 
-    public String getScope() {
+    public @Nullable String getScope() {
         return scope;
     }
 
@@ -190,7 +193,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
         this.scope = scope;
     }
 
-    public String getState() {
+    public @Nullable String getState() {
         return state;
     }
 
@@ -198,7 +201,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
         this.state = state;
     }
 
-    public Instant getCreatedOn() {
+    public @Nullable Instant getCreatedOn() {
         return createdOn;
     }
 
@@ -221,7 +224,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
     }
 
     @Override
-    public boolean equals(Object thatAuthTokenObj) {
+    public boolean equals(@Nullable Object thatAuthTokenObj) {
         if (this == thatAuthTokenObj) {
             return true;
         }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponseExtraFieldsAdapterFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponseExtraFieldsAdapterFactory.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth.client.oauth2;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+public final class AccessTokenResponseExtraFieldsAdapterFactory implements TypeAdapterFactory {
+
+    private static final Set<String> KNOWN_FIELDS = Set.of("access_token", "token_type", "expires_in", "refresh_token",
+            "scope", "state");
+
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+        if (!AccessTokenResponse.class.isAssignableFrom(type.getRawType())) {
+            return null;
+        }
+
+        final TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
+        final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
+
+        return new TypeAdapter<>() {
+
+            @Override
+            public void write(JsonWriter out, T value) throws IOException {
+                delegate.write(out, value);
+            }
+
+            @Override
+            public T read(JsonReader in) throws IOException {
+                JsonElement tree = elementAdapter.read(in);
+                if (tree != null) {
+                    JsonObject obj = tree.getAsJsonObject();
+
+                    T parsed = delegate.fromJsonTree(tree);
+                    AccessTokenResponse response = (AccessTokenResponse) parsed;
+
+                    Map<String, String> extras = new HashMap<>();
+                    for (Map.Entry<String, JsonElement> entry : obj.entrySet()) {
+                        String key = entry.getKey();
+                        if (KNOWN_FIELDS.contains(key)) {
+                            continue;
+                        }
+                        extras.put(key, toStringValue(gson, entry.getValue()));
+                    }
+
+                    if (response != null) {
+                        response.setExtraFields(extras);
+                    }
+                    return parsed;
+                }
+                return null;
+            }
+        };
+    }
+
+    private static String toStringValue(Gson gson, JsonElement el) {
+        if (el == null || el.isJsonNull()) {
+            return null;
+        }
+        if (el.isJsonPrimitive()) {
+            JsonPrimitive p = el.getAsJsonPrimitive();
+            return p.getAsString();
+        }
+
+        return gson.toJson(el);
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponseExtraFieldsAdapterFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponseExtraFieldsAdapterFactory.java
@@ -36,7 +36,7 @@ import com.google.gson.stream.JsonWriter;
  * specification. All unknown JSON properties are collected into a map and exposed via {@code extraFields} on the
  * {@link AccessTokenResponse}.
  *
- * @author Laurent Arnal
+ * @author Laurent Arnal - Initial contribution
  */
 @NonNullByDefault
 public final class AccessTokenResponseExtraFieldsAdapterFactory implements TypeAdapterFactory {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponseExtraFieldsAdapterFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponseExtraFieldsAdapterFactory.java
@@ -30,7 +30,6 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
-@NonNullByDefault
 /**
  * A {@link TypeAdapterFactory} that decorates the default {@link AccessTokenResponse} adapter in order to capture
  * additional fields returned by an OAuth 2.0 authorization server that are not part of the standard RFC 6749
@@ -39,10 +38,11 @@ import com.google.gson.stream.JsonWriter;
  *
  * @author Laurent Arnal
  */
+@NonNullByDefault
 public final class AccessTokenResponseExtraFieldsAdapterFactory implements TypeAdapterFactory {
 
     private static final Set<String> KNOWN_FIELDS = Set.of("access_token", "token_type", "expires_in", "refresh_token",
-            "scope", "state");
+            "scope", "state", "created_on", "extra_fields");
 
     @Override
     public <T> @Nullable TypeAdapter<T> create(@Nullable Gson gson, @Nullable TypeToken<T> type) {
@@ -67,29 +67,32 @@ public final class AccessTokenResponseExtraFieldsAdapterFactory implements TypeA
             @Override
             public T read(JsonReader in) throws IOException {
                 JsonElement tree = elementAdapter.read(in);
-                if (tree != null) {
-                    JsonObject obj = tree.getAsJsonObject();
-
-                    T parsed = delegate.fromJsonTree(tree);
-                    AccessTokenResponse response = (AccessTokenResponse) parsed;
-
-                    Map<String, String> extras = new HashMap<>();
-                    for (Map.Entry<String, JsonElement> entry : obj.entrySet()) {
-                        String key = entry.getKey();
-                        if (KNOWN_FIELDS.contains(key)) {
-                            continue;
-                        }
-                        extras.put(key, toStringValue(gson, entry.getValue()));
-                    }
-
-                    if (response != null) {
-                        response.setExtraFields(extras);
-                    }
-                    return parsed;
+                if (tree == null) {
+                    return null;
                 }
 
-                // Delegate adapter returned null; propagate null without extra fields
-                return null;
+                if (!tree.isJsonObject()) {
+                    return delegate.fromJsonTree(tree);
+                }
+
+                JsonObject obj = tree.getAsJsonObject();
+
+                T parsed = delegate.fromJsonTree(tree);
+                AccessTokenResponse response = (AccessTokenResponse) parsed;
+
+                Map<String, String> extras = new HashMap<>();
+                for (Map.Entry<String, JsonElement> entry : obj.entrySet()) {
+                    String key = entry.getKey();
+                    if (KNOWN_FIELDS.contains(key)) {
+                        continue;
+                    }
+                    extras.put(key, toStringValue(gson, entry.getValue()));
+                }
+
+                if (response != null) {
+                    response.setExtraFields(extras);
+                }
+                return parsed;
             }
         };
     }


### PR DESCRIPTION
# Add extra fields support to oAuth AccessTokenResponse

# Description

This PR is about adding an extraFields maps in the OAuth AccessTokenResponse.
Some oAuth implementation return extra fields beside the accessToken/refreshToken/scope/state standard  field.

With this change, this extraFields will be expose in the token response, giving a chance to use them.

The motivation beside this is for the new Smarthings Binding. Samsung oAuth implementation add en extra clientId field in the response, and I need to get this to handle smartthings stuff properly.

The changes are mainly in 3 files:
- AccesTokenResponse.java to add the extraFields map.
- A new AccessTokenResponseExtraFieldsAdapterFactory.java to handle decoding of extraFields from json response.
- OAuthConnector to register the TypeAdapter on the gson object.

 
