### PR TITLE
DSL Scripts and Rules: import static all Types/State/Command enums

### DIFF
--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
@@ -32,7 +32,6 @@ import org.openhab.core.model.rule.rules.RuleModel
 import org.openhab.core.model.rule.rules.ThingStateChangedEventTrigger
 import org.openhab.core.model.rule.rules.UpdateEventTrigger
 import org.openhab.core.model.script.jvmmodel.ScriptJvmModelInferrer
-import org.openhab.core.model.script.scoping.StateAndCommandProvider
 import org.eclipse.xtext.xbase.jvmmodel.IJvmDeclaredTypeAcceptor
 import org.eclipse.xtext.xbase.jvmmodel.JvmTypesBuilder
 import org.slf4j.Logger
@@ -86,17 +85,6 @@ class RulesJvmModelInferrer extends ScriptJvmModelInferrer {
             ]
 
             val Set<String> fieldNames = newHashSet()
-
-            StateAndCommandProvider::allTypes.forEach [ type |
-                val name = type.toString
-                if (fieldNames.add(name)) {
-                    members += ruleModel.toField(name, typeRef(type.class)) [
-                        static = true
-                    ]
-                } else {
-                    logger.warn("Duplicate field: '{}'. Ignoring '{}'.", name, type.class.name)
-                }
-            ]
 
             itemRegistry?.items?.forEach [ item |
                 val name = item.name

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/interpreter/ScriptInterpreter.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/interpreter/ScriptInterpreter.xtend
@@ -13,7 +13,6 @@
 package org.openhab.core.model.script.interpreter;
 
 import com.google.inject.Inject
-import org.openhab.core.items.Item
 import org.openhab.core.items.ItemNotFoundException
 import org.openhab.core.items.ItemRegistry
 import org.openhab.core.library.types.QuantityType
@@ -21,7 +20,6 @@ import org.openhab.core.types.Type
 import org.openhab.core.model.script.engine.ScriptError
 import org.openhab.core.model.script.engine.ScriptExecutionException
 import org.openhab.core.model.script.lib.NumberExtensions
-import org.openhab.core.model.script.scoping.StateAndCommandProvider
 import org.openhab.core.model.script.script.QuantityLiteral
 import org.eclipse.xtext.common.types.JvmField
 import org.eclipse.xtext.common.types.JvmIdentifiableElement
@@ -63,13 +61,12 @@ class ScriptInterpreter extends XbaseInterpreter {
         // Check if the JvmField is inferred
         val sourceElement = jvmField.sourceElements.head
         if (sourceElement !== null) {
-            val value = context.getValue(QualifiedName.create(jvmField.simpleName))
-            value ?: {
-
-                // Looks like we have a state, command or item field
-                val fieldName = jvmField.simpleName
-                fieldName.stateOrCommand ?: fieldName.item
-            }
+            return context.getValue(QualifiedName.create(jvmField.simpleName))
+                ?: try {
+                       itemRegistry.getItem(jvmField.simpleName)
+                   } catch (ItemNotFoundException e) {
+                       null
+                   }
         } else {
             super._invokeFeature(jvmField, featureCall, receiver, context, indicator)
         }
@@ -94,22 +91,6 @@ class ScriptInterpreter extends XbaseInterpreter {
             }
         }
         super.invokeFeature(feature, featureCall, receiverObj, context, indicator)
-    }
-
-    def protected Type getStateOrCommand(String name) {
-        for (Type type : StateAndCommandProvider::allTypes) {
-            if (type.toString == name) {
-                return type
-            }
-        }
-    }
-
-    def protected Item getItem(String name) {
-        try {
-            return itemRegistry.getItem(name);
-        } catch (ItemNotFoundException e) {
-            return null;
-        }
     }
 
     override protected boolean eq(Object a, Object b) {

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
@@ -16,7 +16,6 @@ import com.google.inject.Inject
 import java.time.ZonedDateTime
 import java.util.Set
 import org.openhab.core.items.ItemRegistry
-import org.openhab.core.model.script.scoping.StateAndCommandProvider
 import org.openhab.core.model.script.script.Script
 import org.eclipse.xtext.xbase.jvmmodel.AbstractModelInferrer
 import org.eclipse.xtext.xbase.jvmmodel.IJvmDeclaredTypeAcceptor
@@ -112,17 +111,6 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
         acceptor.accept(script.toClass(className), [
 
             val Set<String> fieldNames = newHashSet()
-
-            StateAndCommandProvider::allTypes.forEach [ type |
-                val name = type.toString
-                if (fieldNames.add(name)) {
-                    members += script.toField(name, typeRef(type.class)) [
-                        static = true
-                    ]
-                } else {
-                    logger.warn("Duplicate field: '{}'. Ignoring '{}'.", name, type.class.name)
-                }
-            ]
 
             itemRegistry?.items?.forEach [ item |
                 val name = item.name

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImplicitlyImportedTypes.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImplicitlyImportedTypes.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.xtext.xbase.scoping.batch.ImplicitlyImportedFeatures;
+import org.openhab.core.library.types.*;
 import org.openhab.core.library.unit.BinaryPrefix;
 import org.openhab.core.library.unit.ImperialUnits;
 import org.openhab.core.library.unit.MetricPrefix;
@@ -41,6 +42,7 @@ import org.openhab.core.model.script.engine.IThingActionsProvider;
 import org.openhab.core.model.script.engine.action.ActionService;
 import org.openhab.core.model.script.lib.NumberExtensions;
 import org.openhab.core.thing.binding.ThingActions;
+import org.openhab.core.types.*;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -108,6 +110,17 @@ public class ScriptImplicitlyImportedTypes extends ImplicitlyImportedFeatures {
         result.add(Month.class);
         result.add(ZoneId.class);
         result.add(ZonedDateTime.class);
+
+        result.add(IncreaseDecreaseType.class);
+        result.add(NextPreviousType.class);
+        result.add(OnOffType.class);
+        result.add(OpenClosedType.class);
+        result.add(PlayPauseType.class);
+        result.add(RefreshType.class);
+        result.add(RewindFastforwardType.class);
+        result.add(StopMoveType.class);
+        result.add(UnDefType.class);
+        result.add(UpDownType.class);
 
         result.addAll(getActionClasses());
         return result;


### PR DESCRIPTION
This change makes using all Type/Command/State enums as static import simpler … by reducing the code size with 30 lines.  It removes all current usages of class org.openhab.core.model.script.scoping.StateAndCommandProvider.

Before this change a global variable
```
val a5 = ON

rule "System started" … 
```
produced
> 2026-04-22 15:06:26.237 [INFO ] [el.core.internal.ModelRepositoryImpl] - Validation issues found in DSL model 'a.rules', using it anyway:
>    Cannot reference the field 'ON' before it is defined

Now the above works as expected.