### PR TITLE
Textual Rules: allow XBase between then … end

### DIFF
--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
@@ -25,7 +25,6 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
-import org.eclipse.xtext.xbase.XBlockExpression;
 import org.eclipse.xtext.xbase.XExpression;
 import org.eclipse.xtext.xbase.interpreter.IEvaluationContext;
 import org.openhab.core.automation.Action;
@@ -272,7 +271,7 @@ public class DSLRuleProvider
 
         // Create Action
         String context = DSLScriptContextProvider.CONTEXT_IDENTIFIER + modelName + "-" + index + "\n";
-        XBlockExpression expression = rule.getScript();
+        XExpression expression = rule.getScript();
         String script = NodeModelUtils.findActualNodeFor(expression).getText();
         Configuration cfg = new Configuration();
         cfg.put("script", context + removeIndentation(script));

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/Rules.xtext
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/Rules.xtext
@@ -22,7 +22,7 @@ VariableDeclaration:
 Rule:
 	'rule' name=(STRING|ID)
 	'when' eventtrigger+=EventTrigger ('or' eventtrigger+=EventTrigger)*
-	'then' script=Script
+	'then' script=XExpressionInClosure
 	'end'
 ;
 


### PR DESCRIPTION
This changes the Rules.xtext grammar not to use explicitly the Script object from the Script.xtext grammar. This allows at a later time to extend DSL Scripts to start with `import`s, without allowing `import` statements right after `rule … when … then <IMPORT> … end`.

This change also allows at a later moment to merge DSL Rules and DSL Scripts into one.  Then a `Rule` cannot contain a `then Rule end`, because this will be endless recursion. Much like “Groovy files in openhab/automation/jsr223/.groovy” can be considered at the same time as one-shot Groovy-scripts and as Groovy-rules.

This works, wtih and without the current change:
```
var j = 7                                                                                                       
var p = 3
val lock  = new java.util.concurrent.locks.ReentrantLock 
                            
var ()=>String l = [
  lock.lock
  val m = j = 1 + j                                                                                             
  logError("L", "Current value  " + m.toString)
  lock.unlock                                                                                                   
  m.toString
]                                                       
                                                        
rule "System started"
when                                                    
    System reached start level 100
then
    var p = 12
    logError("P" , "P is " + p.toString)
    var n = 7
    logError("N", "N is " + n.toString)
    logError('l', 'System reached start level 100 ' + 7|W.toString)
    logError("E", "New value: " + l.apply)
end

rule "Item s changed"
when
    Item s changed
then
    logError("A", "item s changed to " + s.state + 13|A.toString)
    logError("B", "New value: " + l.apply)
    // Because n is defined only in the previous rule, next line would produce:
    // Script execution of rule with UID 'rr-2' failed: The name 'n' cannot be resolved to an item or type; line 33, column 37, length 1 in rr
    // logError("M", "N again is " + n.toString)
end

```