### PR TITLE
fix accessors on AccessTokenResponse.java

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
@@ -165,7 +165,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
         return tokenType;
     }
 
-    public void setTokenType(String tokenType) {
+    public void setTokenType(@Nullable String tokenType) {
         this.tokenType = tokenType;
     }
 
@@ -189,7 +189,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
         return scope;
     }
 
-    public void setScope(String scope) {
+    public void setScope(@Nullable String scope) {
         this.scope = scope;
     }
 
@@ -197,7 +197,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
         return state;
     }
 
-    public void setState(String state) {
+    public void setState(@Nullable String state) {
         this.state = state;
     }
 
@@ -205,7 +205,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
         return createdOn;
     }
 
-    public void setCreatedOn(Instant createdOn) {
+    public void setCreatedOn(@Nullable Instant createdOn) {
         this.createdOn = createdOn;
     }
 


### PR DESCRIPTION

# Fix setter accessors on AccessTokenResponse.java

This is a fix around previous PR on AccessTokenResponse to fix @Nullable inconsistency between setter and getter.