### PR TITLE
Remove uicomponents identifier for sitemaps

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapMapper.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapMapper.java
@@ -57,9 +57,6 @@ public class UIComponentSitemapMapper {
 
     public static RootUIComponent map(Sitemap element) {
         String sitemapName = element.getName();
-        sitemapName = sitemapName.startsWith(UIComponentSitemapProvider.SITEMAP_PREFIX)
-                ? sitemapName.substring(UIComponentSitemapProvider.SITEMAP_PREFIX.length())
-                : sitemapName;
         RootUIComponent sitemapComponent = new RootUIComponent(sitemapName, "Sitemap");
         addConfig(sitemapComponent, "label", element.getLabel());
         addConfig(sitemapComponent, "icon", element.getIcon());

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -92,8 +92,6 @@ public class UIComponentSitemapProvider extends AbstractProvider<Sitemap>
 
     public static final String SITEMAP_NAMESPACE = "system:sitemap";
 
-    static final String SITEMAP_PREFIX = "uicomponents_";
-
     private static final Pattern CONDITION_PATTERN = Pattern
             .compile("((?<item>[A-Za-z]\\w*)?\\s*(?<condition>==|!=|<=|>=|<|>))?\\s*(?<value>(\\+|-)?.+)");
     private static final Pattern COMMANDS_PATTERN = Pattern.compile("^(?<cmd1>\"[^\"]*\"|[^\": ]*):(?<cmd2>.*)$");
@@ -133,7 +131,7 @@ public class UIComponentSitemapProvider extends AbstractProvider<Sitemap>
             throw new IllegalArgumentException("Root component type is not Sitemap");
         }
 
-        Sitemap sitemap = sitemapFactory.createSitemap(SITEMAP_PREFIX + rootComponent.getUID());
+        Sitemap sitemap = sitemapFactory.createSitemap(rootComponent.getUID());
         Object label = rootComponent.getConfig().get("label");
         if (label != null) {
             sitemap.setLabel(label.toString());
@@ -442,7 +440,7 @@ public class UIComponentSitemapProvider extends AbstractProvider<Sitemap>
     @Override
     public void added(RootUIComponent element) {
         if ("Sitemap".equals(element.getType())) {
-            String sitemapName = SITEMAP_PREFIX + element.getUID();
+            String sitemapName = element.getUID();
             if (sitemaps.get(sitemapName) == null) {
                 Sitemap sitemap = buildSitemap(element);
                 sitemaps.put(sitemapName, sitemap);
@@ -454,7 +452,7 @@ public class UIComponentSitemapProvider extends AbstractProvider<Sitemap>
     @Override
     public void removed(RootUIComponent element) {
         if ("Sitemap".equals(element.getType())) {
-            String sitemapName = SITEMAP_PREFIX + element.getUID();
+            String sitemapName = element.getUID();
             Sitemap sitemap = sitemaps.remove(sitemapName);
             if (sitemap != null) {
                 notifyListenersAboutRemovedElement(sitemap);
@@ -465,8 +463,8 @@ public class UIComponentSitemapProvider extends AbstractProvider<Sitemap>
     @Override
     public void updated(RootUIComponent oldElement, RootUIComponent element) {
         if ("Sitemap".equals(oldElement.getType()) && "Sitemap".equals(element.getType())) {
-            String oldSitemapName = SITEMAP_PREFIX + oldElement.getUID();
-            String sitemapName = SITEMAP_PREFIX + element.getUID();
+            String oldSitemapName = oldElement.getUID();
+            String sitemapName = element.getUID();
             Sitemap oldSitemap = sitemaps.get(oldSitemapName);
             Sitemap sitemap = buildSitemap(element);
             if (!oldSitemapName.equals(sitemapName)) {
@@ -494,8 +492,7 @@ public class UIComponentSitemapProvider extends AbstractProvider<Sitemap>
         Sitemap sitemap = sitemaps.get(key);
         UIComponentRegistry sitemapComponentRegistry = this.sitemapComponentRegistry;
         if (sitemapComponentRegistry != null) {
-            String sitemapName = key.startsWith(SITEMAP_PREFIX) ? key.substring(SITEMAP_PREFIX.length()) : key;
-            sitemapComponentRegistry.remove(sitemapName);
+            sitemapComponentRegistry.remove(key);
             return sitemap;
         }
         return null;


### PR DESCRIPTION
UI Managed sitemaps currently have a `uicomponents_` identifier added in front of their name when addressed in the REST API. The UI then strips this again.
This will change the name of the sitemap when used (the `uicomponents_` leading string will be stripped), but that should be an easy one time setup change in the BasicUI or mobile app configuration.

There is no good reason to keep this with the current sitemap registry and it creates extra complexity in the UI. Logic is now available in the registry to avoid naming conflicts (registry handles it and UI will check for names when creating new sitemap from the UI). It makes the code more complex both in core and the UI for no good reason.

This PR removes this identifier and only identifies the managed sitemap by name. It will require small corresponding change in the sitemap editor UI code that can be included in https://github.com/openhab/openhab-webui/pull/4103 if this gets merged before, and is already included in the larger UI sitemap editor refactoring https://github.com/openhab/openhab-webui/pull/4117.