### PR TITLE
core.model.GenericThingProvider.xtend: Remove compiler warning

### DIFF
--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
@@ -121,7 +121,7 @@ class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implement
         return things
     }
 
-    def public Collection<Thing> getAllFromModel(String modelName) {
+    def Collection<Thing> getAllFromModel(String modelName) {
         thingsMap.getOrDefault(modelName, List.of())
     }
 


### PR DESCRIPTION
> [INFO] --- xtend:2.41.0:compile (default) @ org.openhab.core.model.thing ---                                    
> [WARNING]                                                                                                       
> WARNING:        GenericThingProvider.xtend - bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
> 124: The public modifier is unnecessary on method getAllFromModel
