### PR TITLE
Accept any number of sub-widgets in a sitemap frame/page

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -110,6 +110,7 @@ import org.slf4j.LoggerFactory;
  * @author Laurent Garnier - Consider Colortemperaturepicker element as possible default widget
  * @author Mark Herwege - Implement sitemap registry
  * @author Florian Hotze - Refactor getLabel(Widget w) to use {@link ItemDisplayStateUtil}
+ * @author Laurent Garnier - Change widget id coding to support any number of widgets in frame/page
  */
 @NonNullByDefault
 @Component(immediate = true, configurationPid = "org.openhab.sitemap", //
@@ -681,15 +682,43 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                 w.setItem(id);
             } else {
                 try {
-                    int widgetID = Integer.parseInt(id.substring(0, 2));
-                    if (widgetID < sitemap.getWidgets().size()) {
-                        w = sitemap.getWidgets().get(widgetID);
-                        for (int i = 2; i < id.length(); i += 2) {
-                            int childWidgetID = Integer.parseInt(id.substring(i, i + 2));
-                            if (childWidgetID < ((LinkableWidget) w).getWidgets().size()) {
-                                w = ((LinkableWidget) w).getWidgets().get(childWidgetID);
+                    // Widget id is defined by concatenating the child index at each level from top
+                    // (main page) to bottom (sub-page) using same number of digits at each level.
+                    // Old id coding used 2 digits per level; this coding is still supported.
+                    // New id coding follows this format <n>:<value> where <n> defines how digits are used
+                    // per level in <value>.
+                    // Example: "0002" and "2:0002" are both valid and reference the same widget
+                    // in the sitemap, the third sub-widget in the first sitemap widget.
+                    int codingSize = 2;
+                    String idValue = id;
+                    String splittedId[] = id.split(":", 2);
+                    if (splittedId.length == 2) {
+                        codingSize = Integer.parseInt(splittedId[0]);
+                        idValue = splittedId[1];
+                    }
+                    if (idValue.length() >= codingSize && (idValue.length() % codingSize) == 0) {
+                        int widgetID = Integer.parseInt(idValue.substring(0, codingSize));
+                        if (widgetID < sitemap.getWidgets().size()) {
+                            w = sitemap.getWidgets().get(widgetID);
+                            for (int i = codingSize; i < idValue.length(); i += codingSize) {
+                                int childWidgetID = Integer.parseInt(idValue.substring(i, i + codingSize));
+                                if (childWidgetID < ((LinkableWidget) w).getWidgets().size()) {
+                                    w = ((LinkableWidget) w).getWidgets().get(childWidgetID);
+                                } else {
+                                    logger.warn(
+                                            "Widget id '{}' is invalid, index {} outside the number ({}) of widgets in the page",
+                                            id, childWidgetID, ((LinkableWidget) w).getWidgets().size());
+                                    w = null;
+                                    break;
+                                }
                             }
+                        } else {
+                            logger.warn(
+                                    "Widget id '{}' is invalid, index {} outside the number ({}) of widgets in the sitemap",
+                                    id, widgetID, sitemap.getWidgets().size());
                         }
+                    } else {
+                        throw new NumberFormatException("Unexpected id length");
                     }
                 } catch (NumberFormatException e) {
                     // no valid number, so the requested page id does not exist
@@ -954,22 +983,44 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
             return getWidgetId(w2);
         }
 
+        // Build the id by concatenating the child index at each level from top (main page) to bottom (sub-page),
+        // using same number of digits at each level.
+        // We first try to use 2 digits and if this is not enough, we increment it. That way, we can support
+        // any number of widgets in a page.
+        int codingSize = 2;
         String id = "";
         Widget w = widget;
-        while (w.getParent() instanceof LinkableWidget parent) {
-            String index = String.valueOf(parent.getWidgets().indexOf(w));
-            if (index.length() == 1) {
-                index = "0" + index; // make it two digits
+        boolean built = false;
+        while (!built) {
+            id = "";
+            String codingFormat = "%0" + codingSize + "d";
+            int maxChildren = (int) Math.round(Math.pow(10, codingSize));
+            boolean error = false;
+            while (w.getParent() instanceof LinkableWidget parent) {
+                int num = parent.getWidgets().indexOf(w);
+                if (num >= maxChildren) {
+                    error = true;
+                    break;
+                }
+                String index = String.format(codingFormat, num);
+                id = index + id;
+                w = parent;
             }
-            id = index + id;
-            w = parent;
-        }
-        if (w.getParent() instanceof Sitemap sitemap) {
-            String index = String.valueOf(sitemap.getWidgets().indexOf(w));
-            if (index.length() == 1) {
-                index = "0" + index; // make it two digits
+            if (error) {
+                codingSize++;
+                continue;
             }
-            id = index + id;
+            if (w.getParent() instanceof Sitemap sitemap) {
+                int num = sitemap.getWidgets().indexOf(w);
+                if (num >= maxChildren) {
+                    codingSize++;
+                    continue;
+                }
+                String index = String.format(codingFormat, num);
+                id = index + id;
+            }
+            id = codingSize + ":" + id;
+            built = true;
         }
 
         // if the widget is dynamically created and not available in the sitemap,

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.measure.Unit;
@@ -687,8 +688,8 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                     // Old id coding used 2 digits per level; this coding is still supported.
                     // New id coding follows this format <n>:<value> where <n> defines how digits are used
                     // per level in <value>.
-                    // Example: "0002" and "2:0002" are both valid and reference the same widget
-                    // in the sitemap, the third sub-widget in the first sitemap widget.
+                    // Example: "0002" and "1:02" are both valid and reference the same widget in the
+                    // sitemap, the third sub-widget in the first sitemap widget.
                     int codingSize = 2;
                     String idValue = id;
                     String splittedId[] = id.split(":", 2);
@@ -984,43 +985,24 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         }
 
         // Build the id by concatenating the child index at each level from top (main page) to bottom (sub-page),
-        // using same number of digits at each level.
-        // We first try to use 2 digits and if this is not enough, we increment it. That way, we can support
-        // any number of widgets in a page.
-        int codingSize = 2;
-        String id = "";
+        // using same number of digits at each level. The number of digits is automatically determined.
+        // That way, we can support any number of widgets in a page.
+        List<Integer> indexes = new ArrayList<>();
         Widget w = widget;
-        boolean built = false;
-        while (!built) {
-            id = "";
+        while (w.getParent() instanceof LinkableWidget parent) {
+            indexes.add(parent.getWidgets().indexOf(w));
+            w = parent;
+        }
+        if (w.getParent() instanceof Sitemap sitemap) {
+            indexes.add(sitemap.getWidgets().indexOf(w));
+        }
+        String id = "";
+        if (!indexes.isEmpty()) {
+            int codingSize = "%d".formatted(Collections.max(indexes)).length();
             String codingFormat = "%0" + codingSize + "d";
-            int maxChildren = (int) Math.round(Math.pow(10, codingSize));
-            boolean error = false;
-            while (w.getParent() instanceof LinkableWidget parent) {
-                int num = parent.getWidgets().indexOf(w);
-                if (num >= maxChildren) {
-                    error = true;
-                    break;
-                }
-                String index = String.format(codingFormat, num);
-                id = index + id;
-                w = parent;
-            }
-            if (error) {
-                codingSize++;
-                continue;
-            }
-            if (w.getParent() instanceof Sitemap sitemap) {
-                int num = sitemap.getWidgets().indexOf(w);
-                if (num >= maxChildren) {
-                    codingSize++;
-                    continue;
-                }
-                String index = String.format(codingFormat, num);
-                id = index + id;
-            }
-            id = codingSize + ":" + id;
-            built = true;
+            Collections.reverse(indexes);
+            id = indexes.stream().map(idx -> codingFormat.formatted(idx))
+                    .collect(Collectors.joining("", codingSize + ":", ""));
         }
 
         // if the widget is dynamically created and not available in the sitemap,

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIRegistry.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIRegistry.java
@@ -115,9 +115,12 @@ public interface ItemUIRegistry extends ItemRegistry, ItemUIProvider {
      *
      * This constructs a string out of the position of the sitemap, so if this
      * widget is the third child of a page linked from the fifth widget on the
-     * home screen, its id would be "0503". If the widget is dynamically created
-     * and not available in the sitemap, the name of its associated item is used
-     * instead.
+     * home screen, its id would be "2:0402". The initial "2" before the ":"
+     * defines how many digits are used to code each index. Each index is 0 based.
+     * So the id of the 105th child of a page linked from the fifth widget on the
+     * home screen would be "3:004104".
+     * If the widget is dynamically created and not available in the sitemap,
+     * the name of its associated item is used instead.
      *
      * @param w the widget to get the id for
      * @return an id for this widget

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIRegistry.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIRegistry.java
@@ -115,10 +115,10 @@ public interface ItemUIRegistry extends ItemRegistry, ItemUIProvider {
      *
      * This constructs a string out of the position of the sitemap, so if this
      * widget is the third child of a page linked from the fifth widget on the
-     * home screen, its id would be "2:0402". The initial "2" before the ":"
+     * home screen, its id would be "1:42". The initial "1" before the ":"
      * defines how many digits are used to code each index. Each index is 0 based.
-     * So the id of the 105th child of a page linked from the fifth widget on the
-     * home screen would be "3:004104".
+     * So the id of the 15th child of a page linked from the fifth widget on the
+     * home screen would be "2:0414".
      * If the widget is dynamically created and not available in the sitemap,
      * the name of its associated item is used instead.
      *

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
@@ -62,18 +62,24 @@ import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.sitemap.Button;
+import org.openhab.core.sitemap.Buttongrid;
+import org.openhab.core.sitemap.Chart;
 import org.openhab.core.sitemap.Colorpicker;
 import org.openhab.core.sitemap.Condition;
+import org.openhab.core.sitemap.Frame;
 import org.openhab.core.sitemap.Group;
 import org.openhab.core.sitemap.Image;
 import org.openhab.core.sitemap.Mapping;
 import org.openhab.core.sitemap.Mapview;
 import org.openhab.core.sitemap.Rule;
 import org.openhab.core.sitemap.Selection;
+import org.openhab.core.sitemap.Setpoint;
 import org.openhab.core.sitemap.Sitemap;
 import org.openhab.core.sitemap.Slider;
 import org.openhab.core.sitemap.Switch;
 import org.openhab.core.sitemap.Text;
+import org.openhab.core.sitemap.Webview;
 import org.openhab.core.sitemap.Widget;
 import org.openhab.core.sitemap.registry.SitemapFactory;
 import org.openhab.core.types.CommandDescriptionBuilder;
@@ -128,6 +134,7 @@ public class ItemUIRegistryImplTest {
         TimeZone.setDefault(initialTimeZone);
     }
 
+    private @Mock @NonNullByDefault({}) Frame frameMock;
     private @Mock @NonNullByDefault({}) Group groupMock;
     private @Mock @NonNullByDefault({}) Text textMock;
     private @Mock @NonNullByDefault({}) Colorpicker colorpickerMock;
@@ -136,6 +143,11 @@ public class ItemUIRegistryImplTest {
     private @Mock @NonNullByDefault({}) Slider sliderMock;
     private @Mock @NonNullByDefault({}) Switch switchMock;
     private @Mock @NonNullByDefault({}) Selection selectionMock;
+    private @Mock @NonNullByDefault({}) Setpoint setpointMock;
+    private @Mock @NonNullByDefault({}) Chart chartMock;
+    private @Mock @NonNullByDefault({}) Webview webviewMock;
+    private @Mock @NonNullByDefault({}) Buttongrid buttongridMock;
+    private @Mock @NonNullByDefault({}) Button buttonMock;
     private @Mock @NonNullByDefault({}) Mapping mappingMock;
 
     @BeforeEach
@@ -1444,39 +1456,77 @@ public class ItemUIRegistryImplTest {
 
     @Test
     public void getWidgetId() throws ItemNotFoundException {
-        when(sitemapMock.getWidgets()).thenReturn(List.of(textMock));
-        when(textMock.getWidgets()).thenReturn(List.of(switchMock, sliderMock));
-        when(textMock.getParent()).thenReturn(sitemapMock);
-        when(switchMock.getParent()).thenReturn(textMock);
-        when(sliderMock.getParent()).thenReturn(textMock);
+        when(sitemapMock.getWidgets()).thenReturn(List.of(frameMock));
+        when(frameMock.getWidgets()).thenReturn(List.of(switchMock, sliderMock, groupMock, colorpickerMock, imageMock,
+                mapviewMock, selectionMock, setpointMock, chartMock, webviewMock, textMock, buttongridMock));
+        when(buttongridMock.getWidgets()).thenReturn(List.of(buttonMock));
+        when(frameMock.getParent()).thenReturn(sitemapMock);
+        when(switchMock.getParent()).thenReturn(frameMock);
+        when(sliderMock.getParent()).thenReturn(frameMock);
+        when(groupMock.getParent()).thenReturn(frameMock);
+        when(colorpickerMock.getParent()).thenReturn(frameMock);
+        when(imageMock.getParent()).thenReturn(frameMock);
+        when(mapviewMock.getParent()).thenReturn(frameMock);
+        when(selectionMock.getParent()).thenReturn(frameMock);
+        when(setpointMock.getParent()).thenReturn(frameMock);
+        when(chartMock.getParent()).thenReturn(frameMock);
+        when(webviewMock.getParent()).thenReturn(frameMock);
+        when(textMock.getParent()).thenReturn(frameMock);
+        when(buttongridMock.getParent()).thenReturn(frameMock);
+        when(buttonMock.getParent()).thenReturn(buttongridMock);
 
-        assertEquals("2:00", uiRegistry.getWidgetId(textMock));
-        assertEquals("2:0000", uiRegistry.getWidgetId(switchMock));
-        assertEquals("2:0001", uiRegistry.getWidgetId(sliderMock));
+        assertEquals("1:0", uiRegistry.getWidgetId(frameMock));
+        assertEquals("1:00", uiRegistry.getWidgetId(switchMock));
+        assertEquals("1:01", uiRegistry.getWidgetId(sliderMock));
+        assertEquals("1:02", uiRegistry.getWidgetId(groupMock));
+        assertEquals("1:03", uiRegistry.getWidgetId(colorpickerMock));
+        assertEquals("1:04", uiRegistry.getWidgetId(imageMock));
+        assertEquals("1:05", uiRegistry.getWidgetId(mapviewMock));
+        assertEquals("1:06", uiRegistry.getWidgetId(selectionMock));
+        assertEquals("1:07", uiRegistry.getWidgetId(setpointMock));
+        assertEquals("1:08", uiRegistry.getWidgetId(chartMock));
+        assertEquals("1:09", uiRegistry.getWidgetId(webviewMock));
+        assertEquals("2:0010", uiRegistry.getWidgetId(textMock));
+        assertEquals("2:0011", uiRegistry.getWidgetId(buttongridMock));
+        assertEquals("2:001100", uiRegistry.getWidgetId(buttonMock));
     }
 
     @Test
     public void getWidget() throws ItemNotFoundException {
-        when(sitemapMock.getWidgets()).thenReturn(List.of(textMock));
-        when(textMock.getWidgets()).thenReturn(List.of(switchMock, sliderMock));
+        when(sitemapMock.getWidgets()).thenReturn(List.of(frameMock));
+        when(frameMock.getWidgets()).thenReturn(List.of(switchMock, buttongridMock));
+        when(buttongridMock.getWidgets()).thenReturn(List.of(buttonMock));
 
         when(registryMock.getItem(anyString())).thenThrow(new ItemNotFoundException("not found"));
 
-        assertEquals(textMock, uiRegistry.getWidget(sitemapMock, "2:00"));
+        assertEquals(frameMock, uiRegistry.getWidget(sitemapMock, "1:0"));
+        assertEquals(switchMock, uiRegistry.getWidget(sitemapMock, "1:00"));
+        assertEquals(buttongridMock, uiRegistry.getWidget(sitemapMock, "1:01"));
+        assertEquals(buttonMock, uiRegistry.getWidget(sitemapMock, "1:010"));
+        assertEquals(frameMock, uiRegistry.getWidget(sitemapMock, "2:00"));
         assertEquals(switchMock, uiRegistry.getWidget(sitemapMock, "2:0000"));
-        assertEquals(sliderMock, uiRegistry.getWidget(sitemapMock, "2:0001"));
+        assertEquals(buttongridMock, uiRegistry.getWidget(sitemapMock, "2:0001"));
+        assertEquals(buttonMock, uiRegistry.getWidget(sitemapMock, "2:000100"));
+        assertEquals(frameMock, uiRegistry.getWidget(sitemapMock, "3:000"));
         assertEquals(switchMock, uiRegistry.getWidget(sitemapMock, "3:000000"));
-        assertEquals(sliderMock, uiRegistry.getWidget(sitemapMock, "3:000001"));
-        assertEquals(textMock, uiRegistry.getWidget(sitemapMock, "00"));
+        assertEquals(buttongridMock, uiRegistry.getWidget(sitemapMock, "3:000001"));
+        assertEquals(buttonMock, uiRegistry.getWidget(sitemapMock, "3:000001000"));
+        assertEquals(frameMock, uiRegistry.getWidget(sitemapMock, "00"));
         assertEquals(switchMock, uiRegistry.getWidget(sitemapMock, "0000"));
-        assertEquals(sliderMock, uiRegistry.getWidget(sitemapMock, "0001"));
+        assertEquals(buttongridMock, uiRegistry.getWidget(sitemapMock, "0001"));
+        assertEquals(buttonMock, uiRegistry.getWidget(sitemapMock, "000100"));
+        assertNull(uiRegistry.getWidget(sitemapMock, "1:1"));
+        assertNull(uiRegistry.getWidget(sitemapMock, "1:02"));
+        assertNull(uiRegistry.getWidget(sitemapMock, "1:011"));
         assertNull(uiRegistry.getWidget(sitemapMock, "2:0"));
         assertNull(uiRegistry.getWidget(sitemapMock, "2:000"));
-        assertNull(uiRegistry.getWidget(sitemapMock, "2:0100"));
+        assertNull(uiRegistry.getWidget(sitemapMock, "2:01"));
         assertNull(uiRegistry.getWidget(sitemapMock, "2:0002"));
+        assertNull(uiRegistry.getWidget(sitemapMock, "2:000101"));
         assertNull(uiRegistry.getWidget(sitemapMock, "0"));
         assertNull(uiRegistry.getWidget(sitemapMock, "000"));
-        assertNull(uiRegistry.getWidget(sitemapMock, "0100"));
+        assertNull(uiRegistry.getWidget(sitemapMock, "01"));
         assertNull(uiRegistry.getWidget(sitemapMock, "0002"));
+        assertNull(uiRegistry.getWidget(sitemapMock, "000101"));
     }
 }

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
@@ -1441,4 +1441,42 @@ public class ItemUIRegistryImplTest {
         String icon = uiRegistry.getCategory(widgetMock);
         assertEquals("text", icon);
     }
+
+    @Test
+    public void getWidgetId() throws ItemNotFoundException {
+        when(sitemapMock.getWidgets()).thenReturn(List.of(textMock));
+        when(textMock.getWidgets()).thenReturn(List.of(switchMock, sliderMock));
+        when(textMock.getParent()).thenReturn(sitemapMock);
+        when(switchMock.getParent()).thenReturn(textMock);
+        when(sliderMock.getParent()).thenReturn(textMock);
+
+        assertEquals("2:00", uiRegistry.getWidgetId(textMock));
+        assertEquals("2:0000", uiRegistry.getWidgetId(switchMock));
+        assertEquals("2:0001", uiRegistry.getWidgetId(sliderMock));
+    }
+
+    @Test
+    public void getWidget() throws ItemNotFoundException {
+        when(sitemapMock.getWidgets()).thenReturn(List.of(textMock));
+        when(textMock.getWidgets()).thenReturn(List.of(switchMock, sliderMock));
+
+        when(registryMock.getItem(anyString())).thenThrow(new ItemNotFoundException("not found"));
+
+        assertEquals(textMock, uiRegistry.getWidget(sitemapMock, "2:00"));
+        assertEquals(switchMock, uiRegistry.getWidget(sitemapMock, "2:0000"));
+        assertEquals(sliderMock, uiRegistry.getWidget(sitemapMock, "2:0001"));
+        assertEquals(switchMock, uiRegistry.getWidget(sitemapMock, "3:000000"));
+        assertEquals(sliderMock, uiRegistry.getWidget(sitemapMock, "3:000001"));
+        assertEquals(textMock, uiRegistry.getWidget(sitemapMock, "00"));
+        assertEquals(switchMock, uiRegistry.getWidget(sitemapMock, "0000"));
+        assertEquals(sliderMock, uiRegistry.getWidget(sitemapMock, "0001"));
+        assertNull(uiRegistry.getWidget(sitemapMock, "2:0"));
+        assertNull(uiRegistry.getWidget(sitemapMock, "2:000"));
+        assertNull(uiRegistry.getWidget(sitemapMock, "2:0100"));
+        assertNull(uiRegistry.getWidget(sitemapMock, "2:0002"));
+        assertNull(uiRegistry.getWidget(sitemapMock, "0"));
+        assertNull(uiRegistry.getWidget(sitemapMock, "000"));
+        assertNull(uiRegistry.getWidget(sitemapMock, "0100"));
+        assertNull(uiRegistry.getWidget(sitemapMock, "0002"));
+    }
 }


### PR DESCRIPTION
The previous limit was 100.

Widget id coding is enhanced to support any size.
Old coding is still supported.

Closes #5434
