### PR TITLE
Add support for HTTP401 in OAuth connector

### DIFF
--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
@@ -12,7 +12,17 @@
  */
 package org.openhab.core.auth.oauth2client.internal;
 
-import static org.openhab.core.auth.oauth2client.internal.Keyword.*;
+import static org.openhab.core.auth.oauth2client.internal.Keyword.AUTHORIZATION_CODE;
+import static org.openhab.core.auth.oauth2client.internal.Keyword.CLIENT_CREDENTIALS;
+import static org.openhab.core.auth.oauth2client.internal.Keyword.CLIENT_ID;
+import static org.openhab.core.auth.oauth2client.internal.Keyword.CLIENT_SECRET;
+import static org.openhab.core.auth.oauth2client.internal.Keyword.CODE;
+import static org.openhab.core.auth.oauth2client.internal.Keyword.GRANT_TYPE;
+import static org.openhab.core.auth.oauth2client.internal.Keyword.PASSWORD;
+import static org.openhab.core.auth.oauth2client.internal.Keyword.REDIRECT_URI;
+import static org.openhab.core.auth.oauth2client.internal.Keyword.REFRESH_TOKEN;
+import static org.openhab.core.auth.oauth2client.internal.Keyword.SCOPE;
+import static org.openhab.core.auth.oauth2client.internal.Keyword.USERNAME;
 
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -361,27 +371,43 @@ public class OAuthConnector {
             statusCode = response.getStatus();
             content = response.getContentAsString();
 
-            if (statusCode == HttpStatus.OK_200) {
-                AccessTokenResponse jsonResponse = gson.fromJson(content, AccessTokenResponse.class);
-                if (jsonResponse == null) {
-                    throw new OAuthException("Empty response content when deserializing AccessTokenResponse");
+            switch (statusCode) {
+                case HttpStatus.OK_200 -> {
+                    AccessTokenResponse jsonResponse = gson.fromJson(content, AccessTokenResponse.class);
+                    if (jsonResponse == null) {
+                        throw new OAuthException("Empty response content when deserializing AccessTokenResponse");
+                    }
+                    jsonResponse.setCreatedOn(Instant.now()); // this is not supplied by the response
+                    logger.debug("grant type {} to URL {} success", grantType, request.getURI());
+                    return jsonResponse;
                 }
-                jsonResponse.setCreatedOn(Instant.now()); // this is not supplied by the response
-                logger.debug("grant type {} to URL {} success", grantType, request.getURI());
-                return jsonResponse;
-            } else if (statusCode == HttpStatus.BAD_REQUEST_400) {
-                OAuthResponseException errorResponse = gson.fromJson(content, OAuthResponseException.class);
-                if (errorResponse == null) {
-                    throw new OAuthException("Empty response content when deserializing OAuthResponseException");
-                }
-                logger.error("grant type {} to URL {} failed with error code {}, description {}", grantType,
-                        request.getURI(), errorResponse.getError(), errorResponse.getErrorDescription());
+                case HttpStatus.BAD_REQUEST_400 -> {
+                    OAuthResponseException errorResponse = gson.fromJson(content, OAuthResponseException.class);
+                    if (errorResponse == null) {
+                        throw new OAuthException("Empty response content when deserializing OAuthResponseException");
+                    }
+                    logger.error("grant type {} to URL {} failed with error code {}, description {}", grantType,
+                            request.getURI(), errorResponse.getError(), errorResponse.getErrorDescription());
 
-                throw errorResponse;
-            } else {
-                logger.error("grant type {} to URL {} failed with HTTP response code {}", grantType, request.getURI(),
-                        statusCode);
-                throw new OAuthException("Bad http response, http code " + statusCode);
+                    throw errorResponse;
+                }
+                case HttpStatus.UNAUTHORIZED_401 -> {
+                    // Per RFC 6749 section 5.2, HTTP 401 indicates client authentication failure (invalid_client).
+                    // The response body may contain JSON error details; fall back to invalid_client if not present.
+                    OAuthResponseException errorResponse = gson.fromJson(content, OAuthResponseException.class);
+                    if (errorResponse == null || errorResponse.getError().isEmpty()) {
+                        errorResponse = new OAuthResponseException();
+                        errorResponse.setError("invalid_client");
+                    }
+                    logger.debug("grant type {} to URL {} failed with HTTP 401, error: {}, description: {}", grantType,
+                            request.getURI(), errorResponse.getError(), errorResponse.getErrorDescription());
+                    throw errorResponse;
+                }
+                default -> {
+                    logger.error("grant type {} to URL {} failed with HTTP response code {}", grantType,
+                            request.getURI(), statusCode);
+                    throw new OAuthException("Bad http response, http code " + statusCode);
+                }
             }
         } catch (InterruptedException | TimeoutException | ExecutionException e) {
             throw new IOException("Exception in oauth communication, grant type " + grantType, e);

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
@@ -393,8 +393,18 @@ public class OAuthConnector {
                 }
                 case HttpStatus.UNAUTHORIZED_401 -> {
                     // Per RFC 6749 section 5.2, HTTP 401 indicates client authentication failure (invalid_client).
-                    // The response body may contain JSON error details; fall back to invalid_client if not present.
-                    OAuthResponseException errorResponse = gson.fromJson(content, OAuthResponseException.class);
+                    // The response body may contain JSON error details; fall back to invalid_client if not present
+                    // or if the body is non-JSON (plain-text, HTML, etc.).
+                    OAuthResponseException errorResponse = null;
+                    if (!content.isBlank()) {
+                        try {
+                            errorResponse = gson.fromJson(content, OAuthResponseException.class);
+                        } catch (JsonSyntaxException e) {
+                            logger.debug(
+                                    "grant type {} to URL {} returned HTTP 401 with non-JSON body, treating as invalid_client",
+                                    grantType, request.getURI());
+                        }
+                    }
                     if (errorResponse == null || errorResponse.getError().isEmpty()) {
                         errorResponse = new OAuthResponseException();
                         errorResponse.setError("invalid_client");

--- a/bundles/org.openhab.core.auth.oauth2client/src/test/java/org/openhab/core/auth/oauth2client/internal/OAuthConnectorTest.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/test/java/org/openhab/core/auth/oauth2client/internal/OAuthConnectorTest.java
@@ -106,4 +106,31 @@ class OAuthConnectorTest {
         assertEquals("unauthorized_client", exception.getError());
         assertEquals("The client is not authorized to use this grant type", exception.getErrorDescription());
     }
+
+    /**
+     * RFC 6749 section 5.2: HTTP 401 with a non-JSON body (e.g. "Unauthorized")
+     * must be treated like an empty body and produce an {@link OAuthResponseException}
+     * with {@code error = "invalid_client"} instead of failing JSON parsing.
+     */
+    @Test
+    void testHttp401WithNonJsonBodyThrowsInvalidClientException() {
+        HttpClientFactory httpClientFactory = mock(HttpClientFactory.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        Request request = mock(Request.class, Mockito.RETURNS_SELF);
+        ContentResponse contentResponse = mock(ContentResponse.class);
+
+        try {
+            setupHttpMocks(httpClientFactory, httpClient, request, contentResponse, HttpStatus.UNAUTHORIZED_401,
+                    "Unauthorized");
+        } catch (InterruptedException | TimeoutException | ExecutionException e) {
+            fail(e);
+        }
+
+        OAuthConnector connector = new OAuthConnector(httpClientFactory);
+
+        OAuthResponseException exception = assertThrows(OAuthResponseException.class, () -> connector
+                .grantTypeClientCredentials("http://token.example.com", "clientId", "clientSecret", null, false));
+
+        assertEquals("invalid_client", exception.getError());
+    }
 }

--- a/bundles/org.openhab.core.auth.oauth2client/src/test/java/org/openhab/core/auth/oauth2client/internal/OAuthConnectorTest.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/test/java/org/openhab/core/auth/oauth2client/internal/OAuthConnectorTest.java
@@ -12,6 +12,13 @@
  */
 package org.openhab.core.auth.oauth2client.internal;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -20,14 +27,8 @@ import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.http.HttpStatus;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
-import static org.mockito.ArgumentMatchers.anyString;
 import org.mockito.Mockito;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import org.openhab.core.auth.client.oauth2.OAuthResponseException;
 import org.openhab.core.io.net.http.HttpClientFactory;
 

--- a/bundles/org.openhab.core.auth.oauth2client/src/test/java/org/openhab/core/auth/oauth2client/internal/OAuthConnectorTest.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/test/java/org/openhab/core/auth/oauth2client/internal/OAuthConnectorTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth.oauth2client.internal;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.http.HttpStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.anyString;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.openhab.core.auth.client.oauth2.OAuthResponseException;
+import org.openhab.core.io.net.http.HttpClientFactory;
+
+/**
+ * JUnit tests for {@link OAuthConnector}
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+@NonNullByDefault
+class OAuthConnectorTest {
+
+    private static void setupHttpMocks(HttpClientFactory httpClientFactory, HttpClient httpClient, Request request,
+            ContentResponse contentResponse, int statusCode, String responseBody)
+            throws InterruptedException, TimeoutException, ExecutionException {
+        when(httpClientFactory.createHttpClient(anyString())).thenReturn(httpClient);
+        when(httpClient.isStarted()).thenReturn(true);
+        when(httpClient.newRequest(anyString())).thenReturn(request);
+        when(request.send()).thenReturn(contentResponse);
+        when(contentResponse.getStatus()).thenReturn(statusCode);
+        when(contentResponse.getContentAsString()).thenReturn(responseBody);
+    }
+
+    /**
+     * RFC 6749 section 5.2: HTTP 401 with no JSON body must produce an
+     * {@link OAuthResponseException} with {@code error = "invalid_client"}.
+     */
+    @Test
+    void testHttp401WithEmptyBodyThrowsInvalidClientException() {
+        HttpClientFactory httpClientFactory = mock(HttpClientFactory.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        // RETURNS_SELF handles the Request builder-pattern chain (method/timeout/header/content)
+        Request request = mock(Request.class, Mockito.RETURNS_SELF);
+        ContentResponse contentResponse = mock(ContentResponse.class);
+
+        try {
+            setupHttpMocks(httpClientFactory, httpClient, request, contentResponse, HttpStatus.UNAUTHORIZED_401, "");
+        } catch (InterruptedException | TimeoutException | ExecutionException e) {
+            fail(e);
+        }
+
+        OAuthConnector connector = new OAuthConnector(httpClientFactory);
+
+        OAuthResponseException exception = assertThrows(OAuthResponseException.class, () -> connector
+                .grantTypeClientCredentials("http://token.example.com", "clientId", "clientSecret", null, false));
+
+        assertEquals("invalid_client", exception.getError());
+    }
+
+    /**
+     * RFC 6749 section 5.2: HTTP 401 with a JSON error body must preserve the
+     * server-supplied {@code error} and {@code error_description} fields.
+     */
+    @Test
+    void testHttp401WithJsonBodyThrowsExceptionWithServerError() {
+        HttpClientFactory httpClientFactory = mock(HttpClientFactory.class);
+        HttpClient httpClient = mock(HttpClient.class);
+        Request request = mock(Request.class, Mockito.RETURNS_SELF);
+        ContentResponse contentResponse = mock(ContentResponse.class);
+
+        String jsonBody = "{\"error\":\"unauthorized_client\","
+                + "\"error_description\":\"The client is not authorized to use this grant type\"}";
+
+        try {
+            setupHttpMocks(httpClientFactory, httpClient, request, contentResponse, HttpStatus.UNAUTHORIZED_401,
+                    jsonBody);
+        } catch (InterruptedException | TimeoutException | ExecutionException e) {
+            fail(e);
+        }
+
+        OAuthConnector connector = new OAuthConnector(httpClientFactory);
+
+        OAuthResponseException exception = assertThrows(OAuthResponseException.class, () -> connector
+                .grantTypeClientCredentials("http://token.example.com", "clientId", "clientSecret", null, false));
+
+        assertEquals("unauthorized_client", exception.getError());
+        assertEquals("The client is not authorized to use this grant type", exception.getErrorDescription());
+    }
+}


### PR DESCRIPTION
Currently, the OAuth connector treats a HTTP 401 answer from the server as an unspecified exception.
HTTP 401 is a valid answer from the server, if the request cannot be authenticated - e.g. because the client id does not exist or the provided (refresh) token is invalid. There should therefore be no error logging and the situation must be cleanly communicated towards the calling client. This PR takes care of this.