### PR TITLE
Remove all `super();` calls

### DIFF
--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/ButtonImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/ButtonImpl.java
@@ -30,7 +30,6 @@ public class ButtonImpl extends NonLinkableWidgetImpl implements Button {
     private @Nullable String releaseCmd;
 
     public ButtonImpl() {
-        super();
     }
 
     public ButtonImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/ButtongridImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/ButtongridImpl.java
@@ -29,7 +29,6 @@ public class ButtongridImpl extends LinkableWidgetImpl implements Buttongrid {
     private List<ButtonDefinition> buttons = new CopyOnWriteArrayList<>();
 
     public ButtongridImpl() {
-        super();
     }
 
     public ButtongridImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/ChartImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/ChartImpl.java
@@ -32,7 +32,6 @@ public class ChartImpl extends NonLinkableWidgetImpl implements Chart {
     private @Nullable String interpolation;
 
     public ChartImpl() {
-        super();
     }
 
     public ChartImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/ColorpickerImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/ColorpickerImpl.java
@@ -23,7 +23,6 @@ import org.openhab.core.sitemap.Parent;
 public class ColorpickerImpl extends NonLinkableWidgetImpl implements Colorpicker {
 
     public ColorpickerImpl() {
-        super();
     }
 
     public ColorpickerImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/ColortemperaturepickerImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/ColortemperaturepickerImpl.java
@@ -29,7 +29,6 @@ public class ColortemperaturepickerImpl extends NonLinkableWidgetImpl implements
     private @Nullable BigDecimal maxValue;
 
     public ColortemperaturepickerImpl() {
-        super();
     }
 
     public ColortemperaturepickerImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/DefaultImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/DefaultImpl.java
@@ -26,7 +26,6 @@ public class DefaultImpl extends NonLinkableWidgetImpl implements Default {
     private @Nullable Integer height;
 
     public DefaultImpl() {
-        super();
     }
 
     public DefaultImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/FrameImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/FrameImpl.java
@@ -23,7 +23,6 @@ import org.openhab.core.sitemap.Parent;
 public class FrameImpl extends LinkableWidgetImpl implements Frame {
 
     public FrameImpl() {
-        super();
     }
 
     public FrameImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/GroupImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/GroupImpl.java
@@ -23,7 +23,6 @@ import org.openhab.core.sitemap.Parent;
 public class GroupImpl extends LinkableWidgetImpl implements Group {
 
     public GroupImpl() {
-        super();
     }
 
     public GroupImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/ImageImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/ImageImpl.java
@@ -27,7 +27,6 @@ public class ImageImpl extends LinkableWidgetImpl implements Image {
     private @Nullable Integer refresh;
 
     public ImageImpl() {
-        super();
     }
 
     public ImageImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/InputImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/InputImpl.java
@@ -26,7 +26,6 @@ public class InputImpl extends NonLinkableWidgetImpl implements Input {
     private @Nullable String inputHint;
 
     public InputImpl() {
-        super();
     }
 
     public InputImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/LinkableWidgetImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/LinkableWidgetImpl.java
@@ -29,7 +29,6 @@ public class LinkableWidgetImpl extends WidgetImpl implements LinkableWidget {
     private List<Widget> widgets = new CopyOnWriteArrayList<>();
 
     public LinkableWidgetImpl() {
-        super();
     }
 
     public LinkableWidgetImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/MapviewImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/MapviewImpl.java
@@ -26,7 +26,6 @@ public class MapviewImpl extends NonLinkableWidgetImpl implements Mapview {
     private @Nullable Integer height;
 
     public MapviewImpl() {
-        super();
     }
 
     public MapviewImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/NonLinkableWidgetImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/NonLinkableWidgetImpl.java
@@ -23,7 +23,6 @@ import org.openhab.core.sitemap.Parent;
 public class NonLinkableWidgetImpl extends WidgetImpl implements NonLinkableWidget {
 
     public NonLinkableWidgetImpl() {
-        super();
     }
 
     public NonLinkableWidgetImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/SelectionImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/SelectionImpl.java
@@ -29,7 +29,6 @@ public class SelectionImpl extends NonLinkableWidgetImpl implements Selection {
     private List<Mapping> mappings = new CopyOnWriteArrayList<>();
 
     public SelectionImpl() {
-        super();
     }
 
     public SelectionImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/SetpointImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/SetpointImpl.java
@@ -30,7 +30,6 @@ public class SetpointImpl extends NonLinkableWidgetImpl implements Setpoint {
     private @Nullable BigDecimal step;
 
     public SetpointImpl() {
-        super();
     }
 
     public SetpointImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/SliderImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/SliderImpl.java
@@ -32,7 +32,6 @@ public class SliderImpl extends NonLinkableWidgetImpl implements Slider {
     private @Nullable BigDecimal step;
 
     public SliderImpl() {
-        super();
     }
 
     public SliderImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/SwitchImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/SwitchImpl.java
@@ -29,7 +29,6 @@ public class SwitchImpl extends NonLinkableWidgetImpl implements Switch {
     private List<Mapping> mappings = new CopyOnWriteArrayList<>();
 
     public SwitchImpl() {
-        super();
     }
 
     public SwitchImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/TextImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/TextImpl.java
@@ -23,7 +23,6 @@ import org.openhab.core.sitemap.Text;
 public class TextImpl extends LinkableWidgetImpl implements Text {
 
     public TextImpl() {
-        super();
     }
 
     public TextImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/VideoImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/VideoImpl.java
@@ -27,7 +27,6 @@ public class VideoImpl extends NonLinkableWidgetImpl implements Video {
     private @Nullable String encoding;
 
     public VideoImpl() {
-        super();
     }
 
     public VideoImpl(Parent parent) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/WebviewImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/WebviewImpl.java
@@ -27,7 +27,6 @@ public class WebviewImpl extends NonLinkableWidgetImpl implements Webview {
     private String url = "";
 
     public WebviewImpl() {
-        super();
     }
 
     public WebviewImpl(Parent parent) {

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DTException.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DTException.java
@@ -31,7 +31,6 @@ public class DTException extends Exception {
      * Constructs a new exception with null as its detail message.
      */
     public DTException() {
-        super();
     }
 
     /**


### PR DESCRIPTION
by calling:
>  sed -i "/super();/d" $(git grep -l "super();")

From The Java Tutorials > [Using the Keyword super](https://docs.oracle.com/javase/tutorial/java/IandI/super.html):

>  If a constructor does not explicitly invoke a superclass constructor, the Java compiler automatically inserts a call to the no-argument constructor of the superclass.

Similar to https://github.com/openhab/openhab-core/pull/5009.