### PR TITLE
Improve Javadoc for QuantityType

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
@@ -88,11 +88,13 @@ import tech.uom.lib.common.function.QuantityFunctions;
  * Examples:
  * 
  * <pre>
+ * {@code
  * new QuantityType<>("65 kWh") // 65 kWh, unit is parsed automatically
  * new QuantityType<>(22d, SIUnits.CELSIUS) // 22°C
  * new QuantityType<>(71.6d, ImperialUnits.FAHRENHEIT) // 71.6°F 
  * new QuantityType<>(1, MetricPrefix.MEGA(Units.BYTE)) // 1 MB
  * new QuantityType<>(56.78d, Units.WATT_HOUR) // 56.78 Wh
+ * }
  * </pre>
  * 
  * @param <T> the unit associated with the quantity


### PR DESCRIPTION
I noticed in https://github.com/openhab/openhab-addons/pull/20139/changes#r2725475130 that the Javadoc of `QuantityType` seems to be outdated and incorrectly states that `QuantityType` extends `DecimalType`, which is apparently not the case (anymore).

So I decided to fix the Javadoc and to provide more detailed explanations about quantities and units. I also added a few examples and helpful links 👍