### PR TITLE
Fix config deserialization for records

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -167,20 +167,20 @@ public final class ConfigParser {
         return configurationClass.cast(constructor.newInstance(args));
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     private static @Nullable Object convertValue(Object value, Class<?> type, @Nullable Type genericType,
             String fieldName) {
         // Allows to have List<int>, List<Double>, List<String> etc (and the corresponding Set<?>)
         if (value instanceof Collection<?> valueCollection) {
-            Collection collection = List.class.isAssignableFrom(type) ? new ArrayList<>()
+            Collection<Object> collection = List.class.isAssignableFrom(type) ? new ArrayList<>()
                     : Set.class.isAssignableFrom(type) ? new HashSet<>() : null;
 
             if (collection != null && genericType instanceof ParameterizedType parameterizedType) {
-                Class<?> innerClass = (Class<?>) parameterizedType.getActualTypeArguments()[0];
+                Type innerType = parameterizedType.getActualTypeArguments()[0];
 
-                valueCollection.stream().map(it -> valueAs(it, innerClass)).filter(Objects::nonNull)
-                        .forEach(collection::add);
-
+                if (innerType instanceof Class<?> innerClass) {
+                    valueCollection.stream().map(it -> valueAs(it, innerClass)).filter(Objects::nonNull)
+                            .forEach(collection::add);
+                }
                 return collection;
             } else {
                 LOGGER.warn("Skipping field '{}', only List and Set is supported as target Collection", fieldName);

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public final class ConfigParser {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfigParser.class);
+
     private static final Map<String, Class<?>> WRAPPER_CLASSES_MAP = Map.of(//
             "float", Float.class, //
             "double", Double.class, //
@@ -53,6 +54,16 @@ public final class ConfigParser {
             "short", Short.class, //
             "byte", Byte.class, //
             "boolean", Boolean.class);
+
+    private static final Map<Class<?>, Object> PRIMITIVE_DEFAULTS = Map.of( //
+            boolean.class, false, //
+            byte.class, (byte) 0, //
+            short.class, (short) 0, //
+            int.class, 0, //
+            long.class, 0L, //
+            float.class, 0f, //
+            double.class, 0d, //
+            char.class, '\0');
 
     private ConfigParser() {
         // prevent instantiation
@@ -144,7 +155,13 @@ public final class ConfigParser {
             String name = component.getName();
             Object rawValue = properties.get(name);
 
-            args[i] = convertValue(rawValue, component.getType(), component.getGenericType(), name);
+            Object value = convertValue(rawValue, component.getType(), component.getGenericType(), name);
+
+            if (value == null && component.getType().isPrimitive()) {
+                value = defaultValue(component.getType());
+            }
+
+            args[i] = value;
         }
 
         return configurationClass.cast(constructor.newInstance(args));
@@ -192,6 +209,14 @@ public final class ConfigParser {
             fields.addAll(Arrays.asList(superclazz.getDeclaredFields()));
         }
         return fields;
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        Object value = PRIMITIVE_DEFAULTS.get(type);
+        if (value != null) {
+            return value;
+        }
+        throw new IllegalArgumentException("Unsupported primitive type: " + type);
     }
 
     /**

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -265,7 +265,7 @@ public final class ConfigParser {
      * @param type desired target class
      * @return the converted value or null if conversion fails or input value is null
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings("unchecked")
     public static <T> @Nullable T valueAs(@Nullable Object value, Class<T> type) {
         if (value == null || type.isAssignableFrom(value.getClass())) {
             // exit early if value is null or type is already compatible
@@ -275,63 +275,63 @@ public final class ConfigParser {
         // make sure primitives are converted to their respective wrapper class
         Class<?> typeClass = WRAPPER_CLASSES_MAP.getOrDefault(type.getSimpleName(), type);
 
-        Object result = value;
-        // Handle the conversion case of Number to Float,Double,Long,Integer,Short,Byte,BigDecimal
-        if (value instanceof Number number) {
-            if (Float.class.equals(typeClass)) {
-                result = number.floatValue();
-            } else if (Double.class.equals(typeClass)) {
-                result = number.doubleValue();
-            } else if (Long.class.equals(typeClass)) {
-                result = number.longValue();
-            } else if (Integer.class.equals(typeClass)) {
-                result = number.intValue();
-            } else if (Short.class.equals(typeClass)) {
-                result = number.shortValue();
-            } else if (Byte.class.equals(typeClass)) {
-                result = number.byteValue();
-            } else if (BigDecimal.class.equals(typeClass)) {
-                result = new BigDecimal(number.toString());
-            }
-        } else if (value instanceof String strValue && !String.class.equals(typeClass)) {
-            // Handle the conversion case of String to Float,Double,Long,Integer,BigDecimal,Boolean
-            if (Float.class.equals(typeClass)) {
-                result = Float.valueOf(strValue);
-            } else if (Double.class.equals(typeClass)) {
-                result = Double.valueOf(strValue);
-            } else if (Long.class.equals(typeClass)) {
-                result = Long.valueOf(strValue);
-            } else if (Integer.class.equals(typeClass)) {
-                result = Integer.valueOf(strValue);
-            } else if (Short.class.equals(typeClass)) {
-                result = Short.valueOf(strValue);
-            } else if (Byte.class.equals(typeClass)) {
-                result = Byte.valueOf(strValue);
-            } else if (BigDecimal.class.equals(typeClass)) {
-                result = new BigDecimal(strValue);
-            } else if (Boolean.class.equals(typeClass)) {
-                result = Boolean.valueOf(strValue);
-            } else if (type.isEnum()) {
-                final Class<? extends Enum> enumType = (Class<? extends Enum>) typeClass;
-                try {
-                    result = Enum.valueOf(enumType, value.toString());
-                } catch (IllegalArgumentException e) {
-                    result = null;
+        try {
+            Object result = value;
+            // Handle the conversion case of Number to Float,Double,Long,Integer,Short,Byte,BigDecimal
+            if (value instanceof Number number) {
+                if (Float.class.equals(typeClass)) {
+                    result = number.floatValue();
+                } else if (Double.class.equals(typeClass)) {
+                    result = number.doubleValue();
+                } else if (Long.class.equals(typeClass)) {
+                    result = number.longValue();
+                } else if (Integer.class.equals(typeClass)) {
+                    result = number.intValue();
+                } else if (Short.class.equals(typeClass)) {
+                    result = number.shortValue();
+                } else if (Byte.class.equals(typeClass)) {
+                    result = number.byteValue();
+                } else if (BigDecimal.class.equals(typeClass)) {
+                    result = new BigDecimal(number.toString());
                 }
-            } else if (Set.class.isAssignableFrom(typeClass)) {
-                result = Set.of(value);
-            } else if (Collection.class.isAssignableFrom(typeClass)) {
-                result = List.of(value);
+            } else if (value instanceof String strValue && !String.class.equals(typeClass)) {
+                // Handle the conversion case of String to Float,Double,Long,Integer,BigDecimal,Boolean
+                if (Float.class.equals(typeClass)) {
+                    result = Float.valueOf(strValue);
+                } else if (Double.class.equals(typeClass)) {
+                    result = Double.valueOf(strValue);
+                } else if (Long.class.equals(typeClass)) {
+                    result = Long.valueOf(strValue);
+                } else if (Integer.class.equals(typeClass)) {
+                    result = Integer.valueOf(strValue);
+                } else if (Short.class.equals(typeClass)) {
+                    result = Short.valueOf(strValue);
+                } else if (Byte.class.equals(typeClass)) {
+                    result = Byte.valueOf(strValue);
+                } else if (BigDecimal.class.equals(typeClass)) {
+                    result = new BigDecimal(strValue);
+                } else if (Boolean.class.equals(typeClass)) {
+                    result = Boolean.valueOf(strValue);
+                } else if (type.isEnum()) {
+                    @SuppressWarnings("rawtypes")
+                    final Class<? extends Enum> enumType = (Class<? extends Enum>) typeClass;
+                    result = Enum.valueOf(enumType, value.toString());
+                } else if (Set.class.isAssignableFrom(typeClass)) {
+                    result = Set.of(value);
+                } else if (Collection.class.isAssignableFrom(typeClass)) {
+                    result = List.of(value);
+                }
             }
+            if (result != null && typeClass.isAssignableFrom(result.getClass())) {
+                return (T) result;
+            }
+            LOGGER.warn("Conversion of value '{}' with type '{}' to '{}' failed. Returning null", value,
+                    value.getClass(), type);
+            return null;
+        } catch (RuntimeException e) {
+            LOGGER.warn("Conversion of value '{}' with type '{}' to '{}' failed: {}. Returning null", value,
+                    value.getClass(), type, e.getMessage());
+            return null;
         }
-
-        if (result != null && typeClass.isAssignableFrom(result.getClass())) {
-            return (T) result;
-        }
-
-        LOGGER.warn("Conversion of value '{}' with type '{}' to '{}' failed. Returning null", value, value.getClass(),
-                type);
-
-        return null;
     }
 }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author David Graeff - Initial contribution
  * @author Jan N. Klug - Extended and refactored to an exposed utility class
+ * @author Jacob Laursen - Added full support for Java records
  *
  */
 @NonNullByDefault
@@ -86,7 +87,8 @@ public final class ConfigParser {
      * @param configurationClass The configuration holder class. An instance of this will be created so make sure that
      *            a default constructor is available.
      * @return The configuration holder object. All fields that matched a configuration option are set. If a required
-     *         field is not set, null is returned.
+     *         field is not set, null is returned. For record classes, missing primitives are automatically set to
+     *         their default value.
      */
     public static <T> @Nullable T configurationAs(Map<String, @Nullable Object> properties,
             Class<T> configurationClass) {

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -18,12 +18,12 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.RecordComponent;
+import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -77,116 +77,108 @@ public final class ConfigParser {
      * @return The configuration holder object. All fields that matched a configuration option are set. If a required
      *         field is not set, null is returned.
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     public static <T> @Nullable T configurationAs(Map<String, @Nullable Object> properties,
             Class<T> configurationClass) {
-        Constructor<T> constructor;
-        T configuration = null;
         try {
-            if (!configurationClass.isRecord()) {
-                constructor = configurationClass.getConstructor();
-                configuration = constructor.newInstance();
+            if (configurationClass.isRecord()) {
+                return constructRecord(properties, configurationClass);
             } else {
-                Constructor<?>[] constructors = configurationClass.getConstructors();
-                constructor = (Constructor<T>) constructors[0];
+                return constructClass(properties, configurationClass);
             }
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException
                 | InvocationTargetException e) {
+            LOGGER.warn("Could not create configuration instance of '{}' with properties {}: {}",
+                    configurationClass.getName(), properties, e.getMessage(), e);
             return null;
         }
+    }
 
-        Map<Field, Object> initArgs = new LinkedHashMap<>();
+    private static <T> @Nullable T constructClass(Map<String, @Nullable Object> properties, Class<T> configurationClass)
+            throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
+        T configuration = configurationClass.getConstructor().newInstance();
+
         for (Field field : getAllFields(configurationClass)) {
-            // Don't try to write to final fields and ignore transient fields when it's a class
-            if (!configurationClass.isRecord()
-                    && (Modifier.isFinal(field.getModifiers()) || Modifier.isTransient(field.getModifiers()))) {
+            // Don't try to write to final fields and ignore transient fields
+            if (Modifier.isFinal(field.getModifiers()) || Modifier.isTransient(field.getModifiers())) {
                 continue;
             }
 
             String fieldName = field.getName();
-            Object value = properties.get(fieldName);
+            Object rawValue = properties.get(fieldName);
             // Consider RequiredField annotations
-            if (value == null) {
+            if (rawValue == null) {
                 LOGGER.trace("Skipping field '{}', because config has no entry for it", fieldName);
                 continue;
             }
 
-            Class<?> type = field.getType();
-            // Allows to have List<int>, List<Double>, List<String> etc (and the corresponding Set<?>)
-            if (value instanceof Collection valueCollection) {
-                Collection collection = List.class.isAssignableFrom(type) ? new ArrayList<>()
-                        : Set.class.isAssignableFrom(type) ? new HashSet<>() : //
-                                null;
+            Object value = convertValue(rawValue, field.getType(), field.getGenericType(), fieldName);
 
-                if (collection != null) {
-                    Class<?> innerClass = (Class<?>) ((ParameterizedType) field.getGenericType())
-                            .getActualTypeArguments()[0];
-                    valueCollection.stream().map(it -> valueAs(it, innerClass)).filter(Object.class::isInstance)
-                            .forEach(collection::add);
-                    initArgs.put(field, collection);
-                } else {
-                    LOGGER.warn("Skipping field '{}', only List and Set is supported as target Collection", fieldName);
-                }
-            } else {
-                value = valueAs(value, type);
-                if (value != null) {
-                    initArgs.put(field, value);
-                } else {
-                    LOGGER.warn(
-                            "Could not set value for field '{}' because conversion failed. Check your configuration value.",
-                            fieldName);
-                }
-            }
-        }
-
-        if (configuration instanceof T localConfiguration) {
-            initArgs.forEach((field, value) -> {
+            if (value != null) {
                 try {
                     LOGGER.trace("Setting value ({}) {} to field '{}' in configuration class {}",
-                            field.getType().getSimpleName(), value, field.getName(), configurationClass.getName());
+                            field.getType().getSimpleName(), value, fieldName, configurationClass.getName());
                     field.setAccessible(true);
-                    field.set(localConfiguration, value);
+                    field.set(configuration, value);
                 } catch (IllegalAccessException e) {
-                    LOGGER.warn("Could not set field value for field '{}': {}", field.getName(), e.getMessage(), e);
+                    LOGGER.warn("Could not set field value for field '{}': {}", fieldName, e.getMessage(), e);
                 }
-            });
-        } else {
-            try {
-                RecordComponent[] components = configurationClass.getRecordComponents();
-                Object[] args = new Object[components.length];
-
-                for (int i = 0; i < components.length; i++) {
-                    RecordComponent component = components[i];
-                    String name = component.getName();
-                    Class<?> type = component.getType();
-
-                    Object value = properties.get(name);
-
-                    if (value instanceof Collection<?> valueCollection) {
-                        Collection<Object> collection = List.class.isAssignableFrom(type) ? new ArrayList<>()
-                                : Set.class.isAssignableFrom(type) ? new HashSet<>() : null;
-
-                        if (collection != null) {
-                            Class<?> innerClass = (Class<?>) ((ParameterizedType) component.getGenericType())
-                                    .getActualTypeArguments()[0];
-
-                            valueCollection.stream().map(it -> valueAs(it, innerClass)).filter(Objects::nonNull)
-                                    .forEach(collection::add);
-
-                            args[i] = collection;
-                            continue;
-                        }
-                    }
-
-                    args[i] = valueAs(value, type);
-                }
-
-                configuration = constructor.newInstance(args);
-            } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-                LOGGER.warn("Could invoke default record constructor '{}'", e.getMessage(), e);
             }
         }
+
         return configuration;
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    private static <T> @Nullable T constructRecord(Map<String, @Nullable Object> properties,
+            Class<T> configurationClass)
+            throws InstantiationException, IllegalAccessException, InvocationTargetException {
+
+        Constructor<?>[] constructors = configurationClass.getConstructors();
+        Constructor<T> constructor = (Constructor<T>) constructors[0];
+
+        RecordComponent[] components = configurationClass.getRecordComponents();
+        Object[] args = new Object[components.length];
+
+        for (int i = 0; i < components.length; i++) {
+            RecordComponent component = components[i];
+
+            String name = component.getName();
+            Object rawValue = properties.get(name);
+
+            args[i] = convertValue(rawValue, component.getType(), component.getGenericType(), name);
+        }
+
+        return constructor.newInstance(args);
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static @Nullable Object convertValue(Object value, Class<?> type, @Nullable Type genericType,
+            String fieldName) {
+        // Allows to have List<int>, List<Double>, List<String> etc (and the corresponding Set<?>)
+        if (value instanceof Collection<?> valueCollection) {
+            Collection collection = List.class.isAssignableFrom(type) ? new ArrayList<>()
+                    : Set.class.isAssignableFrom(type) ? new HashSet<>() : null;
+
+            if (collection != null && genericType instanceof ParameterizedType parameterizedType) {
+                Class<?> innerClass = (Class<?>) parameterizedType.getActualTypeArguments()[0];
+
+                valueCollection.stream().map(it -> valueAs(it, innerClass)).filter(Objects::nonNull)
+                        .forEach(collection::add);
+
+                return collection;
+            } else {
+                LOGGER.warn("Skipping field '{}', only List and Set is supported as target Collection", fieldName);
+                return null;
+            }
+        }
+
+        Object converted = valueAs(value, type);
+        if (converted == null) {
+            LOGGER.warn("Could not set value for field '{}' because conversion failed. Check your configuration value.",
+                    fieldName);
+        }
+
+        return converted;
     }
 
     /**

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -128,13 +128,12 @@ public final class ConfigParser {
         return configuration;
     }
 
-    @SuppressWarnings({ "unchecked" })
     private static <T> @Nullable T constructRecord(Map<String, @Nullable Object> properties,
             Class<T> configurationClass)
             throws InstantiationException, IllegalAccessException, InvocationTargetException {
 
-        Constructor<?>[] constructors = configurationClass.getConstructors();
-        Constructor<T> constructor = (Constructor<T>) constructors[0];
+        Constructor<?> constructor = configurationClass.getDeclaredConstructors()[0];
+        constructor.setAccessible(true);
 
         RecordComponent[] components = configurationClass.getRecordComponents();
         Object[] args = new Object[components.length];
@@ -148,7 +147,7 @@ public final class ConfigParser {
             args[i] = convertValue(rawValue, component.getType(), component.getGenericType(), name);
         }
 
-        return constructor.newInstance(args);
+        return configurationClass.cast(constructor.newInstance(args));
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -211,8 +211,13 @@ public final class ConfigParser {
             if (innerType instanceof Class<?> innerClass) {
                 valueCollection.stream().map(it -> valueAs(it, innerClass)).filter(Objects::nonNull)
                         .forEach(collection::add);
+                return collection;
+            } else {
+                LOGGER.warn(
+                        "Skipping field '{}', collection element type '{}' is not supported (only simple class element types are supported)",
+                        fieldName, innerType.getTypeName());
+                return null;
             }
-            return collection;
         }
 
         Object converted = valueAs(value, type);

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -98,8 +98,8 @@ public final class ConfigParser {
             }
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException
                 | InvocationTargetException e) {
-            LOGGER.warn("Could not create configuration instance of '{}' with properties {}: {}",
-                    configurationClass.getName(), properties, e.getMessage(), e);
+            LOGGER.warn("Could not create configuration instance of '{}' with properties keys {}: {}",
+                    configurationClass.getName(), properties.keySet(), e.getMessage(), e);
             return null;
         }
     }
@@ -154,11 +154,22 @@ public final class ConfigParser {
 
             String name = component.getName();
             Object rawValue = properties.get(name);
+            if (rawValue == null) {
+                LOGGER.trace("Skipping component '{}', because config has no entry for it", name);
+            }
+            Object value = rawValue != null
+                    ? convertValue(rawValue, component.getType(), component.getGenericType(), name)
+                    : null;
 
-            Object value = convertValue(rawValue, component.getType(), component.getGenericType(), name);
-
-            if (value == null && component.getType().isPrimitive()) {
-                value = defaultValue(component.getType());
+            if (value == null) {
+                if (component.getType().isPrimitive()) {
+                    value = defaultValue(component.getType());
+                    LOGGER.trace("Setting default value ({}) {} to component '{}' in configuration class {}",
+                            component.getType().getSimpleName(), value, name, configurationClass.getName());
+                }
+            } else {
+                LOGGER.trace("Setting value ({}) {} to component '{}' in configuration class {}",
+                        component.getType().getSimpleName(), value, name, configurationClass.getName());
             }
 
             args[i] = value;
@@ -174,18 +185,25 @@ public final class ConfigParser {
             Collection<Object> collection = List.class.isAssignableFrom(type) ? new ArrayList<>()
                     : Set.class.isAssignableFrom(type) ? new HashSet<>() : null;
 
-            if (collection != null && genericType instanceof ParameterizedType parameterizedType) {
-                Type innerType = parameterizedType.getActualTypeArguments()[0];
-
-                if (innerType instanceof Class<?> innerClass) {
-                    valueCollection.stream().map(it -> valueAs(it, innerClass)).filter(Objects::nonNull)
-                            .forEach(collection::add);
-                }
-                return collection;
-            } else {
-                LOGGER.warn("Skipping field '{}', only List and Set is supported as target Collection", fieldName);
+            if (collection == null) {
+                LOGGER.warn("Skipping field '{}', only List and Set are supported as target collection types",
+                        fieldName);
                 return null;
             }
+
+            if (!(genericType instanceof ParameterizedType parameterizedType)) {
+                LOGGER.warn("Skipping field '{}', target collection type must declare a generic element type",
+                        fieldName);
+                return null;
+            }
+
+            Type innerType = parameterizedType.getActualTypeArguments()[0];
+
+            if (innerType instanceof Class<?> innerClass) {
+                valueCollection.stream().map(it -> valueAs(it, innerClass)).filter(Objects::nonNull)
+                        .forEach(collection::add);
+            }
+            return collection;
         }
 
         Object converted = valueAs(value, type);

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -141,10 +141,9 @@ public final class ConfigParser {
 
     private static <T> @Nullable T constructRecord(Map<String, @Nullable Object> properties,
             Class<T> configurationClass)
-            throws InstantiationException, IllegalAccessException, InvocationTargetException {
+            throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
 
-        Constructor<?> constructor = configurationClass.getDeclaredConstructors()[0];
-        constructor.setAccessible(true);
+        Constructor<?> constructor = getCanonicalRecordConstructor(configurationClass);
 
         RecordComponent[] components = configurationClass.getRecordComponents();
         Object[] args = new Object[components.length];
@@ -176,6 +175,16 @@ public final class ConfigParser {
         }
 
         return configurationClass.cast(constructor.newInstance(args));
+    }
+
+    private static <T> Constructor<T> getCanonicalRecordConstructor(Class<T> clazz) throws NoSuchMethodException {
+
+        Class<?>[] parameterTypes = Arrays.stream(clazz.getRecordComponents()).map(RecordComponent::getType)
+                .toArray(Class<?>[]::new);
+        Constructor<T> constructor = clazz.getDeclaredConstructor(parameterTypes);
+        constructor.setAccessible(true);
+
+        return constructor;
     }
 
     private static @Nullable Object convertValue(Object value, Class<?> type, @Nullable Type genericType,

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.RecordComponent;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -151,7 +152,36 @@ public final class ConfigParser {
             });
         } else {
             try {
-                configuration = constructor.newInstance(initArgs.values().toArray());
+                RecordComponent[] components = configurationClass.getRecordComponents();
+                Object[] args = new Object[components.length];
+
+                for (int i = 0; i < components.length; i++) {
+                    RecordComponent component = components[i];
+                    String name = component.getName();
+                    Class<?> type = component.getType();
+
+                    Object value = properties.get(name);
+
+                    if (value instanceof Collection<?> valueCollection) {
+                        Collection<Object> collection = List.class.isAssignableFrom(type) ? new ArrayList<>()
+                                : Set.class.isAssignableFrom(type) ? new HashSet<>() : null;
+
+                        if (collection != null) {
+                            Class<?> innerClass = (Class<?>) ((ParameterizedType) component.getGenericType())
+                                    .getActualTypeArguments()[0];
+
+                            valueCollection.stream().map(it -> valueAs(it, innerClass)).filter(Objects::nonNull)
+                                    .forEach(collection::add);
+
+                            args[i] = collection;
+                            continue;
+                        }
+                    }
+
+                    args[i] = valueAs(value, type);
+                }
+
+                configuration = constructor.newInstance(args);
             } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
                 LOGGER.warn("Could invoke default record constructor '{}'", e.getMessage(), e);
             }

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
@@ -131,6 +131,23 @@ public class ConfigParserTest {
         Assertions.assertEquals("three", result.third());
     }
 
+    /**
+     * Note: This test does not guarantee failure without proper constructor resolution,
+     * as JVM constructor ordering is unspecified but often stable in practice.
+     * The implementation must explicitly resolve the canonical constructor.
+     */
+    @Test
+    public void configurationAsRecordUsesCanonicalConstructorTest() {
+        Map<String, @Nullable Object> properties = Map.of("a", "a", "b", "b");
+
+        TestCustomConstructorRecord result = ConfigParser.configurationAs(properties,
+                TestCustomConstructorRecord.class);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("a", result.a());
+        Assertions.assertEquals("b", result.b());
+    }
+
     @Test
     public void configurationAsRecordWithCollectionConversionTest() {
         Map<String, @Nullable Object> properties = Map.of("listField", List.of("1", "2", "3"), "setField",
@@ -174,6 +191,13 @@ public class ConfigParserTest {
     }
 
     private record TestRecord(String first, String second, String third) {
+    }
+
+    private record TestCustomConstructorRecord(String a, String b) {
+        @SuppressWarnings("unused")
+        public TestCustomConstructorRecord(String a) {
+            this(a, "not b");
+        }
     }
 
     private record TestCollectionRecord(List<Integer> listField, Set<Integer> setField) {

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
@@ -179,6 +179,17 @@ public class ConfigParserTest {
     }
 
     @Test
+    public void configurationAsRecordWithInvalidPrimitiveValueFallsBackToDefaultTest() {
+        Map<String, @Nullable Object> properties = Map.of("intField", "not-a-number");
+
+        TestPrimitiveRecord result = ConfigParser.configurationAs(properties, TestPrimitiveRecord.class);
+
+        // Expected: fallback to default
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(0, result.intField());
+    }
+
+    @Test
     public void configurationAsRecordWithNestedListTest() {
         Map<String, @Nullable Object> properties = Map.of("nested", List.of(List.of("a", "b"), List.of("c", "d")));
 

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
@@ -144,10 +144,31 @@ public class ConfigParserTest {
         Assertions.assertEquals(Set.of(4, 5, 6), result.setField());
     }
 
+    @Test
+    public void configurationAsRecordWithPrimitiveDefaultsTest() {
+        Map<String, @Nullable Object> properties = Map.of();
+
+        TestPrimitiveRecord result = ConfigParser.configurationAs(properties, TestPrimitiveRecord.class);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertFalse(result.booleanField());
+        Assertions.assertEquals(0, result.byteField());
+        Assertions.assertEquals(0, result.shortField());
+        Assertions.assertEquals(0, result.intField());
+        Assertions.assertEquals(0L, result.longField());
+        Assertions.assertEquals(0f, result.floatField());
+        Assertions.assertEquals(0d, result.doubleField());
+        Assertions.assertEquals('\u0000', result.charField());
+    }
+
     private record TestRecord(String first, String second, String third) {
     }
 
     private record TestCollectionRecord(List<Integer> listField, Set<Integer> setField) {
+    }
+
+    private record TestPrimitiveRecord(boolean booleanField, byte byteField, short shortField, int intField,
+            long longField, float floatField, double doubleField, char charField) {
     }
 
     private enum TestEnum {

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
@@ -196,9 +196,7 @@ public class ConfigParserTest {
         TestNestedListRecord result = ConfigParser.configurationAs(properties, TestNestedListRecord.class);
 
         Assertions.assertNotNull(result);
-        Assertions.assertNotNull(result.nested());
-        Assertions.assertTrue(result.nested().isEmpty(),
-                "Nested lists should be skipped when inner type is not supported");
+        Assertions.assertNull(result.nested(), "Nested lists should result in null when inner type is not supported");
     }
 
     private record TestRecord(String first, String second, String third) {

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
@@ -144,10 +144,10 @@ public class ConfigParserTest {
         Assertions.assertEquals(Set.of(4, 5, 6), result.setField());
     }
 
-    public record TestRecord(String first, String second, String third) {
+    private record TestRecord(String first, String second, String third) {
     }
 
-    public record TestCollectionRecord(List<Integer> listField, Set<Integer> setField) {
+    private record TestCollectionRecord(List<Integer> listField, Set<Integer> setField) {
     }
 
     private enum TestEnum {

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
@@ -161,6 +161,18 @@ public class ConfigParserTest {
         Assertions.assertEquals('\u0000', result.charField());
     }
 
+    @Test
+    public void configurationAsRecordWithNestedListTest() {
+        Map<String, @Nullable Object> properties = Map.of("nested", List.of(List.of("a", "b"), List.of("c", "d")));
+
+        TestNestedListRecord result = ConfigParser.configurationAs(properties, TestNestedListRecord.class);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertNotNull(result.nested());
+        Assertions.assertTrue(result.nested().isEmpty(),
+                "Nested lists should be skipped when inner type is not supported");
+    }
+
     private record TestRecord(String first, String second, String third) {
     }
 
@@ -169,6 +181,9 @@ public class ConfigParserTest {
 
     private record TestPrimitiveRecord(boolean booleanField, byte byteField, short shortField, int intField,
             long longField, float floatField, double doubleField, char charField) {
+    }
+
+    private record TestNestedListRecord(List<List<String>> nested) {
     }
 
     private enum TestEnum {

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
@@ -14,6 +14,7 @@ package org.openhab.core.config.core;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -104,6 +105,49 @@ public class ConfigParserTest {
     public void valueAsDefaultTest() {
         Object result = ConfigParser.valueAsOrElse(null, String.class, "foo");
         Assertions.assertEquals("foo", result);
+    }
+
+    @Test
+    public void configurationAsRecordWithMissingFieldsTest() {
+        Map<String, @Nullable Object> properties = Map.of("first", "one");
+
+        TestRecord result = ConfigParser.configurationAs(properties, TestRecord.class);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("one", result.first());
+        Assertions.assertNull(result.second());
+        Assertions.assertNull(result.third());
+    }
+
+    @Test
+    public void configurationAsRecordWithAllFieldsOutOfOrderTest() {
+        Map<String, @Nullable Object> properties = Map.of("third", "three", "second", "two", "first", "one");
+
+        TestRecord result = ConfigParser.configurationAs(properties, TestRecord.class);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("one", result.first());
+        Assertions.assertEquals("two", result.second());
+        Assertions.assertEquals("three", result.third());
+    }
+
+    @Test
+    public void configurationAsRecordWithCollectionConversionTest() {
+        Map<String, @Nullable Object> properties = Map.of("listField", List.of("1", "2", "3"), "setField",
+                List.of("4", "5", "6"));
+
+        TestCollectionRecord result = ConfigParser.configurationAs(properties, TestCollectionRecord.class);
+
+        Assertions.assertNotNull(result);
+
+        Assertions.assertEquals(List.of(1, 2, 3), result.listField());
+        Assertions.assertEquals(Set.of(4, 5, 6), result.setField());
+    }
+
+    public record TestRecord(String first, String second, String third) {
+    }
+
+    public record TestCollectionRecord(List<Integer> listField, Set<Integer> setField) {
     }
 
     private enum TestEnum {


### PR DESCRIPTION
This addresses several issues with the `record` support:
- Map configuration properties to record components by name and order
- Missing or invalid values for primitive record components now fall back to Java default values (`0`, `false`, etc.)
- Private records are now supported.
- Nested `List`s and `Set`s are now ignored rather than causing `ClassCastException`.
- Enhanced logging to provide better diagnostics similar to existing `class` support.

General:
- Let `valueAs` consistently return null rather than throwing `RuntimeException`s.

See https://github.com/openhab/openhab-addons/pull/20469#issuecomment-4150012154

Regression of #4508