### PR TITLE
Rules.xtext: remove unused imports

### DIFF
--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/Rules.xtext
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/Rules.xtext
@@ -1,19 +1,11 @@
 grammar org.openhab.core.model.rule.Rules with org.openhab.core.model.script.Script
 
-import "http://www.eclipse.org/xtext/xbase/Xbase" as xbase
-import "http://www.eclipse.org/xtext/common/JavaVMTypes" as types
-import "http://www.eclipse.org/emf/2002/Ecore" as ecore
-
 generate rules "https://openhab.org/model/Rules"
 
 RuleModel:
 	importSection = XImportSection?
 	(variables+=VariableDeclaration)*
 	(rules += Rule)*;
-
-//Import:
-//	'import' importedNamespace=QualifiedNameWithWildcard
-//;
 
 VariableDeclaration:
 	(writeable?='var'|'val') (=>(type=JvmTypeReference name=ValidID) | name=ValidID) ('=' right=XExpression)?


### PR DESCRIPTION
The `.java` files generated before and after this change are the same.  The only exception are comments in RulesGrammarAccess.java.