### PR TITLE
Fix community marketplace discourse parsing

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
@@ -187,8 +187,8 @@ public class CommunityMarketplaceAddonService extends AbstractRemoteAddonService
             }
 
             List<DiscourseUser> users = pages.stream().flatMap(p -> Stream.of(p.users)).toList();
-            pages.stream().flatMap(p -> Stream.of(p.topicList.topics))
-                    .filter(t -> showUnpublished || List.of(t.tags).contains(PUBLISHED_TAG))
+            pages.stream().flatMap(p -> Stream.of(p.topicList.topics)).filter(t -> showUnpublished
+                    || (t.tags != null && Arrays.stream(t.tags).anyMatch(tag -> PUBLISHED_TAG.equals(tag.name))))
                     .map(t -> Optional.ofNullable(convertTopicItemToAddon(t, users)))
                     .forEach(a -> a.ifPresent(addons::add));
         } catch (Exception e) {

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/model/DiscourseCategoryResponseDTO.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/model/DiscourseCategoryResponseDTO.java
@@ -14,8 +14,6 @@ package org.openhab.core.addon.marketplace.internal.community.model;
 
 import java.util.Date;
 
-import org.openhab.core.addon.marketplace.internal.community.model.TagDTO.Tag;
-
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -55,7 +53,7 @@ public class DiscourseCategoryResponseDTO {
         public Integer id;
         public String title;
         public String slug;
-        public Tag[] tags;
+        public TagDTO[] tags;
         @SerializedName("posts_count")
         public Integer postsCount;
         @SerializedName("image_url")

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/model/DiscourseTopicResponseDTO.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/model/DiscourseTopicResponseDTO.java
@@ -14,8 +14,6 @@ package org.openhab.core.addon.marketplace.internal.community.model;
 
 import java.util.Date;
 
-import org.openhab.core.addon.marketplace.internal.community.model.TagDTO.Tag;
-
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -46,7 +44,7 @@ public class DiscourseTopicResponseDTO {
     public Integer likeCount;
     public Integer views;
 
-    public Tag[] tags;
+    public TagDTO[] tags;
     @SerializedName("category_id")
     public Integer categoryId;
 

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/model/TagDTO.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/model/TagDTO.java
@@ -18,9 +18,7 @@ package org.openhab.core.addon.marketplace.internal.community.model;
  * @author Ravi Nadahar - Initial contribution
  */
 public class TagDTO {
-    public static class Tag {
-        public Integer id;
-        public String name;
-        public String slug;
-    }
+    public Integer id;
+    public String name;
+    public String slug;
 }


### PR DESCRIPTION
The community marketplace is broken since the last forum upgrade, since the returned JSON has changed. This fixes the parsing, and fixes #5373.

It's still a big problem, because all previous and existing versions of OH uses the "old" parsing, and the community marketplace won't work for any of them. I don't know if downgrading the forum or some other action is considered. If not, this is the fix for the parsing.

If the forum isn't going to be fixed, I'd recommend that this is backported to 5.1x, 5.0x and 4.3x. The backporting should be straight forward, the affected code is the same in all these versions.