### PR TITLE
Align thread calculation with Jetty

### DIFF
--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/WebClientFactoryImpl.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/WebClientFactoryImpl.java
@@ -177,27 +177,24 @@ public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory
         return commonWebSocketClient;
     }
 
-    private int calculateDefaultCustomMaxThreads() {
-
+    private int calculateDefaultMaxThreads(int base, int max, int cpuFactor) {
         int cpus = Runtime.getRuntime().availableProcessors();
 
-        // conservative floor
-        int base = 11;
-
         // scale a bit with CPU count
-        int cpuBased = Math.max(base, cpus * 2);
+        int cpuBased = Math.max(base, cpus * cpuFactor);
 
         // keep a sane upper bound for small clients
-        return Math.min(cpuBased, 32);
+        return Math.min(cpuBased, max);
     }
 
     private void getConfigParameters(Map<String, Object> parameters) {
         minThreadsShared = getConfigParameter(parameters, CONFIG_MIN_THREADS_SHARED, 10);
-        maxThreadsShared = getConfigParameter(parameters, CONFIG_MAX_THREADS_SHARED, 40);
+        maxThreadsShared = getConfigParameter(parameters, CONFIG_MAX_THREADS_SHARED,
+                calculateDefaultMaxThreads(40, 80, 3));
         keepAliveTimeoutShared = getConfigParameter(parameters, CONFIG_KEEP_ALIVE_SHARED, 300);
         minThreadsCustom = getConfigParameter(parameters, CONFIG_MIN_THREADS_CUSTOM, 5);
         maxThreadsCustom = getConfigParameter(parameters, CONFIG_MAX_THREADS_CUSTOM,
-                calculateDefaultCustomMaxThreads());
+                calculateDefaultMaxThreads(10, 32, 2));
         keepAliveTimeoutCustom = getConfigParameter(parameters, CONFIG_KEEP_ALIVE_CUSTOM, 300);
     }
 

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/WebClientFactoryImpl.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/WebClientFactoryImpl.java
@@ -177,12 +177,27 @@ public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory
         return commonWebSocketClient;
     }
 
+    private int calculateDefaultCustomMaxThreads() {
+
+        int cpus = Runtime.getRuntime().availableProcessors();
+
+        // conservative floor
+        int base = 11;
+
+        // scale a bit with CPU count
+        int cpuBased = Math.max(base, cpus * 2);
+
+        // keep a sane upper bound for small clients
+        return Math.min(cpuBased, 32);
+    }
+
     private void getConfigParameters(Map<String, Object> parameters) {
         minThreadsShared = getConfigParameter(parameters, CONFIG_MIN_THREADS_SHARED, 10);
         maxThreadsShared = getConfigParameter(parameters, CONFIG_MAX_THREADS_SHARED, 40);
         keepAliveTimeoutShared = getConfigParameter(parameters, CONFIG_KEEP_ALIVE_SHARED, 300);
         minThreadsCustom = getConfigParameter(parameters, CONFIG_MIN_THREADS_CUSTOM, 5);
-        maxThreadsCustom = getConfigParameter(parameters, CONFIG_MAX_THREADS_CUSTOM, 10);
+        maxThreadsCustom = getConfigParameter(parameters, CONFIG_MAX_THREADS_CUSTOM,
+                calculateDefaultCustomMaxThreads());
         keepAliveTimeoutCustom = getConfigParameter(parameters, CONFIG_KEEP_ALIVE_CUSTOM, 300);
     }
 


### PR DESCRIPTION
Fixes: https://github.com/openhab/openhab-core/issues/5490

This address a design flaw that surface now that CPU's are getting mare and more cores. The maxThreadsCustom was hardcoded while Jetty is requiring threads on hearistic determination. Now that CPU's get more and more cores, this problems surfaces. The fix respects manually settings as before, but determines the fallback on the amount of cores and sets it between 10 and 32 threads.

Tested on my host with Amd 9950x 16 core cpu and fixes the issue with multiple bindings.