### PR TITLE
Include cause in thrown ScriptExceptions from DSLScriptEngine

### DIFF
--- a/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
+++ b/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
@@ -143,7 +143,9 @@ public class DSLScriptEngine implements javax.script.ScriptEngine {
         } catch (ScriptExecutionException | ScriptParsingException e) {
             // in case of error, drop the cached script to make sure, it is re-resolved.
             parsedScript = null;
-            throw new ScriptException(e.getMessage(), modelName, -1);
+            ScriptException se = new ScriptException(e.getMessage(), modelName, -1);
+            se.initCause(e);
+            throw se;
         }
     }
 


### PR DESCRIPTION
`javax.script.ScriptException` for some reason doesn't have a constructor that allows specifying both message, script name and cause, so its design is probably quite old, since Java exceptions didn't originally have the ability to hold "cause". As a result, when `eval()` throws an exception (it is mandated to be a `ScriptException` by `javax.script.ScriptEngine`/JSR 223), only the exception message is retained.

The problem is that these are wrapped exceptions, often in multiple levels, and the message string of the "top level" exception often doesn't capture the real cause of the problem.

There is a way to include the "cause" also for old exceptions that don't include it in the constructor, and this is what I've implemented here. The result is that the actual cause of the exception isn't lost, which greatly aids in figuring out what went wrong.