### PR TITLE
Allow null property values in BaseThingHandler

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
@@ -557,7 +557,7 @@ public abstract class BaseThingHandler implements ThingHandler {
      *
      * @param properties properties map, that was updated and should be persisted (all properties cleared if null)
      */
-    protected void updateProperties(@Nullable Map<String, String> properties) {
+    protected void updateProperties(@Nullable Map<String, @Nullable String> properties) {
         if (properties == null) {
             updatePropertiesInternal(null);
         } else {


### PR DESCRIPTION
`updateProperties` does not allow null values in the passed in Map, yet everywhere else in the code does allow for null values (which specifically unsets the property), including the individual `updateProperty` methods.  I think this was likely an oversight, and not by design, as i can't see why we would enforce non-null values here.