### PR TITLE
Fixes for null pointer error when compiling into eclipse

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
@@ -263,6 +263,10 @@ public class ConfigUtil {
             final List<Object> lst = new ArrayList<>(collection.size());
             for (final Object it : collection) {
                 final Object normalized = normalizeType(it, null);
+                if (normalized == null) {
+                    continue;
+                }
+
                 lst.add(normalized);
                 if (normalized.getClass() != lst.getFirst().getClass()) {
                     throw new IllegalArgumentException(

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/MinMaxValidator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/MinMaxValidator.java
@@ -51,14 +51,14 @@ final class MinMaxValidator implements ConfigDescriptionParameterValidator {
         TypeIntrospection typeIntrospection = TypeIntrospections.get(parameter.getType());
         if (parameter.getMinimum() != null) {
             BigDecimal min = parameter.getMinimum();
-            if (typeIntrospection.isMinViolated(value, min) && min != null) {
+            if (min != null && typeIntrospection.isMinViolated(value, min)) {
                 return createMinMaxViolationMessage(parameter.getName(), typeIntrospection.getMinViolationMessageKey(),
                         min);
             }
         }
         if (parameter.getMaximum() != null) {
             BigDecimal max = parameter.getMaximum();
-            if (typeIntrospection.isMaxViolated(value, max) && max != null) {
+            if (max != null && typeIntrospection.isMaxViolated(value, max)) {
                 return createMinMaxViolationMessage(parameter.getName(), typeIntrospection.getMaxViolationMessageKey(),
                         max);
             }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/MinMaxValidator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/MinMaxValidator.java
@@ -49,19 +49,15 @@ final class MinMaxValidator implements ConfigDescriptionParameterValidator {
         }
 
         TypeIntrospection typeIntrospection = TypeIntrospections.get(parameter.getType());
-        if (parameter.getMinimum() != null) {
-            BigDecimal min = parameter.getMinimum();
-            if (min != null && typeIntrospection.isMinViolated(value, min)) {
-                return createMinMaxViolationMessage(parameter.getName(), typeIntrospection.getMinViolationMessageKey(),
-                        min);
-            }
+        BigDecimal min = parameter.getMinimum();
+        if (min != null && typeIntrospection.isMinViolated(value, min)) {
+            return createMinMaxViolationMessage(parameter.getName(), typeIntrospection.getMinViolationMessageKey(),
+                    min);
         }
-        if (parameter.getMaximum() != null) {
-            BigDecimal max = parameter.getMaximum();
-            if (max != null && typeIntrospection.isMaxViolated(value, max)) {
-                return createMinMaxViolationMessage(parameter.getName(), typeIntrospection.getMaxViolationMessageKey(),
-                        max);
-            }
+        BigDecimal max = parameter.getMaximum();
+        if (max != null && typeIntrospection.isMaxViolated(value, max)) {
+            return createMinMaxViolationMessage(parameter.getName(), typeIntrospection.getMaxViolationMessageKey(),
+                    max);
         }
         return null;
     }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/MinMaxValidator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/MinMaxValidator.java
@@ -51,14 +51,14 @@ final class MinMaxValidator implements ConfigDescriptionParameterValidator {
         TypeIntrospection typeIntrospection = TypeIntrospections.get(parameter.getType());
         if (parameter.getMinimum() != null) {
             BigDecimal min = parameter.getMinimum();
-            if (typeIntrospection.isMinViolated(value, min)) {
+            if (typeIntrospection.isMinViolated(value, min) && min != null) {
                 return createMinMaxViolationMessage(parameter.getName(), typeIntrospection.getMinViolationMessageKey(),
                         min);
             }
         }
         if (parameter.getMaximum() != null) {
             BigDecimal max = parameter.getMaximum();
-            if (typeIntrospection.isMaxViolated(value, max)) {
+            if (typeIntrospection.isMaxViolated(value, max) && max != null) {
                 return createMinMaxViolationMessage(parameter.getName(), typeIntrospection.getMaxViolationMessageKey(),
                         max);
             }

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/GenericItemProvider.java
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/GenericItemProvider.java
@@ -556,7 +556,10 @@ public class GenericItemProvider extends AbstractProvider<Item>
         };
 
         Item baseItem = createItemOfType(baseItemType, modelItem.getName());
-        return applyGroupFunction(baseItem, modelItem, function);
+        if (baseItem != null) {
+            return applyGroupFunction(baseItem, modelItem, function);
+        }
+        return null;
     }
 
     /**

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
@@ -36,7 +36,6 @@ import org.openhab.core.types.EventOption;
 import org.openhab.core.types.StateDescriptionFragmentBuilder;
 import org.openhab.core.types.StateOption;
 import org.openhab.core.util.BundleResolver;
-import org.ops4j.lang.NullArgumentException;
 import org.osgi.framework.Bundle;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -439,7 +438,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
         final Bundle bundle = bundleResolver.resolveBundle(DefaultSystemChannelTypeProvider.class);
 
         if (bundle == null) {
-            throw new NullArgumentException("bundle==null in DefaultSystemChannelTypeProvider::getChannelTypes");
+            throw new NullPointerException("bundle==null in DefaultSystemChannelTypeProvider::getChannelTypes");
         }
 
         for (final ChannelType channelType : CHANNEL_TYPES) {
@@ -454,7 +453,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
         final Bundle bundle = bundleResolver.resolveBundle(DefaultSystemChannelTypeProvider.class);
 
         if (bundle == null) {
-            throw new NullArgumentException("bundle==null in DefaultSystemChannelTypeProvider::getChannelType");
+            throw new NullPointerException("bundle==null in DefaultSystemChannelTypeProvider::getChannelType");
         }
 
         for (final ChannelType channelType : CHANNEL_TYPES) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
@@ -437,9 +437,12 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
         final List<ChannelType> allChannelTypes = new ArrayList<>();
         final Bundle bundle = bundleResolver.resolveBundle(DefaultSystemChannelTypeProvider.class);
 
-        for (final ChannelType channelType : CHANNEL_TYPES) {
-            allChannelTypes.add(createLocalizedChannelType(bundle, channelType, locale));
+        if (bundle != null) {
+            for (final ChannelType channelType : CHANNEL_TYPES) {
+                allChannelTypes.add(createLocalizedChannelType(bundle, channelType, locale));
+            }
         }
+
         return allChannelTypes;
     }
 
@@ -447,9 +450,11 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
     public @Nullable ChannelType getChannelType(ChannelTypeUID channelTypeUID, @Nullable Locale locale) {
         final Bundle bundle = bundleResolver.resolveBundle(DefaultSystemChannelTypeProvider.class);
 
-        for (final ChannelType channelType : CHANNEL_TYPES) {
-            if (channelTypeUID.equals(channelType.getUID())) {
-                return createLocalizedChannelType(bundle, channelType, locale);
+        if (bundle != null) {
+            for (final ChannelType channelType : CHANNEL_TYPES) {
+                if (channelTypeUID.equals(channelType.getUID())) {
+                    return createLocalizedChannelType(bundle, channelType, locale);
+                }
             }
         }
         return null;

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
@@ -36,6 +36,7 @@ import org.openhab.core.types.EventOption;
 import org.openhab.core.types.StateDescriptionFragmentBuilder;
 import org.openhab.core.types.StateOption;
 import org.openhab.core.util.BundleResolver;
+import org.ops4j.lang.NullArgumentException;
 import org.osgi.framework.Bundle;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -437,10 +438,12 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
         final List<ChannelType> allChannelTypes = new ArrayList<>();
         final Bundle bundle = bundleResolver.resolveBundle(DefaultSystemChannelTypeProvider.class);
 
-        if (bundle != null) {
-            for (final ChannelType channelType : CHANNEL_TYPES) {
-                allChannelTypes.add(createLocalizedChannelType(bundle, channelType, locale));
-            }
+        if (bundle == null) {
+            throw new NullArgumentException("bundle==null in DefaultSystemChannelTypeProvider::getChannelTypes");
+        }
+
+        for (final ChannelType channelType : CHANNEL_TYPES) {
+            allChannelTypes.add(createLocalizedChannelType(bundle, channelType, locale));
         }
 
         return allChannelTypes;
@@ -450,13 +453,16 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
     public @Nullable ChannelType getChannelType(ChannelTypeUID channelTypeUID, @Nullable Locale locale) {
         final Bundle bundle = bundleResolver.resolveBundle(DefaultSystemChannelTypeProvider.class);
 
-        if (bundle != null) {
-            for (final ChannelType channelType : CHANNEL_TYPES) {
-                if (channelTypeUID.equals(channelType.getUID())) {
-                    return createLocalizedChannelType(bundle, channelType, locale);
-                }
+        if (bundle == null) {
+            throw new NullArgumentException("bundle==null in DefaultSystemChannelTypeProvider::getChannelType");
+        }
+
+        for (final ChannelType channelType : CHANNEL_TYPES) {
+            if (channelTypeUID.equals(channelType.getUID())) {
+                return createLocalizedChannelType(bundle, channelType, locale);
             }
         }
+
         return null;
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
@@ -438,7 +438,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
         final Bundle bundle = bundleResolver.resolveBundle(DefaultSystemChannelTypeProvider.class);
 
         if (bundle == null) {
-            throw new NullPointerException("bundle==null in DefaultSystemChannelTypeProvider::getChannelTypes");
+            throw new IllegalArgumentException("bundle==null in DefaultSystemChannelTypeProvider::getChannelTypes");
         }
 
         for (final ChannelType channelType : CHANNEL_TYPES) {
@@ -453,7 +453,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
         final Bundle bundle = bundleResolver.resolveBundle(DefaultSystemChannelTypeProvider.class);
 
         if (bundle == null) {
-            throw new NullPointerException("bundle==null in DefaultSystemChannelTypeProvider::getChannelType");
+            throw new IllegalArgumentException("bundle==null in DefaultSystemChannelTypeProvider::getChannelType");
         }
 
         for (final ChannelType channelType : CHANNEL_TYPES) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
@@ -209,15 +209,16 @@ public class ThingImpl implements Thing {
     }
 
     @Override
-    public @Nullable String setProperty(@Nullable String name, @Nullable String value) {
-        if (name == null || name.isEmpty()) {
+    public @Nullable String setProperty(String name, @Nullable String value) {
+        if (name.isEmpty()) {
             throw new IllegalArgumentException("Property name must not be null or empty");
         }
         synchronized (this) {
             if (value == null) {
                 return properties.remove(name);
+            } else {
+                return properties.put(name, value);
             }
-            return properties.put(name, value);
         }
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
@@ -209,8 +209,8 @@ public class ThingImpl implements Thing {
     }
 
     @Override
-    public @Nullable String setProperty(String name, @Nullable String value) {
-        if (name.isEmpty()) {
+    public @Nullable String setProperty(@Nullable String name, @Nullable String value) {
+        if (name == null || name.isEmpty()) {
             throw new IllegalArgumentException("Property name must not be null or empty");
         }
         synchronized (this) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -210,14 +211,14 @@ public class ThingImpl implements Thing {
 
     @Override
     public @Nullable String setProperty(String name, @Nullable String value) {
-        if (name.isEmpty()) {
+        if (name == null || name.isEmpty()) {
             throw new IllegalArgumentException("Property name must not be null or empty");
         }
         synchronized (this) {
-            if (value == null) {
+            if (value != null) {
                 return properties.remove(name);
             } else {
-                return properties.put(name, value);
+                return properties.put(name, Objects.requireNonNull(value));
             }
         }
     }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -215,11 +214,8 @@ public class ThingImpl implements Thing {
             throw new IllegalArgumentException("Property name must not be null or empty");
         }
         synchronized (this) {
-            if (value == null) {
-                return properties.remove(name);
-            } else {
-                return properties.put(name, Objects.requireNonNull(value));
-            }
+            String val = value;
+            return val == null ? properties.remove(name) : properties.put(name, val);
         }
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
@@ -215,7 +215,7 @@ public class ThingImpl implements Thing {
             throw new IllegalArgumentException("Property name must not be null or empty");
         }
         synchronized (this) {
-            if (value != null) {
+            if (value == null) {
                 return properties.remove(name);
             } else {
                 return properties.put(name, Objects.requireNonNull(value));

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
@@ -210,7 +210,7 @@ public class ThingImpl implements Thing {
 
     @Override
     public @Nullable String setProperty(String name, @Nullable String value) {
-        if (name == null || name.isEmpty()) {
+        if (name.isEmpty()) {
             throw new IllegalArgumentException("Property name must not be null or empty");
         }
         synchronized (this) {

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderTest.java
@@ -81,10 +81,12 @@ public class ChannelStateDescriptionProviderTest {
 
         ChannelType channelType1 = Mockito.mock(ChannelType.class);
 
-        when(channelType1.getState()).thenReturn(stateDescription1);
-        when(thingTypeRegistry.getChannelType(channel1, Locale.ENGLISH)).thenReturn(channelType1);
-        when(dynamicStateDescriptionProvider.getStateDescription(channel1, stateDescription1, Locale.ENGLISH))
-                .thenReturn(StateDescriptionFragmentBuilder.create(stateDescription1).build().toStateDescription());
+        if (stateDescription1 != null) {
+            when(channelType1.getState()).thenReturn(stateDescription1);
+            when(thingTypeRegistry.getChannelType(channel1, Locale.ENGLISH)).thenReturn(channelType1);
+            when(dynamicStateDescriptionProvider.getStateDescription(channel1, stateDescription1, Locale.ENGLISH))
+                    .thenReturn(StateDescriptionFragmentBuilder.create(stateDescription1).build().toStateDescription());
+        }
 
         // Setup channel 2
         Channel channel2 = ChannelBuilder.create(CHANNEL_UID_2).build();
@@ -93,10 +95,12 @@ public class ChannelStateDescriptionProviderTest {
                 .withMaximum(new BigDecimal(100)).withStep(BigDecimal.ONE).withReadOnly(channel2State).withPattern("%s")
                 .build().toStateDescription();
         ChannelType channelType2 = Mockito.mock(ChannelType.class);
-        when(channelType2.getState()).thenReturn(stateDescription2);
-        when(thingTypeRegistry.getChannelType(channel2, Locale.ENGLISH)).thenReturn(channelType2);
-        when(dynamicStateDescriptionProvider.getStateDescription(channel2, stateDescription2, Locale.ENGLISH))
-                .thenReturn(StateDescriptionFragmentBuilder.create(stateDescription2).build().toStateDescription());
+        if (stateDescription2 != null) {
+            when(channelType2.getState()).thenReturn(stateDescription2);
+            when(thingTypeRegistry.getChannelType(channel2, Locale.ENGLISH)).thenReturn(channelType2);
+            when(dynamicStateDescriptionProvider.getStateDescription(channel2, stateDescription2, Locale.ENGLISH))
+                    .thenReturn(StateDescriptionFragmentBuilder.create(stateDescription2).build().toStateDescription());
+        }
 
         channelStateDescriptionProvider.addDynamicStateDescriptionProvider(dynamicStateDescriptionProvider);
 
@@ -117,11 +121,13 @@ public class ChannelStateDescriptionProviderTest {
                 .withMaximum(new BigDecimal(100)).withStep(BigDecimal.ONE).withReadOnly(Boolean.TRUE).withPattern("%s")
                 .build().toStateDescription();
         ChannelType channelType = Mockito.mock(ChannelType.class);
-        when(channelType.getState()).thenReturn(stateDescription1);
-        when(thingTypeRegistry.getChannelType(channel1, Locale.ENGLISH)).thenReturn(channelType);
+        if (stateDescription1 != null) {
+            when(channelType.getState()).thenReturn(stateDescription1);
+            when(thingTypeRegistry.getChannelType(channel1, Locale.ENGLISH)).thenReturn(channelType);
 
-        when(dynamicStateDescriptionProvider.getStateDescription(channel1, stateDescription1, Locale.ENGLISH))
-                .thenReturn(StateDescriptionFragmentBuilder.create(stateDescription1).build().toStateDescription());
+            when(dynamicStateDescriptionProvider.getStateDescription(channel1, stateDescription1, Locale.ENGLISH))
+                    .thenReturn(StateDescriptionFragmentBuilder.create(stateDescription1).build().toStateDescription());
+        }
 
         channelStateDescriptionProvider.addDynamicStateDescriptionProvider(dynamicStateDescriptionProvider);
 
@@ -142,11 +148,13 @@ public class ChannelStateDescriptionProviderTest {
                 .withMaximum(new BigDecimal(100)).withStep(BigDecimal.ONE).withReadOnly(Boolean.FALSE).withPattern("%s")
                 .build().toStateDescription();
         ChannelType channelType = Mockito.mock(ChannelType.class);
-        when(channelType.getState()).thenReturn(stateDescription1);
-        when(thingTypeRegistry.getChannelType(channel1, Locale.ENGLISH)).thenReturn(channelType);
+        if (stateDescription1 != null) {
+            when(channelType.getState()).thenReturn(stateDescription1);
+            when(thingTypeRegistry.getChannelType(channel1, Locale.ENGLISH)).thenReturn(channelType);
 
-        when(dynamicStateDescriptionProvider.getStateDescription(channel1, stateDescription1, Locale.ENGLISH))
-                .thenReturn(StateDescriptionFragmentBuilder.create(stateDescription1).build().toStateDescription());
+            when(dynamicStateDescriptionProvider.getStateDescription(channel1, stateDescription1, Locale.ENGLISH))
+                    .thenReturn(StateDescriptionFragmentBuilder.create(stateDescription1).build().toStateDescription());
+        }
 
         channelStateDescriptionProvider.addDynamicStateDescriptionProvider(dynamicStateDescriptionProvider);
 

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderTest.java
@@ -81,12 +81,11 @@ public class ChannelStateDescriptionProviderTest {
 
         ChannelType channelType1 = Mockito.mock(ChannelType.class);
 
-        if (stateDescription1 != null) {
-            when(channelType1.getState()).thenReturn(stateDescription1);
-            when(thingTypeRegistry.getChannelType(channel1, Locale.ENGLISH)).thenReturn(channelType1);
-            when(dynamicStateDescriptionProvider.getStateDescription(channel1, stateDescription1, Locale.ENGLISH))
-                    .thenReturn(StateDescriptionFragmentBuilder.create(stateDescription1).build().toStateDescription());
-        }
+        assertNotNull(stateDescription1);
+        when(channelType1.getState()).thenReturn(stateDescription1);
+        when(thingTypeRegistry.getChannelType(channel1, Locale.ENGLISH)).thenReturn(channelType1);
+        when(dynamicStateDescriptionProvider.getStateDescription(channel1, stateDescription1, Locale.ENGLISH))
+                .thenReturn(StateDescriptionFragmentBuilder.create(stateDescription1).build().toStateDescription());
 
         // Setup channel 2
         Channel channel2 = ChannelBuilder.create(CHANNEL_UID_2).build();
@@ -95,12 +94,12 @@ public class ChannelStateDescriptionProviderTest {
                 .withMaximum(new BigDecimal(100)).withStep(BigDecimal.ONE).withReadOnly(channel2State).withPattern("%s")
                 .build().toStateDescription();
         ChannelType channelType2 = Mockito.mock(ChannelType.class);
-        if (stateDescription2 != null) {
-            when(channelType2.getState()).thenReturn(stateDescription2);
-            when(thingTypeRegistry.getChannelType(channel2, Locale.ENGLISH)).thenReturn(channelType2);
-            when(dynamicStateDescriptionProvider.getStateDescription(channel2, stateDescription2, Locale.ENGLISH))
-                    .thenReturn(StateDescriptionFragmentBuilder.create(stateDescription2).build().toStateDescription());
-        }
+        assertNotNull(stateDescription2);
+
+        when(channelType2.getState()).thenReturn(stateDescription2);
+        when(thingTypeRegistry.getChannelType(channel2, Locale.ENGLISH)).thenReturn(channelType2);
+        when(dynamicStateDescriptionProvider.getStateDescription(channel2, stateDescription2, Locale.ENGLISH))
+                .thenReturn(StateDescriptionFragmentBuilder.create(stateDescription2).build().toStateDescription());
 
         channelStateDescriptionProvider.addDynamicStateDescriptionProvider(dynamicStateDescriptionProvider);
 
@@ -121,13 +120,13 @@ public class ChannelStateDescriptionProviderTest {
                 .withMaximum(new BigDecimal(100)).withStep(BigDecimal.ONE).withReadOnly(Boolean.TRUE).withPattern("%s")
                 .build().toStateDescription();
         ChannelType channelType = Mockito.mock(ChannelType.class);
-        if (stateDescription1 != null) {
-            when(channelType.getState()).thenReturn(stateDescription1);
-            when(thingTypeRegistry.getChannelType(channel1, Locale.ENGLISH)).thenReturn(channelType);
 
-            when(dynamicStateDescriptionProvider.getStateDescription(channel1, stateDescription1, Locale.ENGLISH))
-                    .thenReturn(StateDescriptionFragmentBuilder.create(stateDescription1).build().toStateDescription());
-        }
+        assertNotNull(stateDescription1);
+        when(channelType.getState()).thenReturn(stateDescription1);
+        when(thingTypeRegistry.getChannelType(channel1, Locale.ENGLISH)).thenReturn(channelType);
+
+        when(dynamicStateDescriptionProvider.getStateDescription(channel1, stateDescription1, Locale.ENGLISH))
+                .thenReturn(StateDescriptionFragmentBuilder.create(stateDescription1).build().toStateDescription());
 
         channelStateDescriptionProvider.addDynamicStateDescriptionProvider(dynamicStateDescriptionProvider);
 
@@ -148,13 +147,13 @@ public class ChannelStateDescriptionProviderTest {
                 .withMaximum(new BigDecimal(100)).withStep(BigDecimal.ONE).withReadOnly(Boolean.FALSE).withPattern("%s")
                 .build().toStateDescription();
         ChannelType channelType = Mockito.mock(ChannelType.class);
-        if (stateDescription1 != null) {
-            when(channelType.getState()).thenReturn(stateDescription1);
-            when(thingTypeRegistry.getChannelType(channel1, Locale.ENGLISH)).thenReturn(channelType);
 
-            when(dynamicStateDescriptionProvider.getStateDescription(channel1, stateDescription1, Locale.ENGLISH))
-                    .thenReturn(StateDescriptionFragmentBuilder.create(stateDescription1).build().toStateDescription());
-        }
+        assertNotNull(stateDescription1);
+        when(channelType.getState()).thenReturn(stateDescription1);
+        when(thingTypeRegistry.getChannelType(channel1, Locale.ENGLISH)).thenReturn(channelType);
+
+        when(dynamicStateDescriptionProvider.getStateDescription(channel1, stateDescription1, Locale.ENGLISH))
+                .thenReturn(StateDescriptionFragmentBuilder.create(stateDescription1).build().toStateDescription());
 
         channelStateDescriptionProvider.addDynamicStateDescriptionProvider(dynamicStateDescriptionProvider);
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <karaf.tooling.version>4.4.10</karaf.tooling.version>
     <sat.version>0.18.0</sat.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <xtext.version>2.41.0</xtext.version>
+    <xtext.version>2.42.0</xtext.version>
     <spotless.version>2.44.3</spotless.version>
     <!-- Eclipse Java formatter version 4.26+ does not check test files -->
     <spotless.eclipse.version>4.25</spotless.eclipse.version>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <karaf.tooling.version>4.4.10</karaf.tooling.version>
     <sat.version>0.18.0</sat.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <xtext.version>2.42.0</xtext.version>
+    <xtext.version>2.41.0</xtext.version>
     <spotless.version>2.44.3</spotless.version>
     <!-- Eclipse Java formatter version 4.26+ does not check test files -->
     <spotless.eclipse.version>4.25</spotless.eclipse.version>


### PR DESCRIPTION
# Fixes for null pointer error when compiling into eclipse

When you try to compile core into eclipse, there is a few compile error because of null pointer not handle correctly.
This PR is about to fix them.
