### PR TITLE
DSL Scripts and Rules: allow usage of org.openhab.core.automation.RuleManager

### DIFF
--- a/bundles/org.openhab.core.model.rule/bnd.bnd
+++ b/bundles/org.openhab.core.model.rule/bnd.bnd
@@ -12,6 +12,7 @@ Export-Package: org.openhab.core.model.rule,\
  org.openhab.core.model.rule.services,\
  org.openhab.core.model.rule.validation
 Import-Package: \
+ org.openhab.core.automation,\
  org.openhab.core.automation.module.script.rulesupport.shared,\
  org.openhab.core.common,\
  org.openhab.core.common.registry,\

--- a/bundles/org.openhab.core.model.script/bnd.bnd
+++ b/bundles/org.openhab.core.model.script/bnd.bnd
@@ -19,6 +19,7 @@ Export-Package: org.openhab.core.model.script,\
  org.openhab.core.model.script.validation
 Import-Package: \
  org.openhab.core.audio,\
+ org.openhab.core.automation,\
  org.openhab.core.automation.module.script.action,\
  org.openhab.core.automation.module.script.rulesupport.shared,\
  org.openhab.core.common.registry,\


### PR DESCRIPTION
The changeset allows running from DSL Rules and DSL Sctipts a rule:
```java
val ruleManagerBundleContext = org.osgi.framework.FrameworkUtil.getBundle(
    org.openhab.core.automation.RuleManager).bundleContext
val ruleManagerServiceReference = ruleManagerBundleContext.getServiceReference(
    org.openhab.core.automation.RuleManager)
val ruleManager = ruleManagerBundleContext.getService(ruleManagerServiceReference)

ruleManager.runNow("r2")

```