### PR TITLE
[GHA] Fix mvnw checksum pinning

### DIFF
--- a/.github/workflows/update-maven.yml
+++ b/.github/workflows/update-maven.yml
@@ -41,21 +41,37 @@ jobs:
           VERSION: ${{ steps.maven.outputs.version }}
         run: ./mvnw wrapper:wrapper -Dmaven="${VERSION}"
 
-      - name: Patch SHA512 into wrapper properties
-        # Add the SHA to properties file.
-        # We might need the -L for curl, as after a new release all old SHA files will move to archive folder.
+      - name: Patch SHA256 into wrapper properties
+        # Apache Maven only publishes .sha512 files, so we download the zip and compute SHA-256 locally.
+        # We might need the -L for curl, as after a new release all old files will move to archive folder.
         env:
           VERSION: ${{ steps.maven.outputs.version }}
         run: |
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          SHA=$(curl -sL "https://downloads.apache.org/maven/maven-${MAJOR}/${VERSION}/binaries/apache-maven-${VERSION}-bin.zip.sha512")
-          if [[ ! "$SHA" =~ ^[0-9a-f]{128}$ ]]; then
+          BASE_URL="https://downloads.apache.org/maven/maven-${MAJOR}/${VERSION}/binaries/apache-maven-${VERSION}-bin.zip"
+          ZIP=$(mktemp)
+          curl -sLf "$BASE_URL" -o "$ZIP"
+          EXPECTED_SHA512=$(curl -sLf "${BASE_URL}.sha512")
+          if [[ ! "$EXPECTED_SHA512" =~ ^[0-9a-f]{128}$ ]]; then
             echo "Error: invalid SHA-512 checksum downloaded for Maven ${VERSION}" >&2
             exit 1
           fi
+          ACTUAL_SHA512=$(sha512sum "$ZIP" | awk '{print $1}')
+          if [[ "$ACTUAL_SHA512" != "$EXPECTED_SHA512" ]]; then
+            echo "Error: SHA-512 mismatch for Maven ${VERSION} zip (expected: ${EXPECTED_SHA512}, got: ${ACTUAL_SHA512})" >&2
+            exit 1
+          fi
+          SHA256=$(sha256sum "$ZIP" | awk '{print $1}')
+          rm -f "$ZIP"
+          if [[ ! "$SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "Error: failed to compute a valid SHA-256 checksum for Maven ${VERSION}" >&2
+            exit 1
+          fi
           PROPS=".mvn/wrapper/maven-wrapper.properties"
+          sed -i '/^distributionSha256Sum=/d' "$PROPS"
+          echo "distributionSha256Sum=${SHA256}" >> "$PROPS"
+          # remove entry for SHA-512 if present, as it is not yet supported by wrapper
           sed -i '/^distributionSha512Sum=/d' "$PROPS"
-          echo "distributionSha512Sum=${SHA}" >> "$PROPS"
 
       - name: Open PR if changed
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # 8.1.1


### PR DESCRIPTION
The GHA script took the SHA512 sum published on the download location and updated the properties file for SHA pinning.

Unfortunately, mvnw does not support the keyword `distributionSha512Sum`, but requires `distributionSha256Sum` for the pinning - basically _skipping_ the validation.

So the GHA workflow needs to download the zip, validate SHA512, and finally create SHA256 for the properties file.