### PR TITLE
Adjust syntax for conditions in DSL Rule

### DIFF
--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/Rules.xtext
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/Rules.xtext
@@ -116,19 +116,19 @@ TimeOfDayCondition:
 ;
 
 DayOfWeekCondition:
-	'Day' 'is' weekDays+=WeekDay ('or' weekDays+=WeekDay)*
+	'Day' 'is' weekDays+=WeekDay (',' weekDays+=WeekDay)*
 ;
 
 WeekdayCondition:
-	'Day' ('offset' '='? offset=SIGNED_INT)? 'is' 'a' type=('weekday' | 'weekend')
+	'Day' ('offset' '='? offset=SIGNED_INT)? 'is' type=('weekday' | 'weekend')
 ;
 
 HolidayCondition:
-	'Day' ('offset' '='? offset=SIGNED_INT)? 'is' (negation?='not')? 'a' 'holiday'
+	'Day' ('offset' '='? offset=SIGNED_INT)? 'is' (negation?='not')? holiday='holiday'
 ;
 
 InDaysetCondition:
-	'Day' ('offset' '='? offset=SIGNED_INT)? 'is' 'in' dayset=(STRING|ID)
+	'Day' ('offset' '='? offset=SIGNED_INT)? 'in' dayset=(STRING|ID)
 ;
 
 IntervalCondition:

--- a/itests/org.openhab.core.model.rule.tests/src/main/java/org/openhab/core/model/rule/runtime/DSLRuleProviderTest.java
+++ b/itests/org.openhab.core.model.rule.tests/src/main/java/org/openhab/core/model/rule/runtime/DSLRuleProviderTest.java
@@ -265,12 +265,12 @@ public class DSLRuleProviderTest extends JavaOSGiTest {
                 "   Item X received command ON\n" + //
                 "but only if\n" + //
                 "   Time is between 19:20 and 22:10 and\n" + //
-                "   Day is Thursday or Tuesday or Sunday and\n" + //
-                "   Day is a weekday and\n" + //
-                "   Day is a weekend and\n" + //
-                "   Day offset 3 is a holiday and\n" + //
-                "   Day offset = -2 is not a holiday and\n" + //
-                "   Day is in \"my-dayset\" and\n" + //
+                "   Day is Thursday, Tuesday, Sunday and\n" + //
+                "   Day is weekday and\n" + //
+                "   Day is weekend and\n" + //
+                "   Day offset 3 is holiday and\n" + //
+                "   Day offset = -2 is not holiday and\n" + //
+                "   Day in \"my-dayset\" and\n" + //
                 "   Thing \"T1\" is ONLINE and\n" + //
                 "   Thing \"T2\" is not UNKNOWN and\n" + //
                 "   Item W = \"a value\" and\n" + //


### PR DESCRIPTION
Fix #5488
Fix #5489

Also avoids the 'a' keyword.
