### PR TITLE
Managed sitemaps fix conditions parsing

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -93,7 +93,7 @@ public class UIComponentSitemapProvider extends AbstractProvider<Sitemap>
     public static final String SITEMAP_NAMESPACE = "system:sitemap";
 
     private static final Pattern CONDITION_PATTERN = Pattern
-            .compile("((?<item>[A-Za-z]\\w*)?\\s*(?<condition>==|!=|<=|>=|<|>))?\\s*(?<value>(\\+|-)?.+)");
+            .compile("(?<item>[A-Za-z]\\w*)?\\s*(?<condition>==|!=|<=|>=|<|>)?\\s*(?<value>(\\+|-)?.+)");
     private static final Pattern COMMANDS_PATTERN = Pattern.compile("^(?<cmd1>\"[^\"]*\"|[^\": ]*):(?<cmd2>.*)$");
 
     private Map<String, Sitemap> sitemaps = new HashMap<>();
@@ -404,7 +404,10 @@ public class UIComponentSitemapProvider extends AbstractProvider<Sitemap>
         String conditions = rule;
         if (argument != null) {
             conditions = rule.substring(0, rule.lastIndexOf(argument)).trim();
-            if (conditions.endsWith("=")) {
+            if (conditions.endsWith("=\"")) {
+                // If the argument was surrounded by quotes, we need to remove the quote and the preceding =
+                conditions = conditions.substring(0, conditions.length() - 2);
+            } else if (conditions.endsWith("=")) {
                 conditions = conditions.substring(0, conditions.length() - 1);
             }
         }


### PR DESCRIPTION
Follow-up of https://github.com/openhab/openhab-core/pull/5004

The uicomponents sitemap storage stores widget rules as strings with the full rule definitions (visiblity, icon, label color, value color, icon color). I identified 2 bugs:

- If the argument was surrounded by quotes, the leading quote was not removed and spilled through into the rule conditions.
- A rule without an operator but with item and value defined was not parsed correctly.

This PR corrects these bugs.

Ultimately, it would be better to explicitly store these rules with all their fields separated, and not as a string. However, that would require a storage format change and is a breaking change. It would require migrating the storage to the new format.