### PR TITLE
UpgradeTool add semantics upgrader and OH version

### DIFF
--- a/tools/upgradetool/pom.xml
+++ b/tools/upgradetool/pom.xml
@@ -45,6 +45,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.semantics</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
       <artifactId>org.openhab.core.storage.json</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/tools/upgradetool/pom.xml
+++ b/tools/upgradetool/pom.xml
@@ -98,6 +98,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>${maven.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
@@ -34,14 +34,7 @@ import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.storage.json.internal.JsonStorage;
-import org.openhab.core.tools.internal.HomeAssistantAddonUpgrader;
-import org.openhab.core.tools.internal.HomieAddonUpgrader;
-import org.openhab.core.tools.internal.ItemUnitToMetadataUpgrader;
-import org.openhab.core.tools.internal.JSProfileUpgrader;
-import org.openhab.core.tools.internal.PersistenceUpgrader;
-import org.openhab.core.tools.internal.ScriptProfileUpgrader;
-import org.openhab.core.tools.internal.SemanticTagUpgrader;
-import org.openhab.core.tools.internal.YamlConfigurationV1TagsUpgrader;
+import org.openhab.core.tools.internal.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
@@ -172,7 +172,7 @@ public class UpgradeTool {
                 if (!force) {
                     if (upgrader.getTargetVersion() instanceof String targetVersion) {
                         if (lastExecutedVersion(upgraderName) instanceof String executionVersion) {
-                            if (compareVersions(executionVersion, targetVersion) < 0) {
+                            if (compareVersions(executionVersion, targetVersion) >= 0) {
                                 LOGGER.info("Already executed '{}' to version {}. Use '--force' to execute it again.",
                                         upgraderName, executionVersion);
                                 return;

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
@@ -70,14 +70,14 @@ public class UpgradeTool {
     private static final Pattern CORE_VERSION_PATTERN = Pattern.compile("^openhab-core\\s*:\\s*(\\S+)\\s*$");
 
     private static final List<Upgrader> UPGRADERS = List.of( //
-            new ItemUnitToMetadataUpgrader(), //
-            new JSProfileUpgrader(), //
-            new ScriptProfileUpgrader(), //
-            new YamlConfigurationV1TagsUpgrader(), // Added in 5.0
-            new HomeAssistantAddonUpgrader(), // Added in 5.1
-            new HomieAddonUpgrader(), // Added in 5.1
-            new PersistenceUpgrader(), // Added in 5.1
-            new SemanticTagUpgrader() // Added in 5.2
+            new ItemUnitToMetadataUpgrader(), // Since 4.0.0
+            new JSProfileUpgrader(), // Since 4.0.0
+            new ScriptProfileUpgrader(), // Since 4.2.0
+            new YamlConfigurationV1TagsUpgrader(), // Since in 5.0
+            new HomeAssistantAddonUpgrader(), // Since in 5.1
+            new HomieAddonUpgrader(), // Since in 5.1
+            new PersistenceUpgrader(), // Since in 5.1
+            new SemanticTagUpgrader() // Since in 5.2
     );
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UpgradeTool.class);
@@ -93,10 +93,10 @@ public class UpgradeTool {
                 .numberOfArgs(1).get());
         options.addOption(Option.builder().longOpt(OPT_CONF_DIR).desc(
                 "CONF directory to process. Enclose it in double quotes to ensure that any backslashes are not ignored by your command shell.")
-                .numberOfArgs(1).build());
+                .numberOfArgs(1).get());
         options.addOption(Option.builder().longOpt(OPT_OH_VERSION).desc(
                 "openHAB target version. Upgraders will be executed again if they have been executed in an upgrade to an earlier openHAB version and there are new changes.")
-                .numberOfArgs(1).build());
+                .numberOfArgs(1).get());
         options.addOption(Option.builder().longOpt(OPT_COMMAND).numberOfArgs(1)
                 .desc("command to execute (executes all if omitted)").get());
         options.addOption(Option.builder().longOpt(OPT_LIST_COMMANDS).desc("list available commands").get());
@@ -106,7 +106,7 @@ public class UpgradeTool {
         return options;
     }
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
         Options options = getOptions();
         try {
             CommandLine commandLine = new DefaultParser().parse(options, args);

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
@@ -30,17 +30,11 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.help.HelpFormatter;
+import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.storage.json.internal.JsonStorage;
-import org.openhab.core.tools.internal.HomeAssistantAddonUpgrader;
-import org.openhab.core.tools.internal.HomieAddonUpgrader;
-import org.openhab.core.tools.internal.ItemUnitToMetadataUpgrader;
-import org.openhab.core.tools.internal.JSProfileUpgrader;
-import org.openhab.core.tools.internal.PersistenceUpgrader;
-import org.openhab.core.tools.internal.ScriptProfileUpgrader;
-import org.openhab.core.tools.internal.SemanticTagUpgrader;
-import org.openhab.core.tools.internal.YamlConfigurationV1TagsUpgrader;
+import org.openhab.core.tools.internal.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -173,7 +167,7 @@ public class UpgradeTool {
                 if (!force) {
                     if (upgrader.getTargetVersion() instanceof String targetVersion) {
                         if (lastExecutedVersion(upgraderName) instanceof String executionVersion) {
-                            if (!isBeforeVersion(executionVersion, targetVersion)) {
+                            if (compareVersions(executionVersion, targetVersion) < 0) {
                                 LOGGER.info("Already executed '{}' to version {}. Use '--force' to execute it again.",
                                         upgraderName, executionVersion);
                                 return;
@@ -298,15 +292,16 @@ public class UpgradeTool {
         return new VersionRecord();
     }
 
-    private static boolean isBeforeVersion(String versionA, String versionB) {
-        String version1 = versionA.replaceFirst("[-M].*", "");
-        String version2 = versionB.replaceFirst("[-M].*", "");
-        return version1.compareTo(version2) < 0;
+    private static int compareVersions(String versionA, String versionB) {
+        ComparableVersion version1 = new ComparableVersion(versionA);
+        ComparableVersion version2 = new ComparableVersion(versionB);
+        return version1.compareTo(version2);
     }
 
     private static @Nullable String lastExecuted(String upgrader) {
-        if (upgradeRecords != null) {
-            UpgradeRecord upgradeRecord = upgradeRecords.get(upgrader);
+        JsonStorage<UpgradeRecord> upgrades = upgradeRecords;
+        if (upgrades != null) {
+            UpgradeRecord upgradeRecord = upgrades.get(upgrader);
             if (upgradeRecord != null) {
                 return upgradeRecord.executionDate();
             }
@@ -315,14 +310,16 @@ public class UpgradeTool {
     }
 
     private static @Nullable String lastExecutedVersion(String upgrader) {
-        if (upgradeRecords != null) {
-            UpgradeRecord upgradeRecord = upgradeRecords.get(upgrader);
+        JsonStorage<UpgradeRecord> upgrades = upgradeRecords;
+        if (upgrades != null) {
+            UpgradeRecord upgradeRecord = upgrades.get(upgrader);
             if (upgradeRecord != null) {
                 return upgradeRecord.executionVersion();
             }
         }
-        if (ohVersionRecords != null) {
-            VersionRecord versionRecord = ohVersionRecords.get(UPGRADE_TOOL_VERSION_KEY);
+        JsonStorage<VersionRecord> versions = ohVersionRecords;
+        if (versions != null) {
+            VersionRecord versionRecord = versions.get(UPGRADE_TOOL_VERSION_KEY);
             if (versionRecord != null) {
                 return versionRecord.core();
             }
@@ -333,7 +330,7 @@ public class UpgradeTool {
     private static void updateUpgradeRecord(String upgrader) {
         JsonStorage<UpgradeRecord> records = upgradeRecords;
         if (records != null && ohTargetVersion.isDefined()) {
-            records.put(upgrader, new UpgradeRecord(ZonedDateTime.now(), ohTargetVersion.distro));
+            records.put(upgrader, new UpgradeRecord(ZonedDateTime.now(), ohTargetVersion.core()));
             records.flush();
         }
     }

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
@@ -34,7 +34,14 @@ import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.storage.json.internal.JsonStorage;
-import org.openhab.core.tools.internal.*;
+import org.openhab.core.tools.internal.HomeAssistantAddonUpgrader;
+import org.openhab.core.tools.internal.HomieAddonUpgrader;
+import org.openhab.core.tools.internal.ItemUnitToMetadataUpgrader;
+import org.openhab.core.tools.internal.JSProfileUpgrader;
+import org.openhab.core.tools.internal.PersistenceUpgrader;
+import org.openhab.core.tools.internal.ScriptProfileUpgrader;
+import org.openhab.core.tools.internal.SemanticTagUpgrader;
+import org.openhab.core.tools.internal.YamlConfigurationV1TagsUpgrader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,16 +148,14 @@ public class UpgradeTool {
             Path confPath = getPath("conf", commandLine, OPT_CONF_DIR, ENV_CONF);
 
             if (userdataPath != null) {
-                Path upgradeJsonDatabasePath = userdataPath
-                        .resolve(Path.of("jsondb", "org.openhab.core.tools.UpgradeTool"));
-                upgradeRecords = new JsonStorage<>(upgradeJsonDatabasePath.toFile(), null, 5, 0, 0, List.of());
+                upgradeRecords = getUpgradeRecordsStorage(userdataPath);
             } else {
                 LOGGER.warn("Upgrade records storage is not initialized.");
             }
 
             if (userdataPath != null) {
                 Path ohVersionJsonDatabasePath = userdataPath
-                        .resolve(Path.of("jsondb", "org.openhab.core.tools.ohVersion"));
+                        .resolve(Path.of("jsondb", "org.openhab.core.tools.ohVersion.json"));
                 ohVersionRecords = new JsonStorage<>(ohVersionJsonDatabasePath.toFile(), null, 5, 0, 0, List.of());
             } else {
                 LOGGER.warn("OH version storage is not initialized.");
@@ -208,6 +213,32 @@ public class UpgradeTool {
         }
 
         System.exit(0);
+    }
+
+    private static JsonStorage<UpgradeRecord> getUpgradeRecordsStorage(Path userdataPath) {
+        // The old storage name did not have a json extension. If the new storage name does not exist yet, create it and
+        // move the data from old to new.
+        Path upgradeJsonDatabasePath = userdataPath
+                .resolve(Path.of("jsondb", "org.openhab.core.tools.UpgradeTool.json"));
+        JsonStorage<UpgradeRecord> upgradeRecordStorage = new JsonStorage<>(upgradeJsonDatabasePath.toFile(), null, 5,
+                0, 0, List.of());
+        if (!Files.exists(upgradeJsonDatabasePath)) {
+            Path oldUpgradeJsonDatabasePath = userdataPath
+                    .resolve(Path.of("jsondb", "org.openhab.core.tools.UpgradeTool"));
+            if (Files.isReadable(oldUpgradeJsonDatabasePath)) {
+                JsonStorage<UpgradeRecord> oldUpgradeRecordStorage = new JsonStorage<>(upgradeJsonDatabasePath.toFile(),
+                        null, 5, 0, 0, List.of());
+                oldUpgradeRecordStorage.stream()
+                        .forEach(entry -> upgradeRecordStorage.put(entry.getKey(), entry.getValue()));
+                upgradeRecordStorage.flush();
+                try {
+                    Files.delete(oldUpgradeJsonDatabasePath);
+                } catch (IOException e) {
+                    LOGGER.debug("Failed to delete upgrade tool storage with old name.");
+                }
+            }
+        }
+        return upgradeRecordStorage;
     }
 
     /**
@@ -379,7 +410,7 @@ public class UpgradeTool {
         }
 
         protected boolean isDefined() {
-            return distro != null;
+            return core != null;
         }
     };
 }

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
@@ -12,12 +12,17 @@
  */
 package org.openhab.core.tools;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -45,6 +50,8 @@ import org.slf4j.LoggerFactory;
  * @author Jan N. Klug - Initial contribution
  * @author Jimmy Tanagra - Refactor upgraders into individual classes
  * @author Mark Herwege - Added persistence strategy upgrader
+ * @author Mark Herwege - Added semantic tag upgrader
+ * @author Mark Herwege - Track OH versions and let upgraders set a target version
  */
 @NonNullByDefault
 public class UpgradeTool {
@@ -53,11 +60,14 @@ public class UpgradeTool {
     private static final String OPT_LIST_COMMANDS = "list-commands";
     private static final String OPT_USERDATA_DIR = "userdata";
     private static final String OPT_CONF_DIR = "conf";
+    private static final String OPT_OH_VERSION = "version";
     private static final String OPT_LOG = "log";
     private static final String OPT_FORCE = "force";
 
     private static final String ENV_USERDATA = "OPENHAB_USERDATA";
     private static final String ENV_CONF = "OPENHAB_CONF";
+
+    private static final Pattern CORE_VERSION_PATTERN = Pattern.compile("^openhab-core\\s*:\\s*(\\S+)\\s*$");
 
     private static final List<Upgrader> UPGRADERS = List.of( //
             new ItemUnitToMetadataUpgrader(), //
@@ -73,6 +83,8 @@ public class UpgradeTool {
     private static final Logger LOGGER = LoggerFactory.getLogger(UpgradeTool.class);
     private static @Nullable JsonStorage<UpgradeRecord> upgradeRecords = null;
 
+    private static @Nullable String ohVersion = null;
+
     private static Options getOptions() {
         Options options = new Options();
 
@@ -81,7 +93,10 @@ public class UpgradeTool {
                 .numberOfArgs(1).get());
         options.addOption(Option.builder().longOpt(OPT_CONF_DIR).desc(
                 "CONF directory to process. Enclose it in double quotes to ensure that any backslashes are not ignored by your command shell.")
-                .numberOfArgs(1).get());
+                .numberOfArgs(1).build());
+        options.addOption(Option.builder().longOpt(OPT_OH_VERSION).desc(
+                "openHAB target version. Upgraders will be executed again if they have been executed in an upgrade to an earlier openHAB version and there are new changes.")
+                .numberOfArgs(1).build());
         options.addOption(Option.builder().longOpt(OPT_COMMAND).numberOfArgs(1)
                 .desc("command to execute (executes all if omitted)").get());
         options.addOption(Option.builder().longOpt(OPT_LIST_COMMANDS).desc("list available commands").get());
@@ -132,15 +147,32 @@ public class UpgradeTool {
                 LOGGER.warn("Upgrade records storage is not initialized.");
             }
 
+            ohVersion = commandLine.hasOption(OPT_OH_VERSION) ? commandLine.getOptionValue(OPT_OH_VERSION)
+                    : getTargetVersion(userdataPath);
+
             UPGRADERS.forEach(upgrader -> {
                 String upgraderName = upgrader.getName();
                 if (command != null && !upgraderName.equals(command)) {
                     return;
                 }
-                if (!force && lastExecuted(upgraderName) instanceof String executionDate) {
-                    LOGGER.info("Already executed '{}' on {}. Use '--force' to execute it again.", upgraderName,
-                            executionDate);
-                    return;
+                if (!force) {
+                    if (upgrader.getTargetVersion() instanceof String targetVersion) {
+                        if (lastExecutedVersion(upgraderName) instanceof String executionVersion) {
+                            if (!isBeforeVersion(executionVersion, targetVersion)) {
+                                LOGGER.info("Already executed '{}' to version {}. Use '--force' to execute it again.",
+                                        upgraderName, executionVersion);
+                                return;
+                            }
+                        } else if (lastExecuted(upgraderName) instanceof String executionDate) {
+                            LOGGER.info("Already executed '{}' on {}. Use '--force' to execute it again.", upgraderName,
+                                    executionDate);
+                            return;
+                        }
+                    } else if (lastExecuted(upgraderName) instanceof String executionDate) {
+                        LOGGER.info("Already executed '{}' on {}. Use '--force' to execute it again.", upgraderName,
+                                executionDate);
+                        return;
+                    }
                 }
                 try {
                     LOGGER.info("Executing {}: {}", upgraderName, upgrader.getDescription());
@@ -197,6 +229,36 @@ public class UpgradeTool {
         }
     }
 
+    private static @Nullable String getTargetVersion(@Nullable Path userdataPath) {
+        if (userdataPath == null) {
+            return null;
+        }
+        String ohVersion = null;
+        Path versionFilePath = userdataPath.resolve(Path.of("etc", "version.properties"));
+        try (BufferedReader reader = Files.newBufferedReader(versionFilePath, StandardCharsets.UTF_8)) {
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                Matcher matcher = CORE_VERSION_PATTERN.matcher(line.trim());
+                if (matcher.matches()) {
+                    ohVersion = matcher.group(1);
+                    break;
+                }
+            }
+        } catch (IOException | SecurityException e) {
+            LOGGER.warn(
+                    "Cannot retrieve OH core version from '{}' file. Some tasks may fail. You can provide the target version through the --version option.",
+                    versionFilePath);
+        }
+        return ohVersion;
+    }
+
+    private static boolean isBeforeVersion(String versionA, String versionB) {
+        String version1 = versionA.replaceFirst("[-M].*", "");
+        String version2 = versionB.replaceFirst("[-M].*", "");
+        return version1.compareTo(version2) < 0;
+    }
+
     private static @Nullable String lastExecuted(String upgrader) {
         JsonStorage<UpgradeRecord> records = upgradeRecords;
         if (records != null) {
@@ -208,10 +270,21 @@ public class UpgradeTool {
         return null;
     }
 
+    private static @Nullable String lastExecutedVersion(String upgrader) {
+        JsonStorage<UpgradeRecord> records = upgradeRecords;
+        if (records != null) {
+            UpgradeRecord upgradeRecord = records.get(upgrader);
+            if (upgradeRecord != null) {
+                return upgradeRecord.executionVersion;
+            }
+        }
+        return null;
+    }
+
     private static void updateUpgradeRecord(String upgrader) {
         JsonStorage<UpgradeRecord> records = upgradeRecords;
         if (records != null) {
-            records.put(upgrader, new UpgradeRecord(ZonedDateTime.now()));
+            records.put(upgrader, new UpgradeRecord(ZonedDateTime.now(), ohVersion));
             records.flush();
         }
     }
@@ -226,9 +299,11 @@ public class UpgradeTool {
 
     private static class UpgradeRecord {
         public final String executionDate;
+        public final @Nullable String executionVersion;
 
-        public UpgradeRecord(ZonedDateTime executionDate) {
+        public UpgradeRecord(ZonedDateTime executionDate, @Nullable String executionVersion) {
             this.executionDate = executionDate.toString();
+            this.executionVersion = executionVersion;
         }
     }
 }

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
@@ -261,7 +261,7 @@ public class UpgradeTool {
             prop.load(fis);
             String build = prop.getProperty("build-no");
             String distro = prop.getProperty("openhab-distro");
-            String core = prop.getProperty("opehab-core");
+            String core = prop.getProperty("openhab-core");
             String addons = prop.getProperty("openhab-addons");
             String karaf = prop.getProperty("karaf");
             return new VersionRecord(build, distro, core, addons, karaf);
@@ -292,13 +292,13 @@ public class UpgradeTool {
 
     private static @Nullable String lastExecutedVersion(String upgrader) {
         JsonStorage<UpgradeRecord> upgrades = upgradeRecords;
-        if (upgrades != null) {
-            UpgradeRecord upgradeRecord = upgrades.get(upgrader);
-            if (upgradeRecord != null) {
-                return upgradeRecord.executionVersion();
+        if (upgrades != null && upgrades.get(upgrader) instanceof UpgradeRecord upgradeRecord) {
+            String executionVersion = upgradeRecord.executionVersion();
+            if (executionVersion != null && !executionVersion.isEmpty()) {
+                return executionVersion;
             }
             // Legacy records may lack an executionVersion; in that case, fall back to the
-            // global core version recorded by the upgrade tool (old format).
+            // global core version recorded by the upgrade tool.
             JsonStorage<VersionRecord> versions = ohVersionRecords;
             if (versions != null) {
                 VersionRecord versionRecord = versions.get(UPGRADE_TOOL_VERSION_KEY);

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
@@ -28,7 +28,14 @@ import org.apache.commons.cli.help.HelpFormatter;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.storage.json.internal.JsonStorage;
-import org.openhab.core.tools.internal.*;
+import org.openhab.core.tools.internal.HomeAssistantAddonUpgrader;
+import org.openhab.core.tools.internal.HomieAddonUpgrader;
+import org.openhab.core.tools.internal.ItemUnitToMetadataUpgrader;
+import org.openhab.core.tools.internal.JSProfileUpgrader;
+import org.openhab.core.tools.internal.PersistenceUpgrader;
+import org.openhab.core.tools.internal.ScriptProfileUpgrader;
+import org.openhab.core.tools.internal.SemanticTagUpgrader;
+import org.openhab.core.tools.internal.YamlConfigurationV1TagsUpgrader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +66,8 @@ public class UpgradeTool {
             new YamlConfigurationV1TagsUpgrader(), // Added in 5.0
             new HomeAssistantAddonUpgrader(), // Added in 5.1
             new HomieAddonUpgrader(), // Added in 5.1
-            new PersistenceUpgrader() // Added in 5.1
+            new PersistenceUpgrader(), // Added in 5.1
+            new SemanticTagUpgrader() // Added in 5.2
     );
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UpgradeTool.class);

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
@@ -79,11 +79,11 @@ public class UpgradeTool {
             new ItemUnitToMetadataUpgrader(), // Since 4.0.0
             new JSProfileUpgrader(), // Since 4.0.0
             new ScriptProfileUpgrader(), // Since 4.2.0
-            new YamlConfigurationV1TagsUpgrader(), // Since in 5.0
-            new HomeAssistantAddonUpgrader(), // Since in 5.1
-            new HomieAddonUpgrader(), // Since in 5.1
-            new PersistenceUpgrader(), // Since in 5.1
-            new SemanticTagUpgrader() // Since in 5.2
+            new YamlConfigurationV1TagsUpgrader(), // Since 5.0
+            new HomeAssistantAddonUpgrader(), // Since 5.1
+            new HomieAddonUpgrader(), // Since 5.1
+            new PersistenceUpgrader(), // Since 5.1
+            new SemanticTagUpgrader() // Since 5.2
     );
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UpgradeTool.class);
@@ -308,7 +308,7 @@ public class UpgradeTool {
         if (upgradeRecords != null) {
             UpgradeRecord upgradeRecord = upgradeRecords.get(upgrader);
             if (upgradeRecord != null) {
-                return upgradeRecord.executionDate;
+                return upgradeRecord.executionDate();
             }
         }
         return null;
@@ -318,13 +318,13 @@ public class UpgradeTool {
         if (upgradeRecords != null) {
             UpgradeRecord upgradeRecord = upgradeRecords.get(upgrader);
             if (upgradeRecord != null) {
-                return upgradeRecord.executionVersion;
+                return upgradeRecord.executionVersion();
             }
         }
         if (ohVersionRecords != null) {
             VersionRecord versionRecord = ohVersionRecords.get(UPGRADE_TOOL_VERSION_KEY);
             if (versionRecord != null) {
-                return versionRecord.distro();
+                return versionRecord.core();
             }
         }
         return null;
@@ -354,35 +354,31 @@ public class UpgradeTool {
         }
     }
 
-    private static class UpgradeRecord {
-        public final String executionDate;
-        public final @Nullable String executionVersion;
-
+    private record UpgradeRecord(String executionDate, @Nullable String executionVersion) {
         public UpgradeRecord(ZonedDateTime executionDate, @Nullable String executionVersion) {
-            this.executionDate = executionDate.toString();
-            this.executionVersion = executionVersion;
+            this(executionDate.toString(), executionVersion);
         }
     }
 
-    private static record VersionRecord(String executionDate, @Nullable String build, @Nullable String distro,
+    private record VersionRecord(String executionDate, @Nullable String build, @Nullable String distro,
             @Nullable String core, @Nullable String addons, @Nullable String karaf) {
 
         protected VersionRecord() {
             this(null);
         }
 
-        protected VersionRecord(@Nullable String distro) {
-            this(null, distro, null, null, null);
+        protected VersionRecord(@Nullable String core) {
+            this(null, null, core, null, null);
         }
 
         protected VersionRecord(@Nullable String build, @Nullable String distro, @Nullable String core,
                 @Nullable String addons, @Nullable String karaf) {
-            this(ZonedDateTime.now(), null, distro, null, null, null);
+            this(ZonedDateTime.now(), build, distro, core, addons, karaf);
         }
 
         protected VersionRecord(ZonedDateTime executionDate, @Nullable String build, @Nullable String distro,
                 @Nullable String core, @Nullable String addons, @Nullable String karaf) {
-            this(executionDate.toString(), null, distro, null, null, null);
+            this(executionDate.toString(), build, distro, core, addons, karaf);
         }
 
         protected boolean isDefined() {

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
@@ -226,8 +226,8 @@ public class UpgradeTool {
             Path oldUpgradeJsonDatabasePath = userdataPath
                     .resolve(Path.of("jsondb", "org.openhab.core.tools.UpgradeTool"));
             if (Files.isReadable(oldUpgradeJsonDatabasePath)) {
-                JsonStorage<UpgradeRecord> oldUpgradeRecordStorage = new JsonStorage<>(upgradeJsonDatabasePath.toFile(),
-                        null, 5, 0, 0, List.of());
+                JsonStorage<UpgradeRecord> oldUpgradeRecordStorage = new JsonStorage<>(
+                        oldUpgradeJsonDatabasePath.toFile(), null, 5, 0, 0, List.of());
                 oldUpgradeRecordStorage.stream()
                         .forEach(entry -> upgradeRecordStorage.put(entry.getKey(), entry.getValue()));
                 upgradeRecordStorage.flush();

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
@@ -67,7 +67,13 @@ public class UpgradeTool {
     private static final String ENV_USERDATA = "OPENHAB_USERDATA";
     private static final String ENV_CONF = "OPENHAB_CONF";
 
+    private static final String UPGRADE_TOOL_VERSION_KEY = "UpgradeTool";
+
+    private static final Pattern BUILD_VERSION_PATTERN = Pattern.compile("^build-no\\s*:\\s*(\\S.*\\S)\\s*$");
+    private static final Pattern DISTRO_VERSION_PATTERN = Pattern.compile("^openhab-distro\\s*:\\s*(\\S+)\\s*$");
     private static final Pattern CORE_VERSION_PATTERN = Pattern.compile("^openhab-core\\s*:\\s*(\\S+)\\s*$");
+    private static final Pattern ADDONS_VERSION_PATTERN = Pattern.compile("^openhab-addons\\s*:\\s*(\\S+)\\s*$");
+    private static final Pattern KARAF_VERSION_PATTERN = Pattern.compile("^karaf\\s*:\\s*(\\S+)\\s*$");
 
     private static final List<Upgrader> UPGRADERS = List.of( //
             new ItemUnitToMetadataUpgrader(), // Since 4.0.0
@@ -82,8 +88,9 @@ public class UpgradeTool {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UpgradeTool.class);
     private static @Nullable JsonStorage<UpgradeRecord> upgradeRecords = null;
+    private static @Nullable JsonStorage<VersionRecord> ohVersionRecords = null;
 
-    private static @Nullable String ohVersion = null;
+    private static VersionRecord ohTargetVersion = new VersionRecord();
 
     private static Options getOptions() {
         Options options = new Options();
@@ -147,7 +154,15 @@ public class UpgradeTool {
                 LOGGER.warn("Upgrade records storage is not initialized.");
             }
 
-            ohVersion = commandLine.hasOption(OPT_OH_VERSION) ? commandLine.getOptionValue(OPT_OH_VERSION)
+            if (userdataPath != null) {
+                Path ohVersionJsonDatabasePath = userdataPath
+                        .resolve(Path.of("jsondb", "org.openhab.core.tools.ohVersion"));
+                ohVersionRecords = new JsonStorage<>(ohVersionJsonDatabasePath.toFile(), null, 5, 0, 0, List.of());
+            } else {
+                LOGGER.warn("OH version storage is not initialized.");
+            }
+            ohTargetVersion = commandLine.hasOption(OPT_OH_VERSION)
+                    ? new VersionRecord(commandLine.getOptionValue(OPT_OH_VERSION))
                     : getTargetVersion(userdataPath);
 
             UPGRADERS.forEach(upgrader -> {
@@ -183,6 +198,12 @@ public class UpgradeTool {
                     LOGGER.error("Error executing upgrader {}: {}", upgraderName, e.getMessage());
                 }
             });
+
+            // Only save version record if all upgraders have been executed
+            if (command == null) {
+                updateVersionRecord();
+            }
+
         } catch (ParseException e) {
             HelpFormatter formatter = HelpFormatter.builder().get();
             try {
@@ -229,28 +250,52 @@ public class UpgradeTool {
         }
     }
 
-    private static @Nullable String getTargetVersion(@Nullable Path userdataPath) {
-        if (userdataPath == null) {
-            return null;
-        }
-        String ohVersion = null;
-        Path versionFilePath = userdataPath.resolve(Path.of("etc", "version.properties"));
-        try (BufferedReader reader = Files.newBufferedReader(versionFilePath, StandardCharsets.UTF_8)) {
+    private static VersionRecord getTargetVersion(@Nullable Path userdataPath) {
+        if (userdataPath != null) {
+            Path versionFilePath = userdataPath.resolve(Path.of("etc", "version.properties"));
+            try (BufferedReader reader = Files.newBufferedReader(versionFilePath, StandardCharsets.UTF_8)) {
+                String build = null;
+                String distro = null;
+                String core = null;
+                String addons = null;
+                String karaf = null;
 
-            String line;
-            while ((line = reader.readLine()) != null) {
-                Matcher matcher = CORE_VERSION_PATTERN.matcher(line.trim());
-                if (matcher.matches()) {
-                    ohVersion = matcher.group(1);
-                    break;
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    Matcher matcher = BUILD_VERSION_PATTERN.matcher(line.trim());
+                    if (matcher.matches()) {
+                        build = matcher.group(1);
+                        continue;
+                    }
+                    matcher = DISTRO_VERSION_PATTERN.matcher(line.trim());
+                    if (matcher.matches()) {
+                        distro = matcher.group(1);
+                        continue;
+                    }
+                    matcher = CORE_VERSION_PATTERN.matcher(line.trim());
+                    if (matcher.matches()) {
+                        core = matcher.group(1);
+                        continue;
+                    }
+                    matcher = ADDONS_VERSION_PATTERN.matcher(line.trim());
+                    if (matcher.matches()) {
+                        addons = matcher.group(1);
+                        continue;
+                    }
+                    matcher = KARAF_VERSION_PATTERN.matcher(line.trim());
+                    if (matcher.matches()) {
+                        karaf = matcher.group(1);
+                        continue;
+                    }
                 }
+                return new VersionRecord(build, distro, core, addons, karaf);
+            } catch (IOException | SecurityException e) {
+                LOGGER.warn(
+                        "Cannot retrieve OH core version from '{}' file. Some tasks may fail. You can provide the target version through the --version option.",
+                        versionFilePath);
             }
-        } catch (IOException | SecurityException e) {
-            LOGGER.warn(
-                    "Cannot retrieve OH core version from '{}' file. Some tasks may fail. You can provide the target version through the --version option.",
-                    versionFilePath);
         }
-        return ohVersion;
+        return new VersionRecord();
     }
 
     private static boolean isBeforeVersion(String versionA, String versionB) {
@@ -260,9 +305,8 @@ public class UpgradeTool {
     }
 
     private static @Nullable String lastExecuted(String upgrader) {
-        JsonStorage<UpgradeRecord> records = upgradeRecords;
-        if (records != null) {
-            UpgradeRecord upgradeRecord = records.get(upgrader);
+        if (upgradeRecords != null) {
+            UpgradeRecord upgradeRecord = upgradeRecords.get(upgrader);
             if (upgradeRecord != null) {
                 return upgradeRecord.executionDate;
             }
@@ -271,11 +315,16 @@ public class UpgradeTool {
     }
 
     private static @Nullable String lastExecutedVersion(String upgrader) {
-        JsonStorage<UpgradeRecord> records = upgradeRecords;
-        if (records != null) {
-            UpgradeRecord upgradeRecord = records.get(upgrader);
+        if (upgradeRecords != null) {
+            UpgradeRecord upgradeRecord = upgradeRecords.get(upgrader);
             if (upgradeRecord != null) {
                 return upgradeRecord.executionVersion;
+            }
+        }
+        if (ohVersionRecords != null) {
+            VersionRecord versionRecord = ohVersionRecords.get(UPGRADE_TOOL_VERSION_KEY);
+            if (versionRecord != null) {
+                return versionRecord.distro();
             }
         }
         return null;
@@ -283,8 +332,16 @@ public class UpgradeTool {
 
     private static void updateUpgradeRecord(String upgrader) {
         JsonStorage<UpgradeRecord> records = upgradeRecords;
-        if (records != null) {
-            records.put(upgrader, new UpgradeRecord(ZonedDateTime.now(), ohVersion));
+        if (records != null && ohTargetVersion.isDefined()) {
+            records.put(upgrader, new UpgradeRecord(ZonedDateTime.now(), ohTargetVersion.distro));
+            records.flush();
+        }
+    }
+
+    private static void updateVersionRecord() {
+        JsonStorage<VersionRecord> records = ohVersionRecords;
+        if (records != null && ohTargetVersion.isDefined()) {
+            records.put(UPGRADE_TOOL_VERSION_KEY, ohTargetVersion);
             records.flush();
         }
     }
@@ -306,4 +363,30 @@ public class UpgradeTool {
             this.executionVersion = executionVersion;
         }
     }
+
+    private static record VersionRecord(String executionDate, @Nullable String build, @Nullable String distro,
+            @Nullable String core, @Nullable String addons, @Nullable String karaf) {
+
+        protected VersionRecord() {
+            this(null);
+        }
+
+        protected VersionRecord(@Nullable String distro) {
+            this(null, distro, null, null, null);
+        }
+
+        protected VersionRecord(@Nullable String build, @Nullable String distro, @Nullable String core,
+                @Nullable String addons, @Nullable String karaf) {
+            this(ZonedDateTime.now(), null, distro, null, null, null);
+        }
+
+        protected VersionRecord(ZonedDateTime executionDate, @Nullable String build, @Nullable String distro,
+                @Nullable String core, @Nullable String addons, @Nullable String karaf) {
+            this(executionDate.toString(), null, distro, null, null, null);
+        }
+
+        protected boolean isDefined() {
+            return distro != null;
+        }
+    };
 }

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
@@ -340,12 +340,14 @@ public class UpgradeTool {
             if (upgradeRecord != null) {
                 return upgradeRecord.executionVersion();
             }
-        }
-        JsonStorage<VersionRecord> versions = ohVersionRecords;
-        if (versions != null) {
-            VersionRecord versionRecord = versions.get(UPGRADE_TOOL_VERSION_KEY);
-            if (versionRecord != null) {
-                return versionRecord.core();
+            // Legacy records may lack an executionVersion; in that case, fall back to the
+            // global core version recorded by the upgrade tool (old format).
+            JsonStorage<VersionRecord> versions = ohVersionRecords;
+            if (versions != null) {
+                VersionRecord versionRecord = versions.get(UPGRADE_TOOL_VERSION_KEY);
+                if (versionRecord != null) {
+                    return versionRecord.core();
+                }
             }
         }
         return null;

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
@@ -12,17 +12,15 @@
  */
 package org.openhab.core.tools;
 
-import java.io.BufferedReader;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -62,12 +60,6 @@ public class UpgradeTool {
     private static final String ENV_CONF = "OPENHAB_CONF";
 
     private static final String UPGRADE_TOOL_VERSION_KEY = "UpgradeTool";
-
-    private static final Pattern BUILD_VERSION_PATTERN = Pattern.compile("^build-no\\s*:\\s*(\\S.*\\S)\\s*$");
-    private static final Pattern DISTRO_VERSION_PATTERN = Pattern.compile("^openhab-distro\\s*:\\s*(\\S+)\\s*$");
-    private static final Pattern CORE_VERSION_PATTERN = Pattern.compile("^openhab-core\\s*:\\s*(\\S+)\\s*$");
-    private static final Pattern ADDONS_VERSION_PATTERN = Pattern.compile("^openhab-addons\\s*:\\s*(\\S+)\\s*$");
-    private static final Pattern KARAF_VERSION_PATTERN = Pattern.compile("^karaf\\s*:\\s*(\\S+)\\s*$");
 
     private static final List<Upgrader> UPGRADERS = List.of( //
             new ItemUnitToMetadataUpgrader(), // Since 4.0.0
@@ -142,21 +134,15 @@ public class UpgradeTool {
 
             if (userdataPath != null) {
                 upgradeRecords = getUpgradeRecordsStorage(userdataPath);
-            } else {
-                LOGGER.warn("Upgrade records storage is not initialized.");
-            }
-
-            if (userdataPath != null) {
                 Path ohVersionJsonDatabasePath = userdataPath
                         .resolve(Path.of("jsondb", "org.openhab.core.tools.ohVersion.json"));
                 ohVersionRecords = new JsonStorage<>(ohVersionJsonDatabasePath.toFile(), null, 5, 0, 0, List.of());
+                ohTargetVersion = commandLine.hasOption(OPT_OH_VERSION)
+                        ? new VersionRecord(commandLine.getOptionValue(OPT_OH_VERSION))
+                        : getTargetVersion(userdataPath);
             } else {
-                LOGGER.warn("OH version storage is not initialized.");
+                LOGGER.warn("USERDATA not initialized. Unable to retrieve and save upgrade records.");
             }
-            ohTargetVersion = commandLine.hasOption(OPT_OH_VERSION)
-                    ? new VersionRecord(commandLine.getOptionValue(OPT_OH_VERSION))
-                    : getTargetVersion(userdataPath);
-
             UPGRADERS.forEach(upgrader -> {
                 String upgraderName = upgrader.getName();
                 if (command != null && !upgraderName.equals(command)) {
@@ -268,50 +254,21 @@ public class UpgradeTool {
         }
     }
 
-    private static VersionRecord getTargetVersion(@Nullable Path userdataPath) {
-        if (userdataPath != null) {
-            Path versionFilePath = userdataPath.resolve(Path.of("etc", "version.properties"));
-            try (BufferedReader reader = Files.newBufferedReader(versionFilePath, StandardCharsets.UTF_8)) {
-                String build = null;
-                String distro = null;
-                String core = null;
-                String addons = null;
-                String karaf = null;
-
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    Matcher matcher = BUILD_VERSION_PATTERN.matcher(line.trim());
-                    if (matcher.matches()) {
-                        build = matcher.group(1);
-                        continue;
-                    }
-                    matcher = DISTRO_VERSION_PATTERN.matcher(line.trim());
-                    if (matcher.matches()) {
-                        distro = matcher.group(1);
-                        continue;
-                    }
-                    matcher = CORE_VERSION_PATTERN.matcher(line.trim());
-                    if (matcher.matches()) {
-                        core = matcher.group(1);
-                        continue;
-                    }
-                    matcher = ADDONS_VERSION_PATTERN.matcher(line.trim());
-                    if (matcher.matches()) {
-                        addons = matcher.group(1);
-                        continue;
-                    }
-                    matcher = KARAF_VERSION_PATTERN.matcher(line.trim());
-                    if (matcher.matches()) {
-                        karaf = matcher.group(1);
-                        continue;
-                    }
-                }
-                return new VersionRecord(build, distro, core, addons, karaf);
-            } catch (IOException | SecurityException e) {
-                LOGGER.warn(
-                        "Cannot retrieve OH core version from '{}' file. Some tasks may fail. You can provide the target version through the --version option.",
-                        versionFilePath);
-            }
+    private static VersionRecord getTargetVersion(Path userdataPath) {
+        Path versionFilePath = userdataPath.resolve(Path.of("etc", "version.properties"));
+        Properties prop = new Properties();
+        try (FileInputStream fis = new FileInputStream(versionFilePath.toFile())) {
+            prop.load(fis);
+            String build = prop.getProperty("build-no");
+            String distro = prop.getProperty("openhab-distro");
+            String core = prop.getProperty("opehab-core");
+            String addons = prop.getProperty("openhab-addons");
+            String karaf = prop.getProperty("karaf");
+            return new VersionRecord(build, distro, core, addons, karaf);
+        } catch (IOException e) {
+            LOGGER.warn(
+                    "Cannot retrieve OH core version from '{}' file. Some tasks may fail. You can provide the target version through the --version option.",
+                    versionFilePath);
         }
         return new VersionRecord();
     }

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
@@ -353,7 +353,7 @@ public class UpgradeTool {
 
     private static void updateUpgradeRecord(String upgrader) {
         JsonStorage<UpgradeRecord> records = upgradeRecords;
-        if (records != null && ohTargetVersion.isDefined()) {
+        if (records != null) {
             records.put(upgrader, new UpgradeRecord(ZonedDateTime.now(), ohTargetVersion.core()));
             records.flush();
         }

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/Upgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/Upgrader.java
@@ -30,6 +30,10 @@ public interface Upgrader {
 
     String getDescription();
 
+    default @Nullable String getTargetVersion() {
+        return null;
+    }
+
     /**
      * Executes the upgrade process.
      *

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/HomeAssistantAddonUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/HomeAssistantAddonUpgrader.java
@@ -20,7 +20,7 @@ import org.openhab.core.tools.ExtractedAddonUpgrader;
  * installed, and if Home Assistant things exist, and if so installs the
  * Home Assistant addon.
  *
- * @Since 5.1.0
+ * @since 5.1.0
  *
  * @author Cody Cutrer - Initial contribution
  */

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/HomeAssistantAddonUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/HomeAssistantAddonUpgrader.java
@@ -20,6 +20,8 @@ import org.openhab.core.tools.ExtractedAddonUpgrader;
  * installed, and if Home Assistant things exist, and if so installs the
  * Home Assistant addon.
  *
+ * @Since 5.1.0
+ *
  * @author Cody Cutrer - Initial contribution
  */
 @NonNullByDefault

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/HomieAddonUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/HomieAddonUpgrader.java
@@ -20,7 +20,7 @@ import org.openhab.core.tools.ExtractedAddonUpgrader;
  * installed, and if Home Assistant things exist, and if so installs the
  * Home Assistant addon.
  *
- * @Since 5.1.0
+ * @since 5.1.0
  *
  * @author Cody Cutrer - Initial contribution
  */

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/HomieAddonUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/HomieAddonUpgrader.java
@@ -20,6 +20,8 @@ import org.openhab.core.tools.ExtractedAddonUpgrader;
  * installed, and if Home Assistant things exist, and if so installs the
  * Home Assistant addon.
  *
+ * @Since 5.1.0
+ *
  * @author Cody Cutrer - Initial contribution
  */
 @NonNullByDefault

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/ItemUnitToMetadataUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/ItemUnitToMetadataUpgrader.java
@@ -12,9 +12,7 @@
  */
 package org.openhab.core.tools.internal;
 
-import static org.openhab.core.thing.DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_ATMOSPHERIC_HUMIDITY;
-import static org.openhab.core.thing.DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_BATTERY_LEVEL;
-import static org.openhab.core.thing.DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_COLOR_TEMPERATURE_ABS;
+import static org.openhab.core.thing.DefaultSystemChannelTypeProvider.*;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -64,13 +62,13 @@ public class ItemUnitToMetadataUpgrader implements Upgrader {
             return false;
         }
 
-        userdataPath = userdataPath.resolve("jsondb");
+        Path dataPath = userdataPath.resolve("jsondb");
         boolean noLink;
 
-        Path itemJsonDatabasePath = userdataPath.resolve("org.openhab.core.items.Item.json");
-        Path metadataJsonDatabasePath = userdataPath.resolve("org.openhab.core.items.Metadata.json");
-        Path linkJsonDatabasePath = userdataPath.resolve("org.openhab.core.thing.link.ItemChannelLink.json");
-        Path thingJsonDatabasePath = userdataPath.resolve("org.openhab.core.thing.Thing.json");
+        Path itemJsonDatabasePath = dataPath.resolve("org.openhab.core.items.Item.json");
+        Path metadataJsonDatabasePath = dataPath.resolve("org.openhab.core.items.Metadata.json");
+        Path linkJsonDatabasePath = dataPath.resolve("org.openhab.core.thing.link.ItemChannelLink.json");
+        Path thingJsonDatabasePath = dataPath.resolve("org.openhab.core.thing.Thing.json");
         logger.info("Copying item unit from state description to metadata in database '{}'", itemJsonDatabasePath);
 
         if (!Files.isReadable(itemJsonDatabasePath)) {

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/ItemUnitToMetadataUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/ItemUnitToMetadataUpgrader.java
@@ -12,7 +12,9 @@
  */
 package org.openhab.core.tools.internal;
 
-import static org.openhab.core.thing.DefaultSystemChannelTypeProvider.*;
+import static org.openhab.core.thing.DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_ATMOSPHERIC_HUMIDITY;
+import static org.openhab.core.thing.DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_BATTERY_LEVEL;
+import static org.openhab.core.thing.DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_COLOR_TEMPERATURE_ABS;
 
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/JSProfileUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/JSProfileUpgrader.java
@@ -30,6 +30,8 @@ import org.slf4j.LoggerFactory;
 /**
  * The {@link JSProfileUpgrader} upgrades JS Profile configurations
  *
+ * @Since 4.0.0
+ *
  * @author Jan N. Klug - Initial contribution
  * @author Jimmy Tanagra - Refactored into a separate class
  */
@@ -54,9 +56,9 @@ public class JSProfileUpgrader implements Upgrader {
             return false;
         }
 
-        userdataPath = userdataPath.resolve("jsondb");
+        Path dataPath = userdataPath.resolve("jsondb");
 
-        Path linkJsonDatabasePath = userdataPath.resolve("org.openhab.core.thing.link.ItemChannelLink.json");
+        Path linkJsonDatabasePath = dataPath.resolve("org.openhab.core.thing.link.ItemChannelLink.json");
         logger.info("Upgrading JS profile configuration in database '{}'", linkJsonDatabasePath);
 
         if (!Files.isWritable(linkJsonDatabasePath)) {

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/JSProfileUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/JSProfileUpgrader.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 /**
  * The {@link JSProfileUpgrader} upgrades JS Profile configurations
  *
- * @Since 4.0.0
+ * @since 4.0.0
  *
  * @author Jan N. Klug - Initial contribution
  * @author Jimmy Tanagra - Refactored into a separate class

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/PersistenceUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/PersistenceUpgrader.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  * configuration that has no strategy defined.
  * See <a href="https://github.com/openhab/openhab-core/pull/4682">openhab/openhab-core#4682</a>.
  *
- * @Since 5.1.0
+ * @since 5.1.0
  *
  * @author Mark Herwege - Initial Contribution
  */

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/ScriptProfileUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/ScriptProfileUpgrader.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * {@code commandFromItemScript} and {@code stateFromItemScript}.
  * See <a href="https://github.com/openhab/openhab-core/pull/4058">openhab/openhab-core#4058</a>.
  *
- * @Since 4.2.0
+ * @since 4.2.0
  *
  * @author Florian Hotze - Initial contribution
  * @author Jimmy Tanagra - Refactored into a separate class

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/ScriptProfileUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/ScriptProfileUpgrader.java
@@ -33,6 +33,8 @@ import org.slf4j.LoggerFactory;
  * {@code commandFromItemScript} and {@code stateFromItemScript}.
  * See <a href="https://github.com/openhab/openhab-core/pull/4058">openhab/openhab-core#4058</a>.
  *
+ * @Since 4.2.0
+ *
  * @author Florian Hotze - Initial contribution
  * @author Jimmy Tanagra - Refactored into a separate class
  */

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
@@ -235,7 +235,7 @@ public class SemanticTagUpgrader implements Upgrader {
                 }
             }
 
-            if (newTags.size() < tags.size()) {
+            if (!newTags.equals(tags)) {
                 item.tags = newTags;
                 itemStorage.put(itemKey, item);
             }

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
@@ -94,7 +94,7 @@ public class SemanticTagUpgrader implements Upgrader {
         if (!Files.exists(semanticsJsonDatabasePath)) {
             canUpdateDb = false;
             dbUpdated = true;
-            logger.info("Semantics tags database '{}' does not exist, no tags to update.", semanticsJsonDatabasePath);
+            logger.info("Semantic tags database '{}' does not exist, no tags to update.", semanticsJsonDatabasePath);
         } else if (!Files.isReadable(semanticsJsonDatabasePath)) {
             canUpdateDb = false;
             logger.warn(
@@ -258,7 +258,7 @@ public class SemanticTagUpgrader implements Upgrader {
 
     private String tagClass(String tagUID) {
         int idx = tagUID.indexOf("_");
-        return (idx >= 0 ? tagUID.substring(0, idx) : "").trim();
+        return (idx >= 0 ? tagUID.substring(0, idx) : tagUID).trim();
     }
 
     private @Nullable String tagClass(@Nullable SemanticTag tag) {

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -102,7 +103,7 @@ public class SemanticTagUpgrader implements Upgrader {
         }
 
         Map<String, SemanticTag> defaultTags = (new DefaultSemanticTagProvider()).getAll().stream()
-                .collect(Collectors.toMap(tag -> tag.getName(), tag -> tag));
+                .collect(Collectors.toMap(SemanticTag::getName, Function.identity()));
         Map<String, SemanticTag> customTags = Map.of();
 
         Set<String> changedTags = new HashSet<>(TAGS_CHANGED_CLASS);
@@ -167,7 +168,7 @@ public class SemanticTagUpgrader implements Upgrader {
             dbUpdated = true;
 
             customTags = semanticTagStorage.getValues().stream().map(tag -> SemanticTagDTOMapper.map(tag))
-                    .filter(Objects::nonNull).collect(Collectors.toMap(tag -> tag.getName(), tag -> tag));
+                    .filter(Objects::nonNull).collect(Collectors.toMap(SemanticTag::getName, Function.identity()));
         }
 
         Path itemJsonDatabasePath = userdataPath.resolve(Path.of("jsondb", "org.openhab.core.items.Item.json"));

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.tools.internal;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.items.ManagedItemProvider;
+import org.openhab.core.semantics.SemanticTag;
+import org.openhab.core.semantics.SemanticTagImpl;
+import org.openhab.core.semantics.dto.SemanticTagDTO;
+import org.openhab.core.semantics.dto.SemanticTagDTOMapper;
+import org.openhab.core.semantics.model.DefaultSemanticTagProvider;
+import org.openhab.core.storage.json.internal.JsonStorage;
+import org.openhab.core.tools.Upgrader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link SemanticTagUpgrader} renames custom semantic tags that are now part of standard semantic tags.
+ * The custom tags will get an index appended and managed item tags will be updated accordingly.
+ * This upgrader only considers managed tags and items.
+ *
+ * @author Mark Herwege - Initial contribution
+ */
+@NonNullByDefault
+public class SemanticTagUpgrader implements Upgrader {
+    private final Logger logger = LoggerFactory.getLogger(SemanticTagUpgrader.class);
+
+    private Map<String, SemanticTag> defaultTags = Map.of();
+    private Set<String> defaultTagNames = Set.of();
+    private Set<String> defaultTagSynonyms = Set.of();
+
+    private Map<String, SemanticTag> customTags = new HashMap<>();
+    private Set<String> customTagNames = Set.of();
+    private Set<String> customTagSynonyms = Set.of();
+
+    private Set<String> addedTagNames = new HashSet<>();
+    private Map<String, String> replacedParentUIDs = new HashMap<>();
+
+    private Set<String> itemTags = Set.of();
+
+    private Map<String, String> updateMap = new HashMap<>();
+
+    @Override
+    public String getName() {
+        return "deduplicateSemanticTags";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Rename custom semantic tags that have been superseded by newly provided semantic tags with the same name";
+    }
+
+    @Override
+    public boolean execute(@Nullable Path userdataPath, @Nullable Path confPath) {
+        if (userdataPath == null) {
+            logger.error("{} skipped: no userdata directory found.", getName());
+            return false;
+        }
+
+        Path semanticsJsonDatabasePath = userdataPath
+                .resolve(Path.of("jsondb", "org.openhab.core.semantics.SemanticTag.json"));
+        Path itemJsonDatabasePath = userdataPath.resolve(Path.of("jsondb", "org.openhab.core.items.Item.json"));
+        logger.info("Deduplicating custom semantic tags '{}'", semanticsJsonDatabasePath);
+
+        if (!Files.isReadable(semanticsJsonDatabasePath)) {
+            logger.warn("Cannot access semantic tags database '{}', no tags to update, check path and access rights.",
+                    semanticsJsonDatabasePath);
+            return false;
+        }
+
+        defaultTags = (new DefaultSemanticTagProvider()).getAll().stream()
+                .collect(Collectors.toMap(tag -> tag.getUID(), tag -> tag));
+        defaultTagNames = tagNames(defaultTags);
+        defaultTagSynonyms = tagSynonyms(defaultTags);
+
+        JsonStorage<SemanticTagDTO> semanticTagStorage = new JsonStorage<>(semanticsJsonDatabasePath.toFile(), null, 5,
+                0, 0, List.of());
+        customTags = new HashMap<>(semanticTagStorage.getValues().stream().map(tag -> SemanticTagDTOMapper.map(tag))
+                .filter(Objects::nonNull).collect(Collectors.toMap(tag -> tag.getUID(), tag -> tag)));
+        customTagNames = tagNames(customTags);
+        customTagSynonyms = tagSynonyms(customTags);
+
+        boolean itemStorageExists = Files.isReadable(itemJsonDatabasePath);
+        if (!itemStorageExists) {
+            logger.error("Cannot access item database '{}', update may be incomplete.", itemJsonDatabasePath);
+        }
+        JsonStorage<ManagedItemProvider.PersistedItem> itemStorage = itemStorageExists
+                ? new JsonStorage<>(itemJsonDatabasePath.toFile(), null, 5, 0, 0, List.of())
+                : null;
+        itemTags = itemStorage != null
+                ? itemStorage.getValues().stream().filter(Objects::nonNull).map(item -> item.tags)
+                        .filter(Objects::nonNull).flatMap(Set::stream).collect(Collectors.toSet())
+                : Set.of();
+
+        replacedParentUIDs = new HashMap<>();
+        updateMap = new HashMap<>();
+        semanticTagStorage.getKeys().forEach(tagKey -> {
+            SemanticTag tag = SemanticTagDTOMapper.map(semanticTagStorage.get(tagKey));
+            if (tag != null) {
+                updateTag(semanticTagStorage, tag);
+            }
+        });
+        semanticTagStorage.flush();
+
+        if (itemStorage != null && !updateMap.isEmpty()) {
+            Set<String> oldTags = updateMap.keySet();
+            itemStorage.getKeys().forEach(itemKey -> {
+                ManagedItemProvider.PersistedItem item = itemStorage.get(itemKey);
+                Set<String> tags = item != null ? item.tags : null;
+                if (item != null && tags != null && !Collections.disjoint(tags, oldTags)) {
+                    Set<String> newItemTags = tags.stream().map(tag -> updateMap.getOrDefault(tag, tag))
+                            .collect(Collectors.toSet());
+                    item.tags = newItemTags;
+                    itemStorage.put(itemKey, item);
+                    logger.info("Updated semantic tags for item '{}' with new custom tag name(s)", itemKey);
+                }
+            });
+            itemStorage.flush();
+        }
+
+        return true;
+    }
+
+    private SemanticTag updateTag(JsonStorage<SemanticTagDTO> tagStorage, SemanticTag tag) {
+        SemanticTag newTag = tag;
+        String tagUID = tag.getUID();
+        String tagName = tag.getName();
+        String newTagUID = tagUID;
+        String newTagName = tagName;
+
+        // Make sure all parents exist and are in the proper place in the hierarchy.
+        // Start from the top level.
+        String[] hierarchy = tagUID.split("_");
+        if (hierarchy.length > 2) {
+            // First element of UID is always Location, Equipment, Point or Property
+            for (int i = 2; i <= hierarchy.length; i++) {
+                String tagParentUID = String.join("_", Arrays.copyOfRange(hierarchy, 0, i - 1));
+                if (!(defaultTags.keySet().contains(tagParentUID) || customTags.keySet().contains(tagParentUID))) {
+                    String newTagParentUID = replacedParentUIDs.getOrDefault(tagParentUID, tagParentUID);
+                    SemanticTag tagParent = new SemanticTagImpl(newTagParentUID, tagName(newTagParentUID), null,
+                            List.of());
+                    if (newTagParentUID.equals(tagParentUID)) {
+                        tagParent = updateTag(tagStorage, tagParent);
+                        newTagParentUID = tagParent.getUID();
+                        if (!tagParentUID.equals(newTagParentUID)) {
+                            replacedParentUIDs.put(tagParentUID, newTagParentUID);
+                        }
+                    }
+                    String newTagParentName = tagParent.getName();
+                    hierarchy[i - 2] = newTagParentName;
+                    addedTagNames.add(newTagParentName);
+                    logger.info("Added custom semantic tag parent '{}' for '{}'", newTagParentUID, newTagParentName);
+                }
+            }
+            newTag = new SemanticTagImpl(String.join("_", hierarchy), tag.getLabel(), tag.getDescription(),
+                    tag.getSynonyms());
+            newTagUID = newTag.getUID();
+        }
+
+        // Check if the tag itself does not exist in the default tags, and if so, rename it
+        if (defaultTagNames.contains(tagName)) {
+            for (int i = 1;; i++) {
+                newTagName = tagName + String.valueOf(i);
+                if (!tagNameExists(newTagName)) {
+                    updateMap.put(tagName, newTagName);
+                    newTagUID = tagUID + String.valueOf(i);
+                    newTag = new SemanticTagImpl(newTagUID, tag.getLabel(), tag.getDescription(), tag.getSynonyms());
+                    newTagName = newTag.getName();
+                    addedTagNames.add(newTagName);
+                    logger.info("Changed custom semantic tag '{}' to '{}'", tagName, newTagName);
+                    break;
+                }
+            }
+        }
+
+        tagStorage.put(newTagUID, SemanticTagDTOMapper.map(newTag));
+        if (!newTagUID.equals(tagUID)) {
+            tagStorage.remove(tagUID);
+        }
+        return newTag;
+    }
+
+    private Set<String> tagNames(Map<String, SemanticTag> tags) {
+        return tags.values().stream().map(tag -> tag.getName()).collect(Collectors.toSet());
+    }
+
+    private Set<String> tagSynonyms(Map<String, SemanticTag> tags) {
+        return tags.values().stream().flatMap(tag -> tag.getSynonyms().stream()).collect(Collectors.toSet());
+    }
+
+    private String tagName(String tagUID) {
+        int idx = tagUID.lastIndexOf("_");
+        return (idx >= 0 ? tagUID.substring(idx + 1) : tagUID).trim();
+    }
+
+    private boolean tagNameExists(String tagName) {
+        return defaultTagNames.contains(tagName) || defaultTagSynonyms.contains(tagName)
+                || customTagNames.contains(tagName) || customTagSynonyms.contains(tagName) || itemTags.contains(tagName)
+                || addedTagNames.contains(tagName);
+    }
+}

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
@@ -95,10 +95,10 @@ public class SemanticTagUpgrader implements Upgrader {
             canUpdateDb = false;
             dbUpdated = true;
             logger.info("Semantic tags database '{}' does not exist, no tags to update.", semanticsJsonDatabasePath);
-        } else if (!Files.isReadable(semanticsJsonDatabasePath)) {
+        } else if (!Files.isWritable(semanticsJsonDatabasePath)) {
             canUpdateDb = false;
             logger.warn(
-                    "Cannot access semantic tags database '{}', update may be incomplete, check path and access rights.",
+                    "Cannot update semantic tags database '{}', update may be incomplete, check path and access rights.",
                     semanticsJsonDatabasePath);
         }
 
@@ -177,7 +177,7 @@ public class SemanticTagUpgrader implements Upgrader {
         if (!Files.exists(itemJsonDatabasePath)) {
             logger.info("No item database '{}', no managed items to update.", itemJsonDatabasePath);
             return dbUpdated;
-        } else if (!Files.isReadable(itemJsonDatabasePath)) {
+        } else if (!Files.isWritable(itemJsonDatabasePath)) {
             logger.warn("Cannot access item database '{}', update may be incomplete, check path and access rights.",
                     itemJsonDatabasePath);
             return false;

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
  * class not being shown in the UI.
  * This upgrader only considers managed tags and items.
  *
- * @Since 5.2.0
+ * @since 5.2.0
  *
  * @author Mark Herwege - Initial contribution
  */

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
@@ -53,6 +53,8 @@ import org.slf4j.LoggerFactory;
 public class SemanticTagUpgrader implements Upgrader {
     private final Logger logger = LoggerFactory.getLogger(SemanticTagUpgrader.class);
 
+    private static final String TARGET_VERSION = "5.0.0";
+
     // Tags known to have changed class in 5.0
     private static final Set<String> TAGS_CHANGED_CLASS = Set.of("LowBattery", "OpenLevel", "OpenState", "Tampered");
 
@@ -66,6 +68,11 @@ public class SemanticTagUpgrader implements Upgrader {
     @Override
     public String getDescription() {
         return "Correct custom semantic tags and item semantic tags for changes in provided default semantic tags";
+    }
+
+    @Override
+    public @Nullable String getTargetVersion() {
+        return TARGET_VERSION;
     }
 
     @Override

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * The {@link SemanticTagUpgrader} removes custom semantic tags that are now part of standard semantic tags.
  * The custom tags will also be checked for their position in the hierarchy. If hierarchy in the default tags has
  * changed, and a custom tag depends on it, the custom tag parent will be adjusted.
- * Semantic tags applied to items will be cleaned. If there is more then one semantic tag by class, only one will be
+ * Semantic tags applied to items will be cleaned. If there is more than one semantic tag by class, only one will be
  * kept and the others will be renamed to be non-semantic. Preference is given to keep the tags that moved class. If
  * there is a Property tag, a Point tag will be added if missing.
  * With these adjustments, the model can be further corrected from the UI without issues of double tags of the same

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
@@ -187,8 +187,8 @@ public class SemanticTagUpgrader implements Upgrader {
 
         // Adjust item tags, make sure only 1 tag of every class exists, rename other tags
         Map<String, SemanticTag> allSemanticTags = Stream.of(defaultTags, customTags)
-                .flatMap(map -> map.entrySet().stream())
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                .flatMap(map -> map.entrySet().stream()).collect(Collectors.toMap(Map.Entry::getKey,
+                        Map.Entry::getValue, (defaultTag, customTag) -> defaultTag));
         Set<String> itemTagNames = itemStorage.getValues().stream().filter(Objects::nonNull).map(item -> item.tags)
                 .filter(Objects::nonNull).flatMap(tags -> tags.stream()).collect(Collectors.toSet());
         Set<String> allTagNames = Stream.of(allSemanticTags.keySet(), itemTagNames).flatMap(tags -> tags.stream())

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
@@ -113,7 +113,7 @@ public class SemanticTagUpgrader implements Upgrader {
                     5, 0, 0, List.of());
 
             // Remove duplicate tags from custom tag store
-            for (String tagKey : semanticTagStorage.getKeys()) {
+            for (String tagKey : List.copyOf(semanticTagStorage.getKeys())) {
                 SemanticTag tag = SemanticTagDTOMapper.map(semanticTagStorage.get(tagKey));
                 if (tag == null) {
                     continue;
@@ -130,7 +130,7 @@ public class SemanticTagUpgrader implements Upgrader {
             semanticTagStorage.flush();
 
             // Rewrite parent relationships if position in hierarchy has changed
-            for (String tagKey : semanticTagStorage.getKeys()) {
+            for (String tagKey : List.copyOf(semanticTagStorage.getKeys())) {
                 SemanticTag tag = SemanticTagDTOMapper.map(semanticTagStorage.get(tagKey));
                 if (tag == null) {
                     continue;

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
@@ -47,6 +47,8 @@ import org.slf4j.LoggerFactory;
  * class not being shown in the UI.
  * This upgrader only considers managed tags and items.
  *
+ * @Since 5.2.0
+ *
  * @author Mark Herwege - Initial contribution
  */
 @NonNullByDefault

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/SemanticTagUpgrader.java
@@ -248,7 +248,7 @@ public class SemanticTagUpgrader implements Upgrader {
 
     private String newTagName(String oldTagName, Set<String> allTagNames) {
         String tagName = oldTagName;
-        int i = 0;
+        int i = 1;
         while (allTagNames.contains(tagName)) {
             tagName = oldTagName + String.valueOf(i);
             i++;

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/YamlConfigurationV1TagsUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/YamlConfigurationV1TagsUpgrader.java
@@ -76,6 +76,8 @@ public class YamlConfigurationV1TagsUpgrader implements Upgrader {
                 .disable(YAMLGenerator.Feature.SPLIT_LINES) // do not split long lines
                 .enable(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR) // indent arrays
                 .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES) // use quotes only where necessary
+                .enable(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS) // use quotes for numbers stored as
+                                                                               // strings
                 .enable(YAMLParser.Feature.PARSE_BOOLEAN_LIKE_WORDS_AS_STRINGS) // do not parse ON/OFF/... as booleans
                 .findAndAddModules() //
                 .visibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE) //

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/YamlConfigurationV1TagsUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/YamlConfigurationV1TagsUpgrader.java
@@ -82,7 +82,9 @@ public class YamlConfigurationV1TagsUpgrader implements Upgrader {
                 .findAndAddModules() //
                 .visibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE) //
                 .visibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY) //
-                .defaultPropertyInclusion(Value.construct(Include.NON_NULL, Include.ALWAYS)) //
+                // Correct compatible behavior with {@link YamlModelRepositoryImpl} for jackson > 2.8, don't use
+                // Include.ALWAYS as second argument (which would have been the behavior earlier)
+                .defaultPropertyInclusion(Value.construct(Include.NON_NULL, Include.NON_NULL)) //
                 .enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN) //
                 .build();
     }

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/YamlConfigurationV1TagsUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/YamlConfigurationV1TagsUpgrader.java
@@ -27,13 +27,14 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonInclude.Value;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
 
 /**
@@ -66,24 +67,22 @@ public class YamlConfigurationV1TagsUpgrader implements Upgrader {
 
     private final Logger logger = LoggerFactory.getLogger(YamlConfigurationV1TagsUpgrader.class);
 
-    private final YAMLFactory yamlFactory;
     private final ObjectMapper objectMapper;
 
     public YamlConfigurationV1TagsUpgrader() {
         // match the options used in {@link YamlModelRepositoryImpl}
-        yamlFactory = YAMLFactory.builder() //
+        objectMapper = YAMLMapper.builder() //
                 .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER) // omit "---" at file start
                 .disable(YAMLGenerator.Feature.SPLIT_LINES) // do not split long lines
                 .enable(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR) // indent arrays
                 .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES) // use quotes only where necessary
-                .enable(YAMLParser.Feature.PARSE_BOOLEAN_LIKE_WORDS_AS_STRINGS).build(); // do not parse ON/OFF/... as
-                                                                                         // booleans
-        objectMapper = new ObjectMapper(yamlFactory);
-        objectMapper.findAndRegisterModules();
-        objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
-        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-        objectMapper.setDefaultPropertyInclusion(Include.NON_NULL);
-        objectMapper.enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN);
+                .enable(YAMLParser.Feature.PARSE_BOOLEAN_LIKE_WORDS_AS_STRINGS) // do not parse ON/OFF/... as booleans
+                .findAndAddModules() //
+                .visibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE) //
+                .visibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY) //
+                .defaultPropertyInclusion(Value.construct(Include.NON_NULL, Include.ALWAYS)) //
+                .enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN) //
+                .build();
     }
 
     @Override
@@ -104,15 +103,13 @@ public class YamlConfigurationV1TagsUpgrader implements Upgrader {
         }
 
         String confEnv = System.getenv("OPENHAB_CONF");
-        // If confPath is set to OPENHAB_CONF, look inside /tags/ subdirectory
-        // otherwise use the given confPath as is
-        if (confEnv != null && !confEnv.isBlank() && Path.of(confEnv).toAbsolutePath().equals(confPath)) {
-            confPath = confPath.resolve("tags");
-        }
+        // If confPath is set to OPENHAB_CONF, look inside /tags/ subdirectory otherwise use the given confPath as is.
+        // Make configPath "effectively final" inside the lambda below.
+        Path configPath = confEnv != null && !confEnv.isBlank() && Path.of(confEnv).toAbsolutePath().equals(confPath)
+                ? confPath.resolve("tags")
+                : confPath;
+        logger.info("Upgrading YAML tags configurations in '{}'", configPath);
 
-        logger.info("Upgrading YAML tags configurations in '{}'", confPath);
-
-        Path configPath = confPath; // make configPath "effectively final" inside the lambda below
         try {
             Files.walkFileTree(configPath, new SimpleFileVisitor<>() {
                 @Override


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-core/issues/5363

OH 5.0 introduced additional semantic tags and moved some tags between Point and Property. For some users, this is leading to an inconsistent semantic model that is not always easy to correct directly in the UI. Double semantic tags for one class where not visible and cannot be corrected in the UI (the UI only showed one).
Secondly, when custom tags where built as children of these moved tags, the parentID's in the custom tag database did not match anymore, leading to issues.

The semantic tag upgrader will, for managed custom semantic tags and managed items:
- remove custom semantic tags that have been added to the provided default semantic tags.
- adjust the parentID of a custom semantic tag if the parent now has a different hierarchy.
- clean item tags: only allow a single Location, Equipment, Point, Property tag and remove the extra ones.
- clean items: if there is a Property tag without Point tag, add a "Status" tag.

This is not necessarily making the model fully consistent again (e.g. it is still possible to have both an Equipment and a Point tag), but the remaining issues would be visible in the logs and the health checks, and can be corrected in the UI. As there are always assumptions to be made when we would automatically remove tags, I did not do that, but leave it to the user. The changes are the minimum changes to make it possible to edit the semantic tags through the UI again.

As I foresee that this upgrader may have to run again in future versions of OH, when new tags are added, I put in place infrastructure to have a target version for an upgrader. Upgraders will now store the OH version they run with and this can be checked against the target version to see if an upgrader should be run again (on top of the execution date which was already stored). This will make it possible to just change the target version in the upgrader to run again in a future version upgrade.

And as I am picking up the OH version the upgrader runs with, I store that version information in a separate file in the JSON storage. I see potential to use that in the future to keep track of the JSON DB version vs the OH version and make installation/upgrade decisions based on that (see discussion in https://community.openhab.org/t/openhab-reliability-and-upgrade-experience/167835/72). Having the version of the DB stored in the DB would be requirement for that. There may be a need for multiple (e.g. UpgradeTool here stores a version but it may not have run, so no version from there, a fresh installation should also have a version that could be written in the same file, OH startup would also have a version...). I put in the "UpgradeTool" key to be able to store multiple and decide on what to do based on that.