### PR TITLE
Script.xtext: remove unused imports

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/Script.xtext
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/Script.xtext
@@ -1,8 +1,6 @@
 grammar org.openhab.core.model.script.Script with org.eclipse.xtext.xbase.Xbase
 
 import "http://www.eclipse.org/xtext/xbase/Xbase"
-import "http://www.eclipse.org/xtext/common/JavaVMTypes" as types
-import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
 generate script "https://openhab.org/model/Script"
 


### PR DESCRIPTION
The `.java` files generated before and after this change are the same.