### PR TITLE
model.thing.ThingSyntacticSequencerExtension: avoid redirection over empty class

### DIFF
--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/serializer/ThingSyntacticSequencerExtension.java
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/serializer/ThingSyntacticSequencerExtension.java
@@ -24,8 +24,7 @@ import org.eclipse.xtext.serializer.analysis.ISyntacticSequencerPDAProvider.ISyn
  *
  * @author Alex Tugarev - Initial contribution
  */
-@SuppressWarnings("restriction")
-public class ThingSyntacticSequencerExtension extends ThingSyntacticSequencer {
+public class ThingSyntacticSequencerExtension extends AbstractThingSyntacticSequencer {
 
     @Override
     protected void emit_ModelThing_ThingKeyword_0_q(EObject semanticObject, ISynNavigable transition,


### PR DESCRIPTION
Avoid a compiler warning:

> [INFO] --- compiler:3.15.0:compile (default-compile) @ org.openhab.core.model.thing ---
> [WARNING] org.openhab.core.model.thing/src/org/openhab/core/model/thing/serializer/ThingSyntacticSequencerExtension.java:[27,19] Unnecessary @'SuppressWarnings("restriction")
