### PR TITLE
[rest] PersistenceResource: Support transforming states to display states

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -297,7 +297,8 @@ public class PersistenceResource implements RESTResource {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ItemHistoryDTO.class))),
             @ApiResponse(responseCode = "404", description = "Unknown persistence service or Item not found in persistence store"),
             @ApiResponse(responseCode = "405", description = "Persistence service not queryable") })
-    public Response httpGetPersistenceItemData(@Context HttpHeaders headers,
+    public Response httpGetPersistenceItemData(
+            @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @Parameter(description = "Id of the persistence service. If not provided the default service will be used") @QueryParam("serviceId") @Nullable String serviceId,
             @Parameter(description = "The Item name") @PathParam("itemName") String itemName,
             @Parameter(description = "Start time of the data to return. Will default to 1 day before endtime. ["
@@ -310,8 +311,10 @@ public class PersistenceResource implements RESTResource {
             @Parameter(description = "Gets one value before and after the requested period.") @QueryParam("boundary") boolean boundary,
             @Parameter(description = "Adds the current Item state into the requested period (the Item state will be before or at the endtime)") @QueryParam("itemState") boolean itemState,
             @Parameter(description = "If set to true, formatting from the state description is applied to the values. For QuantityType states, only the value is returned, regardless of the pattern.") @QueryParam("displayState") boolean displayState) {
+        Locale locale = localeService.getLocale(language);
+
         return getItemHistoryDTO(serviceId, itemName, startTime, endTime, pageNumber, pageLength, boundary, itemState,
-                displayState);
+                displayState, locale);
     }
 
     @DELETE
@@ -440,7 +443,7 @@ public class PersistenceResource implements RESTResource {
 
     private Response getItemHistoryDTO(@Nullable String serviceId, String itemName, @Nullable String timeBegin,
             @Nullable String timeEnd, int pageNumber, int pageLength, boolean boundary, boolean itemState,
-            boolean displayState) {
+            boolean displayState, @Nullable Locale locale) {
         // Benchmarking timer...
         long timerStart = System.currentTimeMillis();
 
@@ -465,7 +468,7 @@ public class PersistenceResource implements RESTResource {
 
         @Nullable
         ItemHistoryDTO dto = createDTO(qService, itemName, timeBegin, timeEnd, pageNumber, pageLength, boundary,
-                itemState, displayState);
+                itemState, displayState, locale);
         if (dto == null) {
             return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Item not found: " + itemName);
         }
@@ -476,7 +479,7 @@ public class PersistenceResource implements RESTResource {
 
     protected @Nullable ItemHistoryDTO createDTO(QueryablePersistenceService qService, String itemName,
             @Nullable String timeBegin, @Nullable String timeEnd, int pageNumber, int pageLength, boolean boundary,
-            boolean itemState, boolean displayState) {
+            boolean itemState, boolean displayState, @Nullable Locale locale) {
         String serviceId = qService.getId();
         PersistenceServiceConfiguration config = persistenceServiceConfigurationRegistry.get(serviceId);
         String alias = config != null ? config.getAliases().get(itemName) : null;
@@ -554,7 +557,7 @@ public class PersistenceResource implements RESTResource {
             if (result.iterator().hasNext()) {
                 long timestamp = dateTimeBegin.toInstant().toEpochMilli();
                 State state = result.iterator().next().getState();
-                addData(dto, item, state, timestamp, displayState, targetUnit);
+                addData(dto, item, state, timestamp, displayState, targetUnit, locale);
                 quantity++;
             }
         }
@@ -585,12 +588,12 @@ public class PersistenceResource implements RESTResource {
             // to avoid diagonal lines
             if (state instanceof OnOffType || state instanceof OpenClosedType) {
                 if (lastState != null && !lastState.equals(state)) {
-                    addData(dto, item, lastState, timestamp, displayState, targetUnit);
+                    addData(dto, item, lastState, timestamp, displayState, targetUnit, locale);
                     quantity++;
                 }
             }
 
-            addData(dto, item, state, timestamp, displayState, targetUnit);
+            addData(dto, item, state, timestamp, displayState, targetUnit, locale);
             quantity++;
             lastState = state;
         }
@@ -607,7 +610,7 @@ public class PersistenceResource implements RESTResource {
             if (result.iterator().hasNext()) {
                 long timestamp = dateTimeEnd.toInstant().toEpochMilli();
                 State state = result.iterator().next().getState();
-                addData(dto, item, state, timestamp, displayState, targetUnit);
+                addData(dto, item, state, timestamp, displayState, targetUnit, locale);
                 quantity++;
                 addedBoundaryEnd = true;
             }
@@ -627,7 +630,7 @@ public class PersistenceResource implements RESTResource {
                     logger.debug("State of Item '{}' is undefined, not adding it to the response.", itemName);
                 } else {
                     logger.debug("Adding state of Item '{}' to the response: {} - {}", itemName, time, state);
-                    addData(dto, item, state, time, displayState, targetUnit);
+                    addData(dto, item, state, time, displayState, targetUnit, locale);
                     quantity++;
                     dto.sortData();
                 }
@@ -641,19 +644,24 @@ public class PersistenceResource implements RESTResource {
         return dto;
     }
 
-    private @Nullable String getDisplayState(Item item, State state) {
-        return ItemDisplayStateUtil.getDisplayState(item, state, localeService.getLocale(null),
-                timeZoneProvider.getTimeZone());
+    private @Nullable String getDisplayState(Item item, State state, @Nullable Locale locale) {
+        return ItemDisplayStateUtil.getDisplayState(item, state, locale, timeZoneProvider.getTimeZone());
     }
 
     private void addData(ItemHistoryDTO dto, Item item, State state, long timestamp, boolean displayState,
-            @Nullable Unit<?> targetUnit) {
+            @Nullable Unit<?> targetUnit, @Nullable Locale locale) {
         if (displayState) {
             if (state instanceof QuantityType<?> quantityState && targetUnit != null) {
                 QuantityType<?> convertedState = quantityState.toInvertibleUnit(targetUnit);
-                dto.addData(timestamp, convertedState != null ? convertedState : state);
+                if (convertedState != null) {
+                    dto.addData(timestamp, convertedState);
+                } else {
+                    logger.warn(
+                            "Cannot convert state '{}' to unit '{}' for item '{}', excluding this state from the response",
+                            state, targetUnit, item.getName());
+                }
             } else {
-                String displayStateStr = getDisplayState(item, state);
+                String displayStateStr = getDisplayState(item, state, locale);
                 dto.addData(timestamp, displayStateStr != null ? displayStateStr : state.toString());
             }
         } else {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -85,6 +85,7 @@ import org.openhab.core.persistence.strategy.PersistenceStrategy;
 import org.openhab.core.transform.util.ItemDisplayStateUtil;
 import org.openhab.core.types.State;
 import org.openhab.core.types.StateDescription;
+import org.openhab.core.types.StateOption;
 import org.openhab.core.types.TypeParser;
 import org.openhab.core.types.UnDefType;
 import org.openhab.core.types.util.UnitUtils;
@@ -514,14 +515,29 @@ public class PersistenceResource implements RESTResource {
 
         @Nullable
         Unit<?> targetUnit = null;
+        @Nullable
+        String pattern = null;
+        List<StateOption> options = List.of();
         Item item = null;
         try {
             item = itemRegistry.getItem(itemName);
+            if (displayState) {
+                StateDescription stateDescription = item.getStateDescription(locale);
+                if (stateDescription != null) {
+                    pattern = stateDescription.getPattern();
+                    options = stateDescription.getOptions();
+                }
+            }
             if (item instanceof NumberItem numberItem) {
                 if (displayState) {
-                    StateDescription stateDescription = numberItem.getStateDescription(null);
-                    if (stateDescription != null) {
-                        targetUnit = UnitUtils.parseUnit(stateDescription.getPattern());
+                    if (pattern != null) {
+                        targetUnit = UnitUtils.parseUnit(pattern);
+                    }
+                    if (targetUnit == null) {
+                        StateDescription stateDescription = numberItem.getStateDescription(locale);
+                        if (stateDescription != null) {
+                            targetUnit = UnitUtils.parseUnit(stateDescription.getPattern());
+                        }
                     }
                 }
                 if (targetUnit == null) {
@@ -560,7 +576,7 @@ public class PersistenceResource implements RESTResource {
             if (result.iterator().hasNext()) {
                 long timestamp = dateTimeBegin.toInstant().toEpochMilli();
                 State state = result.iterator().next().getState();
-                addData(dto, state, timestamp, displayState, item, targetUnit, locale);
+                addData(dto, state, timestamp, displayState, item, pattern, options, targetUnit);
                 quantity++;
             }
         }
@@ -591,12 +607,12 @@ public class PersistenceResource implements RESTResource {
             // to avoid diagonal lines
             if (state instanceof OnOffType || state instanceof OpenClosedType) {
                 if (lastState != null && !lastState.equals(state)) {
-                    addData(dto, lastState, timestamp, displayState, item, targetUnit, locale);
+                    addData(dto, lastState, timestamp, displayState, item, pattern, options, targetUnit);
                     quantity++;
                 }
             }
 
-            addData(dto, state, timestamp, displayState, item, targetUnit, locale);
+            addData(dto, state, timestamp, displayState, item, pattern, options, targetUnit);
             quantity++;
             lastState = state;
         }
@@ -613,7 +629,7 @@ public class PersistenceResource implements RESTResource {
             if (result.iterator().hasNext()) {
                 long timestamp = dateTimeEnd.toInstant().toEpochMilli();
                 State state = result.iterator().next().getState();
-                addData(dto, state, timestamp, displayState, item, targetUnit, locale);
+                addData(dto, state, timestamp, displayState, item, pattern, options, targetUnit);
                 quantity++;
                 addedBoundaryEnd = true;
             }
@@ -633,7 +649,7 @@ public class PersistenceResource implements RESTResource {
                     logger.debug("State of Item '{}' is undefined, not adding it to the response.", itemName);
                 } else {
                     logger.debug("Adding state of Item '{}' to the response: {} - {}", itemName, time, state);
-                    addData(dto, state, time, displayState, item, targetUnit, locale);
+                    addData(dto, state, time, displayState, item, pattern, options, targetUnit);
                     quantity++;
                     dto.sortData();
                 }
@@ -647,12 +663,13 @@ public class PersistenceResource implements RESTResource {
         return dto;
     }
 
-    private @Nullable String getDisplayState(Item item, State state, @Nullable Locale locale) {
-        return ItemDisplayStateUtil.getDisplayState(item, state, locale, timeZoneProvider.getTimeZone());
+    private @Nullable String getDisplayState(String itemName, @Nullable String pattern, List<StateOption> options,
+            State state) {
+        return ItemDisplayStateUtil.formatState(itemName, pattern, options, state, timeZoneProvider.getTimeZone());
     }
 
     private void addData(ItemHistoryDTO dto, State state, long timestamp, boolean displayState, @Nullable Item item,
-            @Nullable Unit<?> targetUnit, @Nullable Locale locale) {
+            @Nullable String pattern, List<StateOption> options, @Nullable Unit<?> targetUnit) {
         if (state instanceof QuantityType<?> quantityState && targetUnit != null && item != null) {
             QuantityType<?> convertedState = quantityState.toInvertibleUnit(targetUnit);
             if (convertedState != null) {
@@ -663,7 +680,7 @@ public class PersistenceResource implements RESTResource {
                         state, targetUnit, item.getName());
             }
         } else if (displayState && item != null) {
-            String displayStateStr = getDisplayState(item, state, locale);
+            String displayStateStr = getDisplayState(item.getName(), pattern, options, state);
             dto.addData(timestamp, displayStateStr != null ? displayStateStr : state.toString());
         } else {
             dto.addData(timestamp, state);

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -309,7 +309,7 @@ public class PersistenceResource implements RESTResource {
             @Parameter(description = "The length of each page.") @QueryParam("pagelength") int pageLength,
             @Parameter(description = "Gets one value before and after the requested period.") @QueryParam("boundary") boolean boundary,
             @Parameter(description = "Adds the current Item state into the requested period (the Item state will be before or at the endtime)") @QueryParam("itemState") boolean itemState,
-            @Parameter(description = "If set to true, the unit from the state description is applied to convert the values.") @QueryParam("displayState") boolean displayState) {
+            @Parameter(description = "If set to true, formatting from the state description is applied to the values. For QuantityType states, only the value is returned, regardless of the pattern.") @QueryParam("displayState") boolean displayState) {
         return getItemHistoryDTO(serviceId, itemName, startTime, endTime, pageNumber, pageLength, boundary, itemState,
                 displayState);
     }
@@ -526,7 +526,8 @@ public class PersistenceResource implements RESTResource {
                 }
             }
         } catch (ItemNotFoundException e) {
-            throw new IllegalStateException("Unexpectedly failed to retrieve Item '" + itemName + "' from registry", e);
+            logger.debug("Failed to retrieve Item '{}' from registry", itemName);
+            return null;
         }
 
         Iterable<HistoricItem> result;

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -514,7 +514,7 @@ public class PersistenceResource implements RESTResource {
 
         @Nullable
         Unit<?> targetUnit = null;
-        Item item;
+        Item item = null;
         try {
             item = itemRegistry.getItem(itemName);
             if (item instanceof NumberItem numberItem) {
@@ -529,8 +529,11 @@ public class PersistenceResource implements RESTResource {
                 }
             }
         } catch (ItemNotFoundException e) {
-            logger.debug("Failed to retrieve Item '{}' from registry", itemName);
-            return null;
+            if (displayState) {
+                logger.warn("Failed to retrieve Item '{}' from registry, display state conversion is not available",
+                        itemName);
+            }
+            displayState = false;
         }
 
         Iterable<HistoricItem> result;
@@ -557,7 +560,7 @@ public class PersistenceResource implements RESTResource {
             if (result.iterator().hasNext()) {
                 long timestamp = dateTimeBegin.toInstant().toEpochMilli();
                 State state = result.iterator().next().getState();
-                addData(dto, item, state, timestamp, displayState, targetUnit, locale);
+                addData(dto, state, timestamp, displayState, item, targetUnit, locale);
                 quantity++;
             }
         }
@@ -588,12 +591,12 @@ public class PersistenceResource implements RESTResource {
             // to avoid diagonal lines
             if (state instanceof OnOffType || state instanceof OpenClosedType) {
                 if (lastState != null && !lastState.equals(state)) {
-                    addData(dto, item, lastState, timestamp, displayState, targetUnit, locale);
+                    addData(dto, lastState, timestamp, displayState, item, targetUnit, locale);
                     quantity++;
                 }
             }
 
-            addData(dto, item, state, timestamp, displayState, targetUnit, locale);
+            addData(dto, state, timestamp, displayState, item, targetUnit, locale);
             quantity++;
             lastState = state;
         }
@@ -610,7 +613,7 @@ public class PersistenceResource implements RESTResource {
             if (result.iterator().hasNext()) {
                 long timestamp = dateTimeEnd.toInstant().toEpochMilli();
                 State state = result.iterator().next().getState();
-                addData(dto, item, state, timestamp, displayState, targetUnit, locale);
+                addData(dto, state, timestamp, displayState, item, targetUnit, locale);
                 quantity++;
                 addedBoundaryEnd = true;
             }
@@ -630,7 +633,7 @@ public class PersistenceResource implements RESTResource {
                     logger.debug("State of Item '{}' is undefined, not adding it to the response.", itemName);
                 } else {
                     logger.debug("Adding state of Item '{}' to the response: {} - {}", itemName, time, state);
-                    addData(dto, item, state, time, displayState, targetUnit, locale);
+                    addData(dto, state, time, displayState, item, targetUnit, locale);
                     quantity++;
                     dto.sortData();
                 }
@@ -648,22 +651,20 @@ public class PersistenceResource implements RESTResource {
         return ItemDisplayStateUtil.getDisplayState(item, state, locale, timeZoneProvider.getTimeZone());
     }
 
-    private void addData(ItemHistoryDTO dto, Item item, State state, long timestamp, boolean displayState,
+    private void addData(ItemHistoryDTO dto, State state, long timestamp, boolean displayState, @Nullable Item item,
             @Nullable Unit<?> targetUnit, @Nullable Locale locale) {
-        if (displayState) {
-            if (state instanceof QuantityType<?> quantityState && targetUnit != null) {
-                QuantityType<?> convertedState = quantityState.toInvertibleUnit(targetUnit);
-                if (convertedState != null) {
-                    dto.addData(timestamp, convertedState);
-                } else {
-                    logger.warn(
-                            "Cannot convert state '{}' to unit '{}' for item '{}', excluding this state from the response",
-                            state, targetUnit, item.getName());
-                }
+        if (state instanceof QuantityType<?> quantityState && targetUnit != null && item != null) {
+            QuantityType<?> convertedState = quantityState.toInvertibleUnit(targetUnit);
+            if (convertedState != null) {
+                dto.addData(timestamp, convertedState);
             } else {
-                String displayStateStr = getDisplayState(item, state, locale);
-                dto.addData(timestamp, displayStateStr != null ? displayStateStr : state.toString());
+                logger.warn(
+                        "Cannot convert state '{}' to unit '{}' for item '{}', excluding this state from the response",
+                        state, targetUnit, item.getName());
             }
+        } else if (displayState && item != null) {
+            String displayStateStr = getDisplayState(item, state, locale);
+            dto.addData(timestamp, displayStateStr != null ? displayStateStr : state.toString());
         } else {
             dto.addData(timestamp, state);
         }

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -311,7 +311,7 @@ public class PersistenceResource implements RESTResource {
             @Parameter(description = "The length of each page.") @QueryParam("pagelength") int pageLength,
             @Parameter(description = "Gets one value before and after the requested period.") @QueryParam("boundary") boolean boundary,
             @Parameter(description = "Adds the current Item state into the requested period (the Item state will be before or at the endtime)") @QueryParam("itemState") boolean itemState,
-            @Parameter(description = "If set to true, formatting from the state description is applied to the values. For QuantityType states, only the value is returned, regardless of the pattern.") @QueryParam("displayState") boolean displayState) {
+            @Parameter(description = "If set to true, formatting from the state description is applied to the values. For QuantityType states, the value in the display unit as defined by the pattern, is returned.") @QueryParam("displayState") boolean displayState) {
         Locale locale = localeService.getLocale(language);
 
         return getItemHistoryDTO(serviceId, itemName, startTime, endTime, pageNumber, pageLength, boundary, itemState,

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.annotation.security.RolesAllowed;
+import javax.measure.Unit;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -55,9 +56,11 @@ import org.openhab.core.io.rest.core.config.ConfigurationService;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
+import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.persistence.FilterCriteria;
 import org.openhab.core.persistence.FilterCriteria.Ordering;
 import org.openhab.core.persistence.HistoricItem;
@@ -79,9 +82,12 @@ import org.openhab.core.persistence.registry.PersistenceServiceConfiguration;
 import org.openhab.core.persistence.registry.PersistenceServiceConfigurationDTOMapper;
 import org.openhab.core.persistence.registry.PersistenceServiceConfigurationRegistry;
 import org.openhab.core.persistence.strategy.PersistenceStrategy;
+import org.openhab.core.transform.util.ItemDisplayStateUtil;
 import org.openhab.core.types.State;
+import org.openhab.core.types.StateDescription;
 import org.openhab.core.types.TypeParser;
 import org.openhab.core.types.UnDefType;
+import org.openhab.core.types.util.UnitUtils;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -302,8 +308,10 @@ public class PersistenceResource implements RESTResource {
             @Parameter(description = "Page number of data to return. This parameter will enable paging.") @QueryParam("page") int pageNumber,
             @Parameter(description = "The length of each page.") @QueryParam("pagelength") int pageLength,
             @Parameter(description = "Gets one value before and after the requested period.") @QueryParam("boundary") boolean boundary,
-            @Parameter(description = "Adds the current Item state into the requested period (the Item state will be before or at the endtime)") @QueryParam("itemState") boolean itemState) {
-        return getItemHistoryDTO(serviceId, itemName, startTime, endTime, pageNumber, pageLength, boundary, itemState);
+            @Parameter(description = "Adds the current Item state into the requested period (the Item state will be before or at the endtime)") @QueryParam("itemState") boolean itemState,
+            @Parameter(description = "If set to true, the unit from the state description is applied to convert the values.") @QueryParam("displayState") boolean displayState) {
+        return getItemHistoryDTO(serviceId, itemName, startTime, endTime, pageNumber, pageLength, boundary, itemState,
+                displayState);
     }
 
     @DELETE
@@ -431,7 +439,8 @@ public class PersistenceResource implements RESTResource {
     }
 
     private Response getItemHistoryDTO(@Nullable String serviceId, String itemName, @Nullable String timeBegin,
-            @Nullable String timeEnd, int pageNumber, int pageLength, boolean boundary, boolean itemState) {
+            @Nullable String timeEnd, int pageNumber, int pageLength, boolean boundary, boolean itemState,
+            boolean displayState) {
         // Benchmarking timer...
         long timerStart = System.currentTimeMillis();
 
@@ -456,7 +465,7 @@ public class PersistenceResource implements RESTResource {
 
         @Nullable
         ItemHistoryDTO dto = createDTO(qService, itemName, timeBegin, timeEnd, pageNumber, pageLength, boundary,
-                itemState);
+                itemState, displayState);
         if (dto == null) {
             return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Item not found: " + itemName);
         }
@@ -467,7 +476,7 @@ public class PersistenceResource implements RESTResource {
 
     protected @Nullable ItemHistoryDTO createDTO(QueryablePersistenceService qService, String itemName,
             @Nullable String timeBegin, @Nullable String timeEnd, int pageNumber, int pageLength, boolean boundary,
-            boolean itemState) {
+            boolean itemState, boolean displayState) {
         String serviceId = qService.getId();
         PersistenceServiceConfiguration config = persistenceServiceConfigurationRegistry.get(serviceId);
         String alias = config != null ? config.getAliases().get(itemName) : null;
@@ -500,12 +509,35 @@ public class PersistenceResource implements RESTResource {
                     timeZoneProvider.getTimeZone());
         }
 
+        @Nullable
+        Unit<?> targetUnit = null;
+        Item item;
+        try {
+            item = itemRegistry.getItem(itemName);
+            if (item instanceof NumberItem numberItem) {
+                if (displayState) {
+                    StateDescription stateDescription = numberItem.getStateDescription(null);
+                    if (stateDescription != null) {
+                        targetUnit = UnitUtils.parseUnit(stateDescription.getPattern());
+                    }
+                }
+                if (targetUnit == null) {
+                    targetUnit = numberItem.getUnit();
+                }
+            }
+        } catch (ItemNotFoundException e) {
+            throw new IllegalStateException("Unexpectedly failed to retrieve Item '" + itemName + "' from registry", e);
+        }
+
         Iterable<HistoricItem> result;
 
         long quantity = 0L;
 
         ItemHistoryDTO dto = new ItemHistoryDTO();
         dto.name = itemName;
+        if (targetUnit != null) {
+            dto.unit = targetUnit.toString();
+        }
 
         // If "boundary" is true then we want to get one value before and after the requested period
         // This is necessary for values that don't change often otherwise data will start after the start of the graph
@@ -519,7 +551,9 @@ public class PersistenceResource implements RESTResource {
             filterBeforeStart.setOrdering(Ordering.DESCENDING);
             result = qService.query(filterBeforeStart, alias);
             if (result.iterator().hasNext()) {
-                dto.addData(dateTimeBegin.toInstant().toEpochMilli(), result.iterator().next().getState());
+                long timestamp = dateTimeBegin.toInstant().toEpochMilli();
+                State state = result.iterator().next().getState();
+                addData(dto, item, state, timestamp, displayState, targetUnit);
                 quantity++;
             }
         }
@@ -550,12 +584,12 @@ public class PersistenceResource implements RESTResource {
             // to avoid diagonal lines
             if (state instanceof OnOffType || state instanceof OpenClosedType) {
                 if (lastState != null && !lastState.equals(state)) {
-                    dto.addData(timestamp, lastState);
+                    addData(dto, item, lastState, timestamp, displayState, targetUnit);
                     quantity++;
                 }
             }
 
-            dto.addData(timestamp, state);
+            addData(dto, item, state, timestamp, displayState, targetUnit);
             quantity++;
             lastState = state;
         }
@@ -570,7 +604,9 @@ public class PersistenceResource implements RESTResource {
             filterAfterEnd.setOrdering(Ordering.ASCENDING);
             result = qService.query(filterAfterEnd, alias);
             if (result.iterator().hasNext()) {
-                dto.addData(dateTimeEnd.toInstant().toEpochMilli(), result.iterator().next().getState());
+                long timestamp = dateTimeEnd.toInstant().toEpochMilli();
+                State state = result.iterator().next().getState();
+                addData(dto, item, state, timestamp, displayState, targetUnit);
                 quantity++;
                 addedBoundaryEnd = true;
             }
@@ -590,7 +626,7 @@ public class PersistenceResource implements RESTResource {
                     logger.debug("State of Item '{}' is undefined, not adding it to the response.", itemName);
                 } else {
                     logger.debug("Adding state of Item '{}' to the response: {} - {}", itemName, time, state);
-                    dto.addData(time, state);
+                    addData(dto, item, state, time, displayState, targetUnit);
                     quantity++;
                     dto.sortData();
                 }
@@ -602,6 +638,26 @@ public class PersistenceResource implements RESTResource {
 
         dto.datapoints = Long.toString(quantity);
         return dto;
+    }
+
+    private @Nullable String getDisplayState(Item item, State state) {
+        return ItemDisplayStateUtil.getDisplayState(item, state, localeService.getLocale(null),
+                timeZoneProvider.getTimeZone());
+    }
+
+    private void addData(ItemHistoryDTO dto, Item item, State state, long timestamp, boolean displayState,
+            @Nullable Unit<?> targetUnit) {
+        if (displayState) {
+            if (state instanceof QuantityType<?> quantityState && targetUnit != null) {
+                QuantityType<?> convertedState = quantityState.toInvertibleUnit(targetUnit);
+                dto.addData(timestamp, convertedState != null ? convertedState : state);
+            } else {
+                String displayStateStr = getDisplayState(item, state);
+                dto.addData(timestamp, displayStateStr != null ? displayStateStr : state.toString());
+            }
+        } else {
+            dto.addData(timestamp, state);
+        }
     }
 
     /**

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -527,10 +527,8 @@ public class PersistenceResource implements RESTResource {
                 options = stateDescription.getOptions();
             }
             if (item instanceof NumberItem numberItem) {
-                if (displayState) {
-                    if (pattern != null) {
-                        targetUnit = UnitUtils.parseUnit(pattern);
-                    }
+                if (displayState && pattern != null) {
+                    targetUnit = UnitUtils.parseUnit(pattern);
                 }
                 if (targetUnit == null) {
                     targetUnit = numberItem.getUnit();

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -521,23 +521,15 @@ public class PersistenceResource implements RESTResource {
         Item item = null;
         try {
             item = itemRegistry.getItem(itemName);
-            if (displayState) {
-                StateDescription stateDescription = item.getStateDescription(locale);
-                if (stateDescription != null) {
-                    pattern = stateDescription.getPattern();
-                    options = stateDescription.getOptions();
-                }
+            StateDescription stateDescription = item.getStateDescription(locale);
+            if (displayState && stateDescription != null) {
+                pattern = stateDescription.getPattern();
+                options = stateDescription.getOptions();
             }
             if (item instanceof NumberItem numberItem) {
                 if (displayState) {
                     if (pattern != null) {
                         targetUnit = UnitUtils.parseUnit(pattern);
-                    }
-                    if (targetUnit == null) {
-                        StateDescription stateDescription = numberItem.getStateDescription(locale);
-                        if (stateDescription != null) {
-                            targetUnit = UnitUtils.parseUnit(stateDescription.getPattern());
-                        }
                     }
                 }
                 if (targetUnit == null) {

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
@@ -47,9 +47,11 @@ import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.persistence.HistoricItem;
 import org.openhab.core.persistence.ModifiablePersistenceService;
 import org.openhab.core.persistence.PersistenceItemInfo;
@@ -62,6 +64,7 @@ import org.openhab.core.persistence.registry.PersistenceServiceConfiguration;
 import org.openhab.core.persistence.registry.PersistenceServiceConfigurationRegistry;
 import org.openhab.core.types.State;
 import org.openhab.core.types.StateDescription;
+import org.openhab.core.types.StateOption;
 import org.openhab.core.types.UnDefType;
 
 /**
@@ -224,7 +227,42 @@ public class PersistenceResourceTest {
     }
 
     @Test
-    public void testGetPersistenceItemDataWithUnitConversion() throws ItemNotFoundException {
+    public void testGetPersistenceItemDataWithPersistedUnitDifferentThanItemUnit() throws ItemNotFoundException {
+        NumberItem item = mock(NumberItem.class);
+        doReturn(SIUnits.CELSIUS).when(item).getUnit();
+        when(itemRegistryMock.getItem(ITEM_NAME)).thenReturn(item);
+
+        List<HistoricItem> historicItems = new ArrayList<>();
+        historicItems.add(new HistoricItem() {
+            @Override
+            public ZonedDateTime getTimestamp() {
+                return ZonedDateTime.now();
+            }
+
+            @Override
+            public State getState() {
+                return new QuantityType<>("68 °F");
+            }
+
+            @Override
+            public String getName() {
+                return ITEM_NAME;
+            }
+        });
+        assertEquals(1, historicItems.size());
+        when(pServiceMock.query(any(), any())).thenReturn(historicItems);
+
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, ITEM_NAME, null, null, 0, 0, false, false, false, null);
+
+        assertNotNull(dto);
+        assertEquals("°C", dto.unit);
+        assertThat(dto.data, hasSize(1));
+        // 68 °F = 20 °C, we expect only the numeric value in the state field
+        assertEquals(20, Float.parseFloat(dto.data.get(0).state), 1e-16);
+    }
+
+    @Test
+    public void testGetPersistenceItemDataWithDisplayStateUnitConversion() throws ItemNotFoundException {
         NumberItem item = mock(NumberItem.class);
         when(itemRegistryMock.getItem(ITEM_NAME)).thenReturn(item);
         StateDescription stateDescriptionMock = mock(StateDescription.class);
@@ -240,7 +278,7 @@ public class PersistenceResourceTest {
 
             @Override
             public State getState() {
-                return new QuantityType<>("20 °C");
+                return new QuantityType<>("20.5 °C");
             }
 
             @Override
@@ -248,6 +286,7 @@ public class PersistenceResourceTest {
                 return ITEM_NAME;
             }
         });
+        assertEquals(1, historicItems.size());
         when(pServiceMock.query(any(), any())).thenReturn(historicItems);
 
         ItemHistoryDTO dto = pResource.createDTO(pServiceMock, ITEM_NAME, null, null, 0, 0, false, false, true, null);
@@ -255,8 +294,31 @@ public class PersistenceResourceTest {
         assertNotNull(dto);
         assertEquals("°F", dto.unit);
         assertThat(dto.data, hasSize(1));
-        // 20 °C = 68 °F, we expect only the numeric value in the state field
-        assertEquals("68", dto.data.get(0).state);
+        // 20.5 °C = 68.9 °F, we expect only the numeric value in the state field
+        assertEquals("68.900", dto.data.get(0).state);
+    }
+
+    @Test
+    public void testGetPersistenceItemDataWithDisplayStateOptions() throws ItemNotFoundException {
+        SwitchItem item = mock(SwitchItem.class);
+        when(itemRegistryMock.getItem(ITEM_NAME)).thenReturn(item);
+        StateDescription stateDescriptionMock = mock(StateDescription.class);
+        when(item.getStateDescription(null)).thenReturn(stateDescriptionMock);
+        when(stateDescriptionMock.getOptions())
+                .thenReturn(List.of(new StateOption("ON", "an"), new StateOption("OFF", "aus")));
+
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, ITEM_NAME, null, null, 0, 0, false, false, true, null);
+
+        assertNotNull(dto);
+        assertNull(dto.unit);
+        assertThat(Integer.parseInt(dto.datapoints), is(5));
+        assertThat(dto.data, hasSize(5));
+        // dto.data with raw state would be: [ON, ON, OFF, OFF, ON]
+        assertEquals("an", dto.data.get(0).state);
+        assertEquals("an", dto.data.get(1).state);
+        assertEquals("aus", dto.data.get(2).state);
+        assertEquals("aus", dto.data.get(3).state);
+        assertEquals("an", dto.data.get(4).state);
     }
 
     @Test

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
@@ -49,6 +49,7 @@ import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.persistence.HistoricItem;
 import org.openhab.core.persistence.ModifiablePersistenceService;
 import org.openhab.core.persistence.PersistenceItemInfo;
@@ -60,6 +61,7 @@ import org.openhab.core.persistence.registry.ManagedPersistenceServiceConfigurat
 import org.openhab.core.persistence.registry.PersistenceServiceConfiguration;
 import org.openhab.core.persistence.registry.PersistenceServiceConfigurationRegistry;
 import org.openhab.core.types.State;
+import org.openhab.core.types.StateDescription;
 import org.openhab.core.types.UnDefType;
 
 /**
@@ -134,7 +136,7 @@ public class PersistenceResourceTest {
 
     @Test
     public void testGetPersistenceItemData() {
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, false);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, false, false);
 
         assertNotNull(dto);
         assertThat(Integer.parseInt(dto.datapoints), is(5));
@@ -166,7 +168,7 @@ public class PersistenceResourceTest {
 
     @Test
     public void testGetPersistenceItemDataWithBoundery() {
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, true, false);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, true, false, false);
 
         assertNotNull(dto);
         assertThat(Integer.parseInt(dto.datapoints), is(7));
@@ -178,7 +180,7 @@ public class PersistenceResourceTest {
         when(itemRegistryMock.getItem("testItem")).thenReturn(itemMock);
         when(itemMock.getState()).thenReturn(DecimalType.ZERO);
 
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, true);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, true, false);
 
         assertNotNull(dto);
         assertThat(Integer.parseInt(dto.datapoints), is(6));
@@ -191,7 +193,7 @@ public class PersistenceResourceTest {
         when(itemRegistryMock.getItem("testItem")).thenReturn(itemMock);
         when(itemMock.getState()).thenReturn(UnDefType.UNDEF);
 
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, true);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, true, false);
 
         assertNotNull(dto);
         assertThat(Integer.parseInt(dto.datapoints), is(5));
@@ -203,7 +205,7 @@ public class PersistenceResourceTest {
         when(itemRegistryMock.getItem("testItem")).thenReturn(itemMock);
         when(itemMock.getState()).thenReturn(UnDefType.NULL);
 
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, true);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, true, false);
 
         assertNotNull(dto);
         assertThat(Integer.parseInt(dto.datapoints), is(5));
@@ -216,12 +218,48 @@ public class PersistenceResourceTest {
         when(itemRegistryMock.getItem("testItem")).thenReturn(itemMock);
         when(itemMock.getState()).thenReturn(DecimalType.ZERO);
 
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, true, true);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, true, true, false);
 
         assertNotNull(dto);
         assertThat(Integer.parseInt(dto.datapoints), is(7));
         assertThat(dto.data, hasSize(7));
         assertThat(dto.data.get(dto.data.size() - 1).state, not("0"));
+    }
+
+    @Test
+    public void testGetPersistenceItemDataWithUnitConversion() throws ItemNotFoundException {
+        NumberItem numberItemMock = mock(NumberItem.class);
+        StateDescription stateDescriptionMock = mock(StateDescription.class);
+        when(numberItemMock.getStateDescription(null)).thenReturn(stateDescriptionMock);
+        when(stateDescriptionMock.getPattern()).thenReturn("%.1f °F");
+        when(itemRegistryMock.getItem("testItem")).thenReturn(numberItemMock);
+
+        List<HistoricItem> historicItems = new ArrayList<>();
+        historicItems.add(new HistoricItem() {
+            @Override
+            public ZonedDateTime getTimestamp() {
+                return ZonedDateTime.now();
+            }
+
+            @Override
+            public State getState() {
+                return new QuantityType<>("20 °C");
+            }
+
+            @Override
+            public String getName() {
+                return "testItem";
+            }
+        });
+        when(pServiceMock.query(any(), any())).thenReturn(historicItems);
+
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 0, 0, false, false, true);
+
+        assertNotNull(dto);
+        assertEquals("°F", dto.unit);
+        assertThat(dto.data, hasSize(1));
+        // 20 °C = 68 °F, we expect only the numeric value in the state field
+        assertEquals("68", dto.data.get(0).state);
     }
 
     @Test

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
@@ -136,7 +136,8 @@ public class PersistenceResourceTest {
 
     @Test
     public void testGetPersistenceItemData() {
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, false, false);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, false, false,
+                null);
 
         assertNotNull(dto);
         assertThat(Integer.parseInt(dto.datapoints), is(5));
@@ -168,7 +169,7 @@ public class PersistenceResourceTest {
 
     @Test
     public void testGetPersistenceItemDataWithBoundery() {
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, true, false, false);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, true, false, false, null);
 
         assertNotNull(dto);
         assertThat(Integer.parseInt(dto.datapoints), is(7));
@@ -180,7 +181,7 @@ public class PersistenceResourceTest {
         when(itemRegistryMock.getItem("testItem")).thenReturn(itemMock);
         when(itemMock.getState()).thenReturn(DecimalType.ZERO);
 
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, true, false);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, true, false, null);
 
         assertNotNull(dto);
         assertThat(Integer.parseInt(dto.datapoints), is(6));
@@ -193,7 +194,7 @@ public class PersistenceResourceTest {
         when(itemRegistryMock.getItem("testItem")).thenReturn(itemMock);
         when(itemMock.getState()).thenReturn(UnDefType.UNDEF);
 
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, true, false);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, true, false, null);
 
         assertNotNull(dto);
         assertThat(Integer.parseInt(dto.datapoints), is(5));
@@ -205,7 +206,7 @@ public class PersistenceResourceTest {
         when(itemRegistryMock.getItem("testItem")).thenReturn(itemMock);
         when(itemMock.getState()).thenReturn(UnDefType.NULL);
 
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, true, false);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, true, false, null);
 
         assertNotNull(dto);
         assertThat(Integer.parseInt(dto.datapoints), is(5));
@@ -218,7 +219,7 @@ public class PersistenceResourceTest {
         when(itemRegistryMock.getItem("testItem")).thenReturn(itemMock);
         when(itemMock.getState()).thenReturn(DecimalType.ZERO);
 
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, true, true, false);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, true, true, false, null);
 
         assertNotNull(dto);
         assertThat(Integer.parseInt(dto.datapoints), is(7));
@@ -253,7 +254,7 @@ public class PersistenceResourceTest {
         });
         when(pServiceMock.query(any(), any())).thenReturn(historicItems);
 
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 0, 0, false, false, true);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 0, 0, false, false, true, null);
 
         assertNotNull(dto);
         assertEquals("°F", dto.unit);

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
@@ -76,6 +76,7 @@ import org.openhab.core.types.UnDefType;
 public class PersistenceResourceTest {
 
     private static final String PERSISTENCE_SERVICE_ID = "TestServiceID";
+    private static final String ITEM_NAME = "testItem";
 
     private @NonNullByDefault({}) PersistenceResource pResource;
     private @NonNullByDefault({}) List<HistoricItem> items;
@@ -98,7 +99,7 @@ public class PersistenceResourceTest {
     private static final int VALUE_COUNT = END_VALUE - START_VALUE + 1;
 
     @BeforeEach
-    public void beforeEach() {
+    public void beforeEach() throws ItemNotFoundException {
         pResource = new PersistenceResource(itemRegistryMock, localeServiceMock, persistenceServiceRegistryMock,
                 persistenceManagerMock, persistenceServiceConfigurationRegistryMock,
                 managedPersistenceServiceConfigurationProviderMock, timeZoneProviderMock, configurationServiceMock);
@@ -132,12 +133,12 @@ public class PersistenceResourceTest {
         when(pServiceMock.getId()).thenReturn(PERSISTENCE_SERVICE_ID);
         when(pServiceMock.query(any(), any())).thenReturn(items);
         when(timeZoneProviderMock.getTimeZone()).thenReturn(ZoneId.systemDefault());
+        when(itemRegistryMock.getItem(ITEM_NAME)).thenReturn(itemMock);
     }
 
     @Test
     public void testGetPersistenceItemData() {
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, false, false,
-                null);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, ITEM_NAME, null, null, 1, 10, false, false, false, null);
 
         assertNotNull(dto);
         assertThat(Integer.parseInt(dto.datapoints), is(5));
@@ -169,7 +170,7 @@ public class PersistenceResourceTest {
 
     @Test
     public void testGetPersistenceItemDataWithBoundery() {
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, true, false, false, null);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, ITEM_NAME, null, null, 1, 10, true, false, false, null);
 
         assertNotNull(dto);
         assertThat(Integer.parseInt(dto.datapoints), is(7));
@@ -177,11 +178,10 @@ public class PersistenceResourceTest {
     }
 
     @Test
-    public void testGetPersistenceItemDataWithItemState() throws ItemNotFoundException {
-        when(itemRegistryMock.getItem("testItem")).thenReturn(itemMock);
+    public void testGetPersistenceItemDataWithItemState() {
         when(itemMock.getState()).thenReturn(DecimalType.ZERO);
 
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, true, false, null);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, ITEM_NAME, null, null, 1, 10, false, true, false, null);
 
         assertNotNull(dto);
         assertThat(Integer.parseInt(dto.datapoints), is(6));
@@ -190,11 +190,10 @@ public class PersistenceResourceTest {
     }
 
     @Test
-    public void testGetPersistenceItemDataWithItemStateUndefined() throws ItemNotFoundException {
-        when(itemRegistryMock.getItem("testItem")).thenReturn(itemMock);
+    public void testGetPersistenceItemDataWithItemStateUndefined() {
         when(itemMock.getState()).thenReturn(UnDefType.UNDEF);
 
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, true, false, null);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, ITEM_NAME, null, null, 1, 10, false, true, false, null);
 
         assertNotNull(dto);
         assertThat(Integer.parseInt(dto.datapoints), is(5));
@@ -202,11 +201,10 @@ public class PersistenceResourceTest {
     }
 
     @Test
-    public void testGetPersistenceItemDataWithItemStateNull() throws ItemNotFoundException {
-        when(itemRegistryMock.getItem("testItem")).thenReturn(itemMock);
+    public void testGetPersistenceItemDataWithItemStateNull() {
         when(itemMock.getState()).thenReturn(UnDefType.NULL);
 
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, false, true, false, null);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, ITEM_NAME, null, null, 1, 10, false, true, false, null);
 
         assertNotNull(dto);
         assertThat(Integer.parseInt(dto.datapoints), is(5));
@@ -214,12 +212,10 @@ public class PersistenceResourceTest {
     }
 
     @Test
-    public void testGetPersistenceItemDataWithBoundaryAndItemStateButNoItemStateRequired()
-            throws ItemNotFoundException {
-        when(itemRegistryMock.getItem("testItem")).thenReturn(itemMock);
+    public void testGetPersistenceItemDataWithBoundaryAndItemStateButNoItemStateRequired() {
         when(itemMock.getState()).thenReturn(DecimalType.ZERO);
 
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 1, 10, true, true, false, null);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, ITEM_NAME, null, null, 1, 10, true, true, false, null);
 
         assertNotNull(dto);
         assertThat(Integer.parseInt(dto.datapoints), is(7));
@@ -229,11 +225,11 @@ public class PersistenceResourceTest {
 
     @Test
     public void testGetPersistenceItemDataWithUnitConversion() throws ItemNotFoundException {
-        NumberItem numberItemMock = mock(NumberItem.class);
+        NumberItem item = mock(NumberItem.class);
+        when(itemRegistryMock.getItem(ITEM_NAME)).thenReturn(item);
         StateDescription stateDescriptionMock = mock(StateDescription.class);
-        when(numberItemMock.getStateDescription(null)).thenReturn(stateDescriptionMock);
+        when(item.getStateDescription(null)).thenReturn(stateDescriptionMock);
         when(stateDescriptionMock.getPattern()).thenReturn("%.1f °F");
-        when(itemRegistryMock.getItem("testItem")).thenReturn(numberItemMock);
 
         List<HistoricItem> historicItems = new ArrayList<>();
         historicItems.add(new HistoricItem() {
@@ -249,12 +245,12 @@ public class PersistenceResourceTest {
 
             @Override
             public String getName() {
-                return "testItem";
+                return ITEM_NAME;
             }
         });
         when(pServiceMock.query(any(), any())).thenReturn(historicItems);
 
-        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, "testItem", null, null, 0, 0, false, false, true, null);
+        ItemHistoryDTO dto = pResource.createDTO(pServiceMock, ITEM_NAME, null, null, 0, 0, false, false, true, null);
 
         assertNotNull(dto);
         assertEquals("°F", dto.unit);
@@ -266,11 +262,11 @@ public class PersistenceResourceTest {
     @Test
     public void testPutPersistenceItemData() throws ItemNotFoundException {
         HttpHeaders headersMock = mock(HttpHeaders.class);
-        Item item = new NumberItem("itemName");
-        when(itemRegistryMock.getItem("itemName")).thenReturn(item);
+        Item item = new NumberItem(ITEM_NAME);
+        when(itemRegistryMock.getItem(ITEM_NAME)).thenReturn(item);
 
-        pResource.httpPutPersistenceItemData(headersMock, PERSISTENCE_SERVICE_ID, "itemName",
-                "2024-02-01T00:00:00.000Z", "0");
+        pResource.httpPutPersistenceItemData(headersMock, PERSISTENCE_SERVICE_ID, ITEM_NAME, "2024-02-01T00:00:00.000Z",
+                "0");
 
         verify(persistenceManagerMock).handleExternalPersistenceDataChange(eq(pServiceMock), eq(item));
     }

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilder.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilder.java
@@ -13,14 +13,10 @@
 package org.openhab.core.io.rest.sse.internal;
 
 import java.util.HashMap;
-import java.util.IllegalFormatException;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import javax.measure.Unit;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.sse.OutboundSseEvent;
 import javax.ws.rs.sse.OutboundSseEvent.Builder;
@@ -33,18 +29,11 @@ import org.openhab.core.io.rest.sse.internal.dto.StateDTO;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemRegistry;
-import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.service.StartLevelService;
-import org.openhab.core.transform.TransformationException;
-import org.openhab.core.transform.TransformationHelper;
-import org.openhab.core.transform.TransformationService;
+import org.openhab.core.transform.util.ItemDisplayStateUtil;
 import org.openhab.core.types.State;
-import org.openhab.core.types.StateDescription;
-import org.openhab.core.types.StateOption;
-import org.openhab.core.types.UnDefType;
-import org.openhab.core.types.util.UnitUtils;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -61,8 +50,6 @@ import org.slf4j.LoggerFactory;
 @Component(service = SseItemStatesEventBuilder.class)
 @NonNullByDefault
 public class SseItemStatesEventBuilder {
-
-    private static final Pattern EXTRACT_TRANSFORM_FUNCTION_PATTERN = Pattern.compile("(.*?)\\((.*)\\):(.*)");
 
     private final Logger logger = LoggerFactory.getLogger(SseItemStatesEventBuilder.class);
 
@@ -117,102 +104,7 @@ public class SseItemStatesEventBuilder {
     }
 
     protected @Nullable String getDisplayState(Item item, Locale locale) {
-        StateDescription stateDescription = item.getStateDescription(locale);
-        State state = item.getState();
-        String displayState = state.toString();
-
-        if (stateDescription != null) {
-            String pattern = stateDescription.getPattern();
-            // First check if the pattern is a transformation
-            Matcher matcher;
-            if (pattern != null && (matcher = EXTRACT_TRANSFORM_FUNCTION_PATTERN.matcher(pattern)).find()) {
-                try {
-                    String type = matcher.group(1);
-                    String function = matcher.group(2);
-                    String value = matcher.group(3);
-                    TransformationService transformation = TransformationHelper.getTransformationService(type);
-                    if (transformation != null) {
-                        String format = state instanceof UnDefType ? "%s" : value;
-                        try {
-                            displayState = transformation.transform(function, state.format(format));
-                            if (displayState == null) {
-                                displayState = state.toString();
-                            }
-                        } catch (IllegalArgumentException e) {
-                            throw new TransformationException(
-                                    "Cannot format state '" + state + "' to format '" + format + "'", e);
-                        } catch (RuntimeException e) {
-                            throw new TransformationException("Transformation service of type '" + type
-                                    + "' threw an exception: " + e.getMessage(), e);
-                        }
-                    } else {
-                        throw new TransformationException(
-                                "Transformation service of type '" + type + "' is not available.");
-                    }
-                } catch (TransformationException e) {
-                    logger.warn("Failed transforming the state '{}' on item '{}' with pattern '{}': {}", state,
-                            item.getName(), pattern, e.getMessage());
-                }
-            }
-            // If no transformation, NULL/UNDEF state is returned as "NULL"/"UNDEF" without considering anything else
-            else if (!(state instanceof UnDefType)) {
-                boolean optionMatched = false;
-                if (!stateDescription.getOptions().isEmpty()) {
-                    // Look for a state option with a value corresponding to the state
-                    for (StateOption option : stateDescription.getOptions()) {
-                        String label = option.getLabel();
-                        if (option.getValue().equals(state.toString()) && label != null) {
-                            optionMatched = true;
-                            try {
-                                displayState = pattern == null ? label : String.format(pattern, label);
-                            } catch (IllegalFormatException e) {
-                                logger.debug(
-                                        "Unable to format option label '{}' of item {} using format pattern '{}': {}, displaying option label",
-                                        label, item.getName(), pattern, e.getMessage());
-                                displayState = label;
-                            }
-                            break;
-                        }
-                    }
-                }
-                if (pattern != null && !optionMatched) {
-                    // if it's not a transformation pattern and there is no matching state option,
-                    // then it must be a format string
-                    if (state instanceof QuantityType quantityState) {
-                        // sanity convert current state to the item state description unit in case it was
-                        // updated in the meantime. The item state is still in the "original" unit while the
-                        // state description will display the new unit:
-                        Unit<?> patternUnit = UnitUtils.parseUnit(pattern);
-                        if (patternUnit != null && !quantityState.getUnit().equals(patternUnit)) {
-                            quantityState = quantityState.toInvertibleUnit(patternUnit);
-                        }
-
-                        if (quantityState != null) {
-                            state = quantityState;
-                        }
-                    }
-
-                    // The following exception handling has been added to work around a Java bug with formatting
-                    // numbers. See http://bugs.sun.com/view_bug.do?bug_id=6476425
-                    // This also handles IllegalFormatConversionException, which is a subclass of
-                    // IllegalArgument.
-                    try {
-                        if (state instanceof DateTimeType dateTimeState) {
-                            displayState = dateTimeState.format(pattern, timeZoneProvider.getTimeZone());
-                        } else {
-                            displayState = state.format(pattern);
-                        }
-                    } catch (IllegalArgumentException e) {
-                        logger.debug(
-                                "Unable to format value '{}' of item {} using format pattern '{}': {}, displaying raw state",
-                                state, item.getName(), pattern, e.getMessage());
-                        displayState = state.toString();
-                    }
-                }
-            }
-        }
-
-        return displayState;
+        return ItemDisplayStateUtil.getDisplayState(item, locale, timeZoneProvider.getTimeZone());
     }
 
     // Taken from org.openhab.core.items.events.ItemEventFactory

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/ItemHistoryDTO.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/ItemHistoryDTO.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.types.State;
@@ -32,6 +33,9 @@ public class ItemHistoryDTO {
 
     public String name;
     public String datapoints;
+
+    @Schema(description = "The unit for the returned values (if available)")
+    public @Nullable String unit;
 
     public List<HistoryDataBean> data = new ArrayList<>();
 
@@ -57,6 +61,20 @@ public class ItemHistoryDTO {
         } else {
             newVal.state = state.toString();
         }
+        data.add(newVal);
+    }
+
+    /**
+     * Add a new record to the data history.
+     * This method returns a double value equal to the state. This may be used for comparison by the caller.
+     *
+     * @param time the time of the record
+     * @param state the state at this time
+     */
+    public void addData(long time, String state) {
+        HistoryDataBean newVal = new HistoryDataBean();
+        newVal.time = time;
+        newVal.state = state;
         data.add(newVal);
     }
 

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/ItemHistoryDTO.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/ItemHistoryDTO.java
@@ -44,7 +44,6 @@ public class ItemHistoryDTO {
 
     /**
      * Add a new record to the data history.
-     * This method returns a double value equal to the state. This may be used for comparison by the caller.
      *
      * @param time the time of the record
      * @param state the state at this time
@@ -66,7 +65,6 @@ public class ItemHistoryDTO {
 
     /**
      * Add a new record to the data history.
-     * This method returns a double value equal to the state. This may be used for comparison by the caller.
      *
      * @param time the time of the record
      * @param state the state at this time

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/util/ItemDisplayStateUtil.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/util/ItemDisplayStateUtil.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.transform.util;
+
+import java.time.ZoneId;
+import java.util.IllegalFormatException;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.measure.Unit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.items.Item;
+import org.openhab.core.library.types.DateTimeType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.transform.TransformationException;
+import org.openhab.core.transform.TransformationHelper;
+import org.openhab.core.transform.TransformationService;
+import org.openhab.core.types.State;
+import org.openhab.core.types.StateDescription;
+import org.openhab.core.types.StateOption;
+import org.openhab.core.types.UnDefType;
+import org.openhab.core.types.util.UnitUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class for getting the display state of an Item from its {@link StateDescription}.
+ *
+ * @author Florian Hotze - Initial contribution (extracted from SseItemStatesEventBuilder)
+ */
+@NonNullByDefault
+public class ItemDisplayStateUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ItemDisplayStateUtil.class);
+
+    private static final Pattern EXTRACT_TRANSFORM_FUNCTION_PATTERN = Pattern.compile("(.*?)\\((.*)\\):(.*)");
+
+    /**
+     * Get the display state of an item.
+     *
+     * @param item the item
+     * @param locale the locale
+     * @param zoneId the timezone id
+     * @return the display state
+     */
+    public static @Nullable String getDisplayState(Item item, Locale locale, ZoneId zoneId) {
+        return getDisplayState(item, item.getState(), locale, zoneId);
+    }
+
+    /**
+     * Get the display state of an item for a given state.
+     *
+     * @param item the item
+     * @param state the state
+     * @param locale the locale
+     * @param zoneId the timezone id
+     * @return the display state
+     */
+    public static @Nullable String getDisplayState(Item item, State state, Locale locale, ZoneId zoneId) {
+        StateDescription stateDescription = item.getStateDescription(locale);
+        String displayState = state.toString();
+
+        if (stateDescription != null) {
+            String pattern = stateDescription.getPattern();
+            // First check if the pattern is a transformation
+            Matcher matcher;
+            if (pattern != null && (matcher = EXTRACT_TRANSFORM_FUNCTION_PATTERN.matcher(pattern)).find()) {
+                try {
+                    String type = matcher.group(1);
+                    String function = matcher.group(2);
+                    String value = matcher.group(3);
+                    TransformationService transformation = TransformationHelper.getTransformationService(type);
+                    if (transformation != null) {
+                        String format = state instanceof UnDefType ? "%s" : value;
+                        try {
+                            displayState = transformation.transform(function, state.format(format));
+                            if (displayState == null) {
+                                displayState = state.toString();
+                            }
+                        } catch (IllegalArgumentException e) {
+                            throw new TransformationException(
+                                    "Cannot format state '" + state + "' to format '" + format + "'", e);
+                        } catch (RuntimeException e) {
+                            throw new TransformationException("Transformation service of type '" + type
+                                    + "' threw an exception: " + e.getMessage(), e);
+                        }
+                    } else {
+                        throw new TransformationException(
+                                "Transformation service of type '" + type + "' is not available.");
+                    }
+                } catch (TransformationException e) {
+                    LOGGER.warn("Failed transforming the state '{}' on item '{}' with pattern '{}': {}", state,
+                            item.getName(), pattern, e.getMessage());
+                }
+            }
+            // If no transformation, NULL/UNDEF state is returned as "NULL"/"UNDEF" without considering anything else
+            else if (!(state instanceof UnDefType)) {
+                boolean optionMatched = false;
+                if (!stateDescription.getOptions().isEmpty()) {
+                    // Look for a state option with a value corresponding to the state
+                    for (StateOption option : stateDescription.getOptions()) {
+                        String label = option.getLabel();
+                        if (option.getValue().equals(state.toString()) && label != null) {
+                            optionMatched = true;
+                            try {
+                                displayState = pattern == null ? label : String.format(pattern, label);
+                            } catch (IllegalFormatException e) {
+                                LOGGER.debug(
+                                        "Unable to format option label '{}' of item {} using format pattern '{}': {}, displaying option label",
+                                        label, item.getName(), pattern, e.getMessage());
+                                displayState = label;
+                            }
+                            break;
+                        }
+                    }
+                }
+                if (pattern != null && !optionMatched) {
+                    // if it's not a transformation pattern and there is no matching state option,
+                    // then it must be a format string
+                    if (state instanceof QuantityType quantityState) {
+                        // sanity convert current state to the item state description unit in case it was
+                        // updated in the meantime. The item state is still in the "original" unit while the
+                        // state description will display the new unit:
+                        Unit<?> patternUnit = UnitUtils.parseUnit(pattern);
+                        if (patternUnit != null && !quantityState.getUnit().equals(patternUnit)) {
+                            quantityState = quantityState.toInvertibleUnit(patternUnit);
+                        }
+
+                        if (quantityState != null) {
+                            state = quantityState;
+                        }
+                    }
+
+                    // The following exception handling has been added to work around a Java bug with formatting
+                    // numbers. See http://bugs.sun.com/view_bug.do?bug_id=6476425
+                    // This also handles IllegalFormatConversionException, which is a subclass of
+                    // IllegalArgument.
+                    try {
+                        if (state instanceof DateTimeType dateTimeState) {
+                            displayState = dateTimeState.format(pattern, zoneId);
+                        } else {
+                            displayState = state.format(pattern);
+                        }
+                    } catch (IllegalArgumentException e) {
+                        LOGGER.debug(
+                                "Unable to format value '{}' of item {} using format pattern '{}': {}, displaying raw state",
+                                state, item.getName(), pattern, e.getMessage());
+                        displayState = state.toString();
+                    }
+                }
+            }
+        }
+
+        return displayState;
+    }
+}

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/util/ItemDisplayStateUtil.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/util/ItemDisplayStateUtil.java
@@ -14,6 +14,7 @@ package org.openhab.core.transform.util;
 
 import java.time.ZoneId;
 import java.util.IllegalFormatException;
+import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -104,7 +105,7 @@ public class ItemDisplayStateUtil {
      * @param zoneId the timezone id
      * @return the display state
      */
-    public static @Nullable String getDisplayState(Item item, Locale locale, ZoneId zoneId) {
+    public static @Nullable String getDisplayState(Item item, @Nullable Locale locale, ZoneId zoneId) {
         return getDisplayState(item, item.getState(), locale, zoneId);
     }
 
@@ -117,15 +118,26 @@ public class ItemDisplayStateUtil {
      * @param zoneId the timezone id
      * @return the display state
      */
-    public static @Nullable String getDisplayState(Item item, State state, Locale locale, ZoneId zoneId) {
-        String displayState = state.toString();
-
+    public static @Nullable String getDisplayState(Item item, State state, @Nullable Locale locale, ZoneId zoneId) {
         StateDescription stateDescription = item.getStateDescription(locale);
         if (stateDescription == null) {
-            return displayState;
+            return state.toString();
         }
+        return formatState(item.getName(), stateDescription.getPattern(), stateDescription.getOptions(), state, zoneId);
+    }
 
-        String pattern = stateDescription.getPattern();
+    /**
+     * Format a state with the provided pattern.
+     *
+     * @param pattern the pattern to format
+     * @param state the state
+     * @param zoneId the timezone id
+     * @return the display state
+     */
+    public static @Nullable String formatState(String itemName, @Nullable String pattern, List<StateOption> options,
+            State state, ZoneId zoneId) {
+        String displayState = state.toString();
+
         // First check if the pattern is a transformation
         Matcher matcher;
         if (pattern != null && (matcher = EXTRACT_TRANSFORM_FUNCTION_PATTERN.matcher(pattern)).find()) {
@@ -139,16 +151,16 @@ public class ItemDisplayStateUtil {
                     displayState = state.toString();
                 }
             } catch (TransformationException e) {
-                LOGGER.warn("Failed transforming the state '{}' on item '{}' with pattern '{}': {}", state,
-                        item.getName(), pattern, e.getMessage());
+                LOGGER.warn("Failed transforming the state '{}' on item '{}' with pattern '{}': {}", state, itemName,
+                        pattern, e.getMessage());
             }
         }
         // If no transformation, NULL/UNDEF state is returned as "NULL"/"UNDEF" without considering anything else
         else if (!(state instanceof UnDefType)) {
             boolean optionMatched = false;
-            if (!stateDescription.getOptions().isEmpty()) {
+            if (!options.isEmpty()) {
                 // Look for a state option with a value corresponding to the state
-                for (StateOption option : stateDescription.getOptions()) {
+                for (StateOption option : options) {
                     String label = option.getLabel();
                     if (option.getValue().equals(state.toString()) && label != null) {
                         optionMatched = true;
@@ -157,7 +169,7 @@ public class ItemDisplayStateUtil {
                         } catch (IllegalFormatException e) {
                             LOGGER.debug(
                                     "Unable to format option label '{}' of item {} using format pattern '{}': {}, displaying option label",
-                                    label, item.getName(), pattern, e.getMessage());
+                                    label, itemName, pattern, e.getMessage());
                             displayState = label;
                         }
                         break;
@@ -194,7 +206,7 @@ public class ItemDisplayStateUtil {
                 } catch (IllegalArgumentException e) {
                     LOGGER.debug(
                             "Unable to format value '{}' of item {} using format pattern '{}': {}, displaying raw state",
-                            state, item.getName(), pattern, e.getMessage());
+                            state, itemName, pattern, e.getMessage());
                     displayState = state.toString();
                 }
             }

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/util/ItemDisplayStateUtil.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/util/ItemDisplayStateUtil.java
@@ -47,7 +47,10 @@ public class ItemDisplayStateUtil {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ItemDisplayStateUtil.class);
 
-    private static final Pattern EXTRACT_TRANSFORM_FUNCTION_PATTERN = Pattern.compile("(.*?)\\((.*)\\):(.*)");
+    /**
+     * RegEx to extract and parse a transformation function call, e.g., <code>MAP(en.map):%s</code>
+     */
+    public static final Pattern EXTRACT_TRANSFORM_FUNCTION_PATTERN = Pattern.compile("(.*?)\\((.*)\\):(.*)");
 
     /**
      * Transform an arbitrary value with a transformation service
@@ -86,11 +89,15 @@ public class ItemDisplayStateUtil {
      * @throws TransformationException when state formatting failed, the transformation service is unavailable, or the
      *             transformation failed
      */
-    public static @Nullable String transform(String serviceName, String function, String format, State state)
-            throws TransformationException {
+    public static @Nullable String transform(String serviceName, String function, String format, State state,
+            ZoneId zoneId) throws TransformationException {
         String effectiveFormat = state instanceof UnDefType ? "%s" : format;
         try {
-            return transform(serviceName, function, state.format(effectiveFormat));
+            if (state instanceof DateTimeType dtt) {
+                return transform(serviceName, function, dtt.format(format, zoneId));
+            } else {
+                return transform(serviceName, function, state.format(effectiveFormat));
+            }
         } catch (IllegalArgumentException e) {
             throw new TransformationException("Cannot format state '" + state + "' to format '" + effectiveFormat + "'",
                     e);
@@ -146,7 +153,7 @@ public class ItemDisplayStateUtil {
                 String function = matcher.group(2);
                 String format = matcher.group(3);
 
-                displayState = transform(type, function, format, state);
+                displayState = transform(type, function, format, state, zoneId);
                 if (displayState == null) {
                     displayState = state.toString();
                 }

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/util/ItemDisplayStateUtil.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/util/ItemDisplayStateUtil.java
@@ -49,6 +49,37 @@ public class ItemDisplayStateUtil {
     private static final Pattern EXTRACT_TRANSFORM_FUNCTION_PATTERN = Pattern.compile("(.*?)\\((.*)\\):(.*)");
 
     /**
+     * Transform an Item state with a transformation service
+     * 
+     * @param serviceName the name of the transformation service
+     * @param function the name of the transformation function
+     * @param format the format to apply to the state before applying the transformation function
+     * @param state the state to transform
+     * @return the transformed state, can be null if the transformation function returns null
+     * @throws TransformationException when state formatting failed, the transformation service is unavailable, or the
+     *             transformation failed
+     */
+    public static @Nullable String transform(String serviceName, String function, String format, State state)
+            throws TransformationException {
+        TransformationService transformation = TransformationHelper.getTransformationService(serviceName);
+        if (transformation != null) {
+            String effectiveFormat = state instanceof UnDefType ? "%s" : format;
+            try {
+                return transformation.transform(function, state.format(effectiveFormat));
+            } catch (IllegalArgumentException e) {
+                throw new TransformationException(
+                        "Cannot format state '" + state + "' to format '" + effectiveFormat + "'", e);
+            } catch (RuntimeException e) {
+                throw new TransformationException(
+                        "Transformation service of type '" + serviceName + "' threw an exception: " + e.getMessage(),
+                        e);
+            }
+        } else {
+            throw new TransformationException("Transformation service of type '" + serviceName + "' is not available.");
+        }
+    }
+
+    /**
      * Get the display state of an item.
      *
      * @param item the item
@@ -84,26 +115,11 @@ public class ItemDisplayStateUtil {
             try {
                 String type = matcher.group(1);
                 String function = matcher.group(2);
-                String value = matcher.group(3);
-                TransformationService transformation = TransformationHelper.getTransformationService(type);
-                if (transformation != null) {
-                    String format = state instanceof UnDefType ? "%s" : value;
-                    try {
-                        displayState = transformation.transform(function, state.format(format));
-                        if (displayState == null) {
-                            displayState = state.toString();
-                        }
-                    } catch (IllegalArgumentException e) {
-                        throw new TransformationException(
-                                "Cannot format state '" + state + "' to format '" + format + "'", e);
-                    } catch (RuntimeException e) {
-                        throw new TransformationException(
-                                "Transformation service of type '" + type + "' threw an exception: " + e.getMessage(),
-                                e);
-                    }
-                } else {
-                    throw new TransformationException(
-                            "Transformation service of type '" + type + "' is not available.");
+                String format = matcher.group(3);
+
+                displayState = transform(type, function, format, state);
+                if (displayState == null) {
+                    displayState = state.toString();
                 }
             } catch (TransformationException e) {
                 LOGGER.warn("Failed transforming the state '{}' on item '{}' with pattern '{}': {}", state,

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/util/ItemDisplayStateUtil.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/util/ItemDisplayStateUtil.java
@@ -70,96 +70,99 @@ public class ItemDisplayStateUtil {
      * @return the display state
      */
     public static @Nullable String getDisplayState(Item item, State state, Locale locale, ZoneId zoneId) {
-        StateDescription stateDescription = item.getStateDescription(locale);
         String displayState = state.toString();
 
-        if (stateDescription != null) {
-            String pattern = stateDescription.getPattern();
-            // First check if the pattern is a transformation
-            Matcher matcher;
-            if (pattern != null && (matcher = EXTRACT_TRANSFORM_FUNCTION_PATTERN.matcher(pattern)).find()) {
-                try {
-                    String type = matcher.group(1);
-                    String function = matcher.group(2);
-                    String value = matcher.group(3);
-                    TransformationService transformation = TransformationHelper.getTransformationService(type);
-                    if (transformation != null) {
-                        String format = state instanceof UnDefType ? "%s" : value;
-                        try {
-                            displayState = transformation.transform(function, state.format(format));
-                            if (displayState == null) {
-                                displayState = state.toString();
-                            }
-                        } catch (IllegalArgumentException e) {
-                            throw new TransformationException(
-                                    "Cannot format state '" + state + "' to format '" + format + "'", e);
-                        } catch (RuntimeException e) {
-                            throw new TransformationException("Transformation service of type '" + type
-                                    + "' threw an exception: " + e.getMessage(), e);
-                        }
-                    } else {
-                        throw new TransformationException(
-                                "Transformation service of type '" + type + "' is not available.");
-                    }
-                } catch (TransformationException e) {
-                    LOGGER.warn("Failed transforming the state '{}' on item '{}' with pattern '{}': {}", state,
-                            item.getName(), pattern, e.getMessage());
-                }
-            }
-            // If no transformation, NULL/UNDEF state is returned as "NULL"/"UNDEF" without considering anything else
-            else if (!(state instanceof UnDefType)) {
-                boolean optionMatched = false;
-                if (!stateDescription.getOptions().isEmpty()) {
-                    // Look for a state option with a value corresponding to the state
-                    for (StateOption option : stateDescription.getOptions()) {
-                        String label = option.getLabel();
-                        if (option.getValue().equals(state.toString()) && label != null) {
-                            optionMatched = true;
-                            try {
-                                displayState = pattern == null ? label : String.format(pattern, label);
-                            } catch (IllegalFormatException e) {
-                                LOGGER.debug(
-                                        "Unable to format option label '{}' of item {} using format pattern '{}': {}, displaying option label",
-                                        label, item.getName(), pattern, e.getMessage());
-                                displayState = label;
-                            }
-                            break;
-                        }
-                    }
-                }
-                if (pattern != null && !optionMatched) {
-                    // if it's not a transformation pattern and there is no matching state option,
-                    // then it must be a format string
-                    if (state instanceof QuantityType quantityState) {
-                        // sanity convert current state to the item state description unit in case it was
-                        // updated in the meantime. The item state is still in the "original" unit while the
-                        // state description will display the new unit:
-                        Unit<?> patternUnit = UnitUtils.parseUnit(pattern);
-                        if (patternUnit != null && !quantityState.getUnit().equals(patternUnit)) {
-                            quantityState = quantityState.toInvertibleUnit(patternUnit);
-                        }
+        StateDescription stateDescription = item.getStateDescription(locale);
+        if (stateDescription == null) {
+            return displayState;
+        }
 
-                        if (quantityState != null) {
-                            state = quantityState;
-                        }
-                    }
-
-                    // The following exception handling has been added to work around a Java bug with formatting
-                    // numbers. See http://bugs.sun.com/view_bug.do?bug_id=6476425
-                    // This also handles IllegalFormatConversionException, which is a subclass of
-                    // IllegalArgument.
+        String pattern = stateDescription.getPattern();
+        // First check if the pattern is a transformation
+        Matcher matcher;
+        if (pattern != null && (matcher = EXTRACT_TRANSFORM_FUNCTION_PATTERN.matcher(pattern)).find()) {
+            try {
+                String type = matcher.group(1);
+                String function = matcher.group(2);
+                String value = matcher.group(3);
+                TransformationService transformation = TransformationHelper.getTransformationService(type);
+                if (transformation != null) {
+                    String format = state instanceof UnDefType ? "%s" : value;
                     try {
-                        if (state instanceof DateTimeType dateTimeState) {
-                            displayState = dateTimeState.format(pattern, zoneId);
-                        } else {
-                            displayState = state.format(pattern);
+                        displayState = transformation.transform(function, state.format(format));
+                        if (displayState == null) {
+                            displayState = state.toString();
                         }
                     } catch (IllegalArgumentException e) {
-                        LOGGER.debug(
-                                "Unable to format value '{}' of item {} using format pattern '{}': {}, displaying raw state",
-                                state, item.getName(), pattern, e.getMessage());
-                        displayState = state.toString();
+                        throw new TransformationException(
+                                "Cannot format state '" + state + "' to format '" + format + "'", e);
+                    } catch (RuntimeException e) {
+                        throw new TransformationException(
+                                "Transformation service of type '" + type + "' threw an exception: " + e.getMessage(),
+                                e);
                     }
+                } else {
+                    throw new TransformationException(
+                            "Transformation service of type '" + type + "' is not available.");
+                }
+            } catch (TransformationException e) {
+                LOGGER.warn("Failed transforming the state '{}' on item '{}' with pattern '{}': {}", state,
+                        item.getName(), pattern, e.getMessage());
+            }
+        }
+        // If no transformation, NULL/UNDEF state is returned as "NULL"/"UNDEF" without considering anything else
+        else if (!(state instanceof UnDefType)) {
+            boolean optionMatched = false;
+            if (!stateDescription.getOptions().isEmpty()) {
+                // Look for a state option with a value corresponding to the state
+                for (StateOption option : stateDescription.getOptions()) {
+                    String label = option.getLabel();
+                    if (option.getValue().equals(state.toString()) && label != null) {
+                        optionMatched = true;
+                        try {
+                            displayState = pattern == null ? label : String.format(pattern, label);
+                        } catch (IllegalFormatException e) {
+                            LOGGER.debug(
+                                    "Unable to format option label '{}' of item {} using format pattern '{}': {}, displaying option label",
+                                    label, item.getName(), pattern, e.getMessage());
+                            displayState = label;
+                        }
+                        break;
+                    }
+                }
+            }
+            if (pattern != null && !optionMatched) {
+                // if it's not a transformation pattern and there is no matching state option,
+                // then it must be a format string
+                if (state instanceof QuantityType quantityState) {
+                    // sanity convert current state to the item state description unit in case it was
+                    // updated in the meantime. The item state is still in the "original" unit while the
+                    // state description will display the new unit:
+                    Unit<?> patternUnit = UnitUtils.parseUnit(pattern);
+                    if (patternUnit != null && !quantityState.getUnit().equals(patternUnit)) {
+                        quantityState = quantityState.toInvertibleUnit(patternUnit);
+                    }
+
+                    if (quantityState != null) {
+                        state = quantityState;
+                    }
+                }
+
+                // The following exception handling has been added to work around a Java bug with formatting
+                // numbers. See http://bugs.sun.com/view_bug.do?bug_id=6476425
+                // This also handles IllegalFormatConversionException, which is a subclass of
+                // IllegalArgument.
+                try {
+                    if (state instanceof DateTimeType dateTimeState) {
+                        displayState = dateTimeState.format(pattern, zoneId);
+                    } else {
+                        displayState = state.format(pattern);
+                    }
+                } catch (IllegalArgumentException e) {
+                    LOGGER.debug(
+                            "Unable to format value '{}' of item {} using format pattern '{}': {}, displaying raw state",
+                            state, item.getName(), pattern, e.getMessage());
+                    displayState = state.toString();
                 }
             }
         }

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/util/ItemDisplayStateUtil.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/util/ItemDisplayStateUtil.java
@@ -49,8 +49,34 @@ public class ItemDisplayStateUtil {
     private static final Pattern EXTRACT_TRANSFORM_FUNCTION_PATTERN = Pattern.compile("(.*?)\\((.*)\\):(.*)");
 
     /**
+     * Transform an arbitrary value with a transformation service
+     *
+     * @param serviceName the name of the transformation service
+     * @param function the name of the transformation function
+     * @param value the value to transform
+     * @return the transformed state, can be null if the transformation function returns null
+     * @throws TransformationException when state formatting failed, the transformation service is unavailable, or the
+     *             transformation failed
+     */
+    public static @Nullable String transform(String serviceName, String function, String value)
+            throws TransformationException {
+        TransformationService transformation = TransformationHelper.getTransformationService(serviceName);
+        if (transformation != null) {
+            try {
+                return transformation.transform(function, value);
+            } catch (RuntimeException e) {
+                throw new TransformationException(
+                        "Transformation service of type '" + serviceName + "' threw an exception: " + e.getMessage(),
+                        e);
+            }
+        } else {
+            throw new TransformationException("Transformation service of type '" + serviceName + "' is not available.");
+        }
+    }
+
+    /**
      * Transform an Item state with a transformation service
-     * 
+     *
      * @param serviceName the name of the transformation service
      * @param function the name of the transformation function
      * @param format the format to apply to the state before applying the transformation function
@@ -61,21 +87,12 @@ public class ItemDisplayStateUtil {
      */
     public static @Nullable String transform(String serviceName, String function, String format, State state)
             throws TransformationException {
-        TransformationService transformation = TransformationHelper.getTransformationService(serviceName);
-        if (transformation != null) {
-            String effectiveFormat = state instanceof UnDefType ? "%s" : format;
-            try {
-                return transformation.transform(function, state.format(effectiveFormat));
-            } catch (IllegalArgumentException e) {
-                throw new TransformationException(
-                        "Cannot format state '" + state + "' to format '" + effectiveFormat + "'", e);
-            } catch (RuntimeException e) {
-                throw new TransformationException(
-                        "Transformation service of type '" + serviceName + "' threw an exception: " + e.getMessage(),
-                        e);
-            }
-        } else {
-            throw new TransformationException("Transformation service of type '" + serviceName + "' is not available.");
+        String effectiveFormat = state instanceof UnDefType ? "%s" : format;
+        try {
+            return transform(serviceName, function, state.format(effectiveFormat));
+        } catch (IllegalArgumentException e) {
+            throw new TransformationException("Cannot format state '" + state + "' to format '" + effectiveFormat + "'",
+                    e);
         }
     }
 

--- a/bundles/org.openhab.core.transform/src/test/java/org/openhab/core/transform/util/ItemDisplayStateUtilTest.java
+++ b/bundles/org.openhab.core.transform/src/test/java/org/openhab/core/transform/util/ItemDisplayStateUtilTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.transform.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.*;
+
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.items.Item;
+import org.openhab.core.library.types.DateTimeType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.transform.TransformationHelper;
+import org.openhab.core.transform.TransformationService;
+import org.openhab.core.types.State;
+import org.openhab.core.types.StateDescription;
+import org.openhab.core.types.StateOption;
+import org.openhab.core.types.UnDefType;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+
+/**
+ * Unit tests for {@link ItemDisplayStateUtil}.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+public class ItemDisplayStateUtilTest {
+
+    private Item item;
+    private StateDescription stateDescription;
+    private final Locale locale = Locale.ENGLISH;
+    private final ZoneId zoneId = ZoneId.of("Europe/Berlin");
+
+    private TransformationHelper transformationHelper;
+    private TransformationService mapTransformationService;
+
+    @BeforeEach
+    public void setUp() {
+        item = mock(Item.class);
+        stateDescription = mock(StateDescription.class);
+        when(item.getStateDescription(locale)).thenReturn(stateDescription);
+
+        // Setup TransformationHelper
+        BundleContext bundleContext = mock(BundleContext.class);
+        transformationHelper = new TransformationHelper(bundleContext);
+
+        mapTransformationService = mock(TransformationService.class);
+        @SuppressWarnings("unchecked")
+        ServiceReference<TransformationService> serviceRef = mock(ServiceReference.class);
+        when(serviceRef.getProperty(TransformationService.SERVICE_PROPERTY_NAME)).thenReturn("MAP");
+        when(bundleContext.getService(serviceRef)).thenReturn(mapTransformationService);
+
+        transformationHelper.setTransformationService(serviceRef);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        transformationHelper.deactivate();
+    }
+
+    @Test
+    public void getDisplayStateReturnsRawStateWhenNoStateDescription() {
+        when(item.getStateDescription(locale)).thenReturn(null);
+        State state = new StringType("someState");
+
+        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+
+        assertThat(result, is("someState"));
+    }
+
+    @Test
+    public void getDisplayStateReturnsUnDefStateAsString() {
+        State state = UnDefType.NULL;
+        when(stateDescription.getPattern()).thenReturn("%s");
+
+        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+
+        assertThat(result, is("NULL"));
+    }
+
+    @Test
+    public void getDisplayStateAppliesTransformation() throws Exception {
+        State state = new StringType("ON");
+        when(stateDescription.getPattern()).thenReturn("MAP(test.map):%s");
+        when(mapTransformationService.transform("test.map", "ON")).thenReturn("Active");
+
+        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+
+        assertThat(result, is("Active"));
+    }
+
+    @Test
+    public void getDisplayStateReturnsRawStateWhenTransformationReturnsNull() throws Exception {
+        State state = new StringType("ON");
+        when(stateDescription.getPattern()).thenReturn("MAP(test.map):%s");
+        when(mapTransformationService.transform("test.map", "ON")).thenReturn(null);
+
+        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+
+        assertThat(result, is("ON"));
+    }
+
+    @Test
+    public void getDisplayStateReturnsRawStateWhenTransformationServiceNotAvailable() {
+        State state = new StringType("ON");
+        when(stateDescription.getPattern()).thenReturn("UNKNOWN(test.map):%s");
+
+        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+
+        assertThat(result, is("ON"));
+    }
+
+    @Test
+    public void getDisplayStateAppliesStateOptionLabel() {
+        State state = new StringType("1");
+
+        StateOption option = new StateOption("1", "Option Label");
+
+        when(stateDescription.getOptions()).thenReturn(List.of(option));
+        when(stateDescription.getPattern()).thenReturn("Prefix: %s");
+
+        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+
+        assertThat(result, is("Prefix: Option Label"));
+    }
+
+    @Test
+    public void getDisplayStateAppliesStateOptionLabelWithoutPattern() {
+        State state = new StringType("1");
+
+        StateOption option = new StateOption("1", "Option Label");
+
+        when(stateDescription.getOptions()).thenReturn(List.of(option));
+        when(stateDescription.getPattern()).thenReturn(null);
+
+        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+
+        assertThat(result, is("Option Label"));
+    }
+
+    @Test
+    public void getDisplayStateReturnsLabelWhenOptionPatternIsInvalid() {
+        State state = new StringType("1");
+
+        StateOption option = new StateOption("1", "Option Label");
+
+        when(stateDescription.getOptions()).thenReturn(List.of(option));
+        when(stateDescription.getPattern()).thenReturn("%d"); // Label is String, %d will fail
+
+        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+
+        assertThat(result, is("Option Label"));
+    }
+
+    @Test
+    public void getDisplayStateConvertsQuantityTypeToPatternUnit() {
+        QuantityType<?> state = new QuantityType<>("20 °C");
+        when(stateDescription.getPattern()).thenReturn("%.1f °F");
+        when(stateDescription.getOptions()).thenReturn(Collections.emptyList());
+
+        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+
+        // 20°C = 68°F
+        assertThat(result, is("68.0 °F"));
+    }
+
+    @Test
+    public void getDisplayStateFormatsDateTimeTypeWithZoneId() {
+        DateTimeType state = new DateTimeType("2023-01-01T10:00:00Z");
+        when(stateDescription.getPattern()).thenReturn("%1$tH:%1$tM");
+        when(stateDescription.getOptions()).thenReturn(Collections.emptyList());
+
+        // UTC 10:00 is 11:00 in Europe/Berlin (CET)
+        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+
+        assertThat(result, is("11:00"));
+    }
+
+    @Test
+    public void getDisplayStateFormatsStateWithRegularPattern() {
+        State state = new StringType("test");
+        when(stateDescription.getPattern()).thenReturn("Result: %s");
+        when(stateDescription.getOptions()).thenReturn(Collections.emptyList());
+
+        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+
+        assertThat(result, is("Result: test"));
+    }
+
+    @Test
+    public void getDisplayStateReturnsRawStateWhenPatternIsInvalid() {
+        State state = new StringType("test");
+        when(stateDescription.getPattern()).thenReturn("%d"); // String cannot be formatted as %d
+        when(stateDescription.getOptions()).thenReturn(Collections.emptyList());
+
+        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+
+        assertThat(result, is("test"));
+    }
+}

--- a/bundles/org.openhab.core.transform/src/test/java/org/openhab/core/transform/util/ItemDisplayStateUtilTest.java
+++ b/bundles/org.openhab.core.transform/src/test/java/org/openhab/core/transform/util/ItemDisplayStateUtilTest.java
@@ -14,6 +14,7 @@ package org.openhab.core.transform.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 import java.time.ZoneId;
@@ -28,6 +29,7 @@ import org.openhab.core.items.Item;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.transform.TransformationException;
 import org.openhab.core.transform.TransformationHelper;
 import org.openhab.core.transform.TransformationService;
 import org.openhab.core.types.State;
@@ -87,19 +89,11 @@ public class ItemDisplayStateUtilTest {
     }
 
     @Test
-    public void getDisplayStateReturnsUnDefStateAsString() {
-        State state = UnDefType.NULL;
-        when(stateDescription.getPattern()).thenReturn("%s");
-
-        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
-
-        assertThat(result, is("NULL"));
-    }
-
-    @Test
-    public void getDisplayStateAppliesTransformation() throws Exception {
+    public void getDisplayStateCallsFormatState() throws Exception {
         State state = new StringType("ON");
+        when(item.getName()).thenReturn("testItem");
         when(stateDescription.getPattern()).thenReturn("MAP(test.map):%s");
+        when(stateDescription.getOptions()).thenReturn(Collections.emptyList());
         when(mapTransformationService.transform("test.map", "ON")).thenReturn("Active");
 
         String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
@@ -108,111 +102,167 @@ public class ItemDisplayStateUtilTest {
     }
 
     @Test
-    public void getDisplayStateReturnsRawStateWhenTransformationReturnsNull() throws Exception {
+    public void formatStateReturnsUnDefStateAsString() {
+        State state = UnDefType.NULL;
+        String result = ItemDisplayStateUtil.formatState("item", "%s", Collections.emptyList(), state, zoneId);
+        assertThat(result, is("NULL"));
+    }
+
+    @Test
+    public void formatStateAppliesTransformation() throws Exception {
         State state = new StringType("ON");
-        when(stateDescription.getPattern()).thenReturn("MAP(test.map):%s");
+        when(mapTransformationService.transform("test.map", "ON")).thenReturn("Active");
+
+        String result = ItemDisplayStateUtil.formatState("item", "MAP(test.map):%s", Collections.emptyList(), state,
+                zoneId);
+
+        assertThat(result, is("Active"));
+    }
+
+    @Test
+    public void formatStateReturnsRawStateWhenTransformationReturnsNull() throws Exception {
+        State state = new StringType("ON");
         when(mapTransformationService.transform("test.map", "ON")).thenReturn(null);
 
-        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+        String result = ItemDisplayStateUtil.formatState("item", "MAP(test.map):%s", Collections.emptyList(), state,
+                zoneId);
 
         assertThat(result, is("ON"));
     }
 
     @Test
-    public void getDisplayStateReturnsRawStateWhenTransformationServiceNotAvailable() {
+    public void formatStateReturnsRawStateWhenTransformationServiceNotAvailable() {
         State state = new StringType("ON");
-        when(stateDescription.getPattern()).thenReturn("UNKNOWN(test.map):%s");
 
-        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+        String result = ItemDisplayStateUtil.formatState("item", "UNKNOWN(test.map):%s", Collections.emptyList(), state,
+                zoneId);
 
         assertThat(result, is("ON"));
     }
 
     @Test
-    public void getDisplayStateAppliesStateOptionLabel() {
+    public void formatStateAppliesStateOptionLabel() {
         State state = new StringType("1");
-
         StateOption option = new StateOption("1", "Option Label");
 
-        when(stateDescription.getOptions()).thenReturn(List.of(option));
-        when(stateDescription.getPattern()).thenReturn("Prefix: %s");
-
-        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+        String result = ItemDisplayStateUtil.formatState("item", "Prefix: %s", List.of(option), state, zoneId);
 
         assertThat(result, is("Prefix: Option Label"));
     }
 
     @Test
-    public void getDisplayStateAppliesStateOptionLabelWithoutPattern() {
+    public void formatStateAppliesStateOptionLabelWithoutPattern() {
         State state = new StringType("1");
-
         StateOption option = new StateOption("1", "Option Label");
 
-        when(stateDescription.getOptions()).thenReturn(List.of(option));
-        when(stateDescription.getPattern()).thenReturn(null);
-
-        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+        String result = ItemDisplayStateUtil.formatState("item", null, List.of(option), state, zoneId);
 
         assertThat(result, is("Option Label"));
     }
 
     @Test
-    public void getDisplayStateReturnsLabelWhenOptionPatternIsInvalid() {
+    public void formatStateReturnsLabelWhenOptionPatternIsInvalid() {
         State state = new StringType("1");
-
         StateOption option = new StateOption("1", "Option Label");
 
-        when(stateDescription.getOptions()).thenReturn(List.of(option));
-        when(stateDescription.getPattern()).thenReturn("%d"); // Label is String, %d will fail
-
-        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+        String result = ItemDisplayStateUtil.formatState("item", "%d", List.of(option), state, zoneId);
 
         assertThat(result, is("Option Label"));
     }
 
     @Test
-    public void getDisplayStateConvertsQuantityTypeToPatternUnit() {
+    public void formatStateConvertsQuantityTypeToPatternUnit() {
         QuantityType<?> state = new QuantityType<>("20 °C");
-        when(stateDescription.getPattern()).thenReturn("%.1f °F");
-        when(stateDescription.getOptions()).thenReturn(Collections.emptyList());
 
-        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+        String result = ItemDisplayStateUtil.formatState("item", "%.1f °F", Collections.emptyList(), state, zoneId);
 
         // 20°C = 68°F
         assertThat(result, is("68.0 °F"));
     }
 
     @Test
-    public void getDisplayStateFormatsDateTimeTypeWithZoneId() {
+    public void formatStateFormatsDateTimeTypeWithZoneId() {
         DateTimeType state = new DateTimeType("2023-01-01T10:00:00Z");
-        when(stateDescription.getPattern()).thenReturn("%1$tH:%1$tM");
-        when(stateDescription.getOptions()).thenReturn(Collections.emptyList());
 
         // UTC 10:00 is 11:00 in Europe/Berlin (CET)
-        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+        String result = ItemDisplayStateUtil.formatState("item", "%1$tH:%1$tM", Collections.emptyList(), state, zoneId);
 
         assertThat(result, is("11:00"));
     }
 
     @Test
-    public void getDisplayStateFormatsStateWithRegularPattern() {
+    public void formatStateFormatsStateWithRegularPattern() {
         State state = new StringType("test");
-        when(stateDescription.getPattern()).thenReturn("Result: %s");
-        when(stateDescription.getOptions()).thenReturn(Collections.emptyList());
 
-        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+        String result = ItemDisplayStateUtil.formatState("item", "Result: %s", Collections.emptyList(), state, zoneId);
 
         assertThat(result, is("Result: test"));
     }
 
     @Test
-    public void getDisplayStateReturnsRawStateWhenPatternIsInvalid() {
+    public void formatStateReturnsRawStateWhenPatternIsInvalid() {
         State state = new StringType("test");
-        when(stateDescription.getPattern()).thenReturn("%d"); // String cannot be formatted as %d
-        when(stateDescription.getOptions()).thenReturn(Collections.emptyList());
 
-        String result = ItemDisplayStateUtil.getDisplayState(item, state, locale, zoneId);
+        String result = ItemDisplayStateUtil.formatState("item", "%d", Collections.emptyList(), state, zoneId);
 
         assertThat(result, is("test"));
+    }
+
+    @Test
+    public void transformValueSucceeds() throws Exception {
+        when(mapTransformationService.transform("test.map", "input")).thenReturn("output");
+        String result = ItemDisplayStateUtil.transform("MAP", "test.map", "input");
+        assertThat(result, is("output"));
+    }
+
+    @Test
+    public void transformValueThrowsWhenServiceNotFound() {
+        TransformationException exception = assertThrows(TransformationException.class, () -> {
+            ItemDisplayStateUtil.transform("UNKNOWN", "test.map", "input");
+        });
+        assertThat(exception.getMessage(), is("Transformation service of type 'UNKNOWN' is not available."));
+    }
+
+    @Test
+    public void transformValueThrowsWhenServiceFails() throws Exception {
+        when(mapTransformationService.transform("test.map", "input")).thenThrow(new RuntimeException("error"));
+        TransformationException exception = assertThrows(TransformationException.class, () -> {
+            ItemDisplayStateUtil.transform("MAP", "test.map", "input");
+        });
+        assertThat(exception.getMessage(), is("Transformation service of type 'MAP' threw an exception: error"));
+    }
+
+    @Test
+    public void transformStateSucceeds() throws Exception {
+        State state = new StringType("ON");
+        when(mapTransformationService.transform("test.map", "ON")).thenReturn("Active");
+        String result = ItemDisplayStateUtil.transform("MAP", "test.map", "%s", state, zoneId);
+        assertThat(result, is("Active"));
+    }
+
+    @Test
+    public void transformStateFormatsDateTimeWithZone() throws Exception {
+        DateTimeType state = new DateTimeType("2023-01-01T10:00:00Z");
+        // UTC 10:00 is 11:00 in Europe/Berlin
+        when(mapTransformationService.transform("test.map", "11:00")).thenReturn("Eleven");
+        String result = ItemDisplayStateUtil.transform("MAP", "test.map", "%1$tH:%1$tM", state, zoneId);
+        assertThat(result, is("Eleven"));
+    }
+
+    @Test
+    public void transformStateUsesDefaultFormatForUnDef() throws Exception {
+        State state = UnDefType.NULL;
+        when(mapTransformationService.transform("test.map", "NULL")).thenReturn("Missing");
+        String result = ItemDisplayStateUtil.transform("MAP", "test.map", "invalid-format", state, zoneId);
+        assertThat(result, is("Missing"));
+    }
+
+    @Test
+    public void transformStateThrowsOnInvalidFormat() {
+        State state = new StringType("ON");
+        TransformationException exception = assertThrows(TransformationException.class, () -> {
+            ItemDisplayStateUtil.transform("MAP", "test.map", "%d", state, zoneId);
+        });
+        assertThat(exception.getMessage(), is("Cannot format state 'ON' to format '%d'"));
     }
 }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.IllegalFormatException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -77,7 +76,6 @@ import org.openhab.core.transform.util.ItemDisplayStateUtil;
 import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.State;
 import org.openhab.core.types.StateDescription;
-import org.openhab.core.types.StateOption;
 import org.openhab.core.types.UnDefType;
 import org.openhab.core.types.util.UnitUtils;
 import org.openhab.core.ui.items.ItemUIProvider;
@@ -347,14 +345,15 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
             return transform(label, true, null, null);
         }
 
-        String labelMappedOption = null;
-        State state = null;
-        StateDescription stateDescription = null;
+        State state;
+        StateDescription stateDescription;
         String formatPattern = getFormatPattern(w);
 
         if (formatPattern != null && label.indexOf("[") < 0) {
             label = label + " [" + formatPattern + "]";
         }
+
+        String value = null;
 
         // now insert the value, if the state is a string or decimal value and there is some formatting pattern defined
         // in the label or state description (i.e. it contains at least a %)
@@ -374,131 +373,54 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
             if (formatPattern != null) {
                 state = item.getState();
-
-                if (formatPattern.contains("%d")) {
-                    if (!(state instanceof UnDefType) && !(state instanceof Number)) {
+                if (state == null || state instanceof UnDefType) {
+                    if (!EXTRACT_TRANSFORM_FUNCTION_PATTERN.matcher(formatPattern).find()) {
+                        value = formatUndefined(formatPattern);
+                    }
+                } else {
+                    if (formatPattern.contains("%d") && !(state instanceof Number)) {
                         // States which do not provide a Number will be converted to DecimalType.
                         // e.g.: GroupItem can provide a count of items matching the active state
                         // for some group functions.
                         state = item.getStateAs(DecimalType.class);
                     }
 
-                    // for fraction digits in state we don't want to risk format exceptions,
-                    // so treat everything as floats:
-                    formatPattern = formatPattern.replace("%d", "%.0f");
+                    if (formatPattern.contains("%d")) {
+                        // for fraction digits in state we don't want to risk format exceptions,
+                        // so treat everything as floats:
+                        formatPattern = formatPattern.replace("%d", "%.0f");
+                    }
+
+                    if (!(state instanceof QuantityType) && formatPattern.contains("%unit%")) {
+                        formatPattern = formatPattern.replace("%unit%", "").trim();
+                    }
+
+                    if (state != null) {
+                        value = ItemDisplayStateUtil.formatState(itemName, formatPattern,
+                                stateDescription != null ? stateDescription.getOptions() : Collections.emptyList(),
+                                state, timeZoneProvider.getTimeZone());
+                    }
                 }
             }
         } catch (ItemNotFoundException e) {
             logger.warn("Cannot retrieve item '{}' for widget {}", itemName, w.getClass().getSimpleName());
         }
 
-        boolean considerTransform = false;
-        String transformFailbackValue = null;
-        if (formatPattern != null) {
-            if (formatPattern.isEmpty()) {
-                label = label.substring(0, label.indexOf("[")).trim();
+        label = label.trim();
+        int index = label.indexOf("[");
+        if (index >= 0) {
+            if (formatPattern != null && !formatPattern.isEmpty()) {
+                label = label.substring(0, index + 1) + formatPattern + "]";
             } else {
-                if (state == null) {
-                    formatPattern = formatUndefined(formatPattern);
-                    considerTransform = true;
-                } else if (state instanceof UnDefType) {
-                    Matcher matcher = EXTRACT_TRANSFORM_FUNCTION_PATTERN.matcher(formatPattern);
-                    if (matcher.find()) {
-                        considerTransform = true;
-                        String type = matcher.group(1);
-                        String function = matcher.group(2);
-                        formatPattern = type + "(" + function + "):" + state.toString();
-                        transformFailbackValue = "-";
-                    } else {
-                        formatPattern = formatUndefined(formatPattern);
-                    }
-                } else {
-                    // if the channel contains options, we build a label with the mapped option value
-                    if (stateDescription != null) {
-                        for (StateOption option : stateDescription.getOptions()) {
-                            String optionLabel = option.getLabel();
-                            if (option.getValue().equals(state.toString()) && optionLabel != null) {
-                                String formatPatternOption;
-                                try {
-                                    formatPatternOption = String.format(formatPattern, optionLabel);
-                                } catch (IllegalFormatException e) {
-                                    logger.debug(
-                                            "Mapping option value '{}' for item {} using format '{}' failed ({}); format is ignored and option label is used",
-                                            optionLabel, itemName, formatPattern, e.getMessage());
-                                    formatPatternOption = optionLabel;
-                                }
-                                labelMappedOption = label.trim();
-                                labelMappedOption = labelMappedOption.substring(0, labelMappedOption.indexOf("[") + 1)
-                                        + formatPatternOption + "]";
-                                break;
-                            }
-                        }
-                    }
-
-                    if (state instanceof DecimalType) {
-                        // for DecimalTypes we don't want to risk format exceptions, if pattern contains unit
-                        // placeholder
-                        if (formatPattern.contains(UnitUtils.UNIT_PLACEHOLDER)) {
-                            formatPattern = formatPattern.replaceAll(UnitUtils.UNIT_PLACEHOLDER, "").stripTrailing();
-                        }
-                    } else if (state instanceof QuantityType quantityState) {
-                        // sanity convert current state to the item state description unit in case it was updated in the
-                        // meantime. The item state is still in the "original" unit while the state description will
-                        // display the new unit:
-                        Unit<?> patternUnit = UnitUtils.parseUnit(formatPattern);
-                        if (patternUnit != null && !quantityState.getUnit().equals(patternUnit)) {
-                            quantityState = quantityState.toInvertibleUnit(patternUnit);
-                        }
-
-                        // The widget may define its own unit in the widget label. Convert to this unit:
-                        if (quantityState != null) {
-                            quantityState = convertStateToWidgetUnit(quantityState, w);
-                            state = quantityState;
-                        }
-                    }
-
-                    // The following exception handling has been added to work around a Java bug with formatting
-                    // numbers. See http://bugs.sun.com/view_bug.do?bug_id=6476425
-                    // Without this catch, the whole sitemap, or page can not be displayed!
-                    // This also handles IllegalFormatConversionException, which is a subclass of IllegalArgument.
-                    try {
-                        Matcher matcher = EXTRACT_TRANSFORM_FUNCTION_PATTERN.matcher(formatPattern);
-                        if (matcher.find()) {
-                            considerTransform = true;
-                            String type = matcher.group(1);
-                            String function = matcher.group(2);
-                            String value = matcher.group(3);
-                            formatPattern = type + "(" + function + "):";
-                            if (state instanceof DateTimeType dateTimeState) {
-                                formatPattern += dateTimeState.format(value, timeZoneProvider.getTimeZone());
-                                transformFailbackValue = dateTimeState.toFullString(timeZoneProvider.getTimeZone());
-                            } else {
-                                formatPattern += state.format(value);
-                                transformFailbackValue = state.toString();
-                            }
-                        } else {
-                            if (state instanceof DateTimeType dateTimeState) {
-                                formatPattern = dateTimeState.format(formatPattern, timeZoneProvider.getTimeZone());
-                            } else {
-                                formatPattern = state.format(formatPattern);
-                            }
-                        }
-                    } catch (IllegalArgumentException e) {
-                        logger.warn("Exception while formatting value '{}' of item {} with format '{}': {}", state,
-                                itemName, formatPattern, e.getMessage());
-                        formatPattern = "Err";
-                    }
-                }
-
-                label = label.trim();
-                int index = label.indexOf("[");
-                if (index >= 0) {
-                    label = label.substring(0, index + 1) + formatPattern + "]";
-                }
+                return label.substring(0, index).trim();
             }
         }
 
-        return transform(label, considerTransform, transformFailbackValue, labelMappedOption);
+        if (value == null) {
+            value = "-";
+        }
+
+        return insertInLabel(label, value);
     }
 
     @Override
@@ -628,7 +550,11 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     private String insertInLabel(String label, Object o) {
-        return label.substring(0, label.indexOf("[") + 1) + o + "]";
+        int index = label.indexOf("[");
+        if (index >= 0) {
+            return label.substring(0, index + 1) + o + "]";
+        }
+        return label;
     }
 
     /*

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.ui.internal.items;
 
+import static org.openhab.core.transform.util.ItemDisplayStateUtil.EXTRACT_TRANSFORM_FUNCTION_PATTERN;
+
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -114,9 +116,6 @@ import org.slf4j.LoggerFactory;
 public class ItemUIRegistryImpl implements ItemUIRegistry {
 
     protected static final String CONFIG_URI = "system:sitemap";
-
-    /* RegEx to extract and parse a function String <code>'(.*?)\((.*)\):(.*)'</code> */
-    protected static final Pattern EXTRACT_TRANSFORM_FUNCTION_PATTERN = Pattern.compile("(.*?)\\((.*)\\):(.*)");
 
     /* RegEx to identify format patterns. See java.util.Formatter#formatSpecifier (without the '%' at the very end). */
     protected static final String IDENTIFY_FORMAT_PATTERN_PATTERN = "%(?:(unit%)|(?:(?:\\d+\\$)?(?:[-#+ 0,(<]*)?(?:\\d+)?(?:\\.\\d+)?(?:[tT])?(?:[a-zA-Z])))";
@@ -342,18 +341,16 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
         String itemName = w.getItem();
         if (itemName == null || itemName.isBlank()) {
-            return transform(label, true, null, null);
+            return transform(label, null);
         }
 
-        State state;
-        StateDescription stateDescription;
+        State state = null;
+        StateDescription stateDescription = null;
         String formatPattern = getFormatPattern(w);
 
         if (formatPattern != null && label.indexOf("[") < 0) {
             label = label + " [" + formatPattern + "]";
         }
-
-        String value = null;
 
         // now insert the value, if the state is a string or decimal value and there is some formatting pattern defined
         // in the label or state description (i.e. it contains at least a %)
@@ -373,37 +370,48 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
             if (formatPattern != null) {
                 state = item.getState();
-                if (state == null || state instanceof UnDefType) {
-                    if (!EXTRACT_TRANSFORM_FUNCTION_PATTERN.matcher(formatPattern).find()) {
-                        value = formatUndefined(formatPattern);
-                    }
-                } else {
-                    if (formatPattern.contains("%d") && !(state instanceof Number)) {
+
+                if (formatPattern.contains("%d")) {
+                    if (!(state instanceof UnDefType) && !(state instanceof Number)) {
                         // States which do not provide a Number will be converted to DecimalType.
                         // e.g.: GroupItem can provide a count of items matching the active state
                         // for some group functions.
                         state = item.getStateAs(DecimalType.class);
                     }
 
-                    if (formatPattern.contains("%d")) {
-                        // for fraction digits in state we don't want to risk format exceptions,
-                        // so treat everything as floats:
-                        formatPattern = formatPattern.replace("%d", "%.0f");
-                    }
-
-                    if (!(state instanceof QuantityType) && formatPattern.contains("%unit%")) {
-                        formatPattern = formatPattern.replace("%unit%", "").trim();
-                    }
-
-                    if (state != null) {
-                        value = ItemDisplayStateUtil.formatState(itemName, formatPattern,
-                                stateDescription != null ? stateDescription.getOptions() : Collections.emptyList(),
-                                state, timeZoneProvider.getTimeZone());
-                    }
+                    // for fraction digits in state we don't want to risk format exceptions,
+                    // so treat everything as floats:
+                    formatPattern = formatPattern.replace("%d", "%.0f");
                 }
             }
         } catch (ItemNotFoundException e) {
             logger.warn("Cannot retrieve item '{}' for widget {}", itemName, w.getClass().getSimpleName());
+        }
+
+        String value = null;
+        if (formatPattern != null) {
+            if (formatPattern.isEmpty()) {
+                label = label.substring(0, label.indexOf("[")).trim();
+            } else {
+                if (state == null || state instanceof UnDefType) {
+                    Matcher matcher = EXTRACT_TRANSFORM_FUNCTION_PATTERN.matcher(formatPattern);
+                    if (matcher.find()) {
+                        String type = matcher.group(1);
+                        String function = matcher.group(2);
+                        value = transform(label, "-");
+                    } else {
+                        value = formatUndefined(formatPattern);
+                    }
+                } else if (!(state instanceof QuantityType) && formatPattern.contains("%unit%")) {
+                    formatPattern = formatPattern.replace("%unit%", "").trim();
+                }
+            }
+        }
+
+        if (value == null) {
+            value = ItemDisplayStateUtil.formatState(itemName, formatPattern,
+                    stateDescription != null ? stateDescription.getOptions() : Collections.emptyList(),
+                    state == null ? UnDefType.NULL : state, timeZoneProvider.getTimeZone());
         }
 
         label = label.trim();
@@ -565,13 +573,12 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
      * If the value does not start with the call to a transformation service,
      * we return the label with the mapped option value if provided (not null).
      */
-    private String transform(String label, boolean matchTransform, @Nullable String transformFailbackValue,
-            @Nullable String labelMappedOption) {
+    private String transform(String label, @Nullable String transformFailbackValue) {
         String ret = label;
         String formatPattern = getFormatPattern(label);
         if (formatPattern != null) {
             Matcher matcher = EXTRACT_TRANSFORM_FUNCTION_PATTERN.matcher(formatPattern);
-            if (matchTransform && matcher.find()) {
+            if (matcher.find()) {
                 String type = matcher.group(1);
                 String function = matcher.group(2);
                 String value = matcher.group(3);
@@ -579,19 +586,17 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                 try {
                     String transformationResult = ItemDisplayStateUtil.transform(type, function, value);
                     if (transformationResult != null) {
-                        ret = insertInLabel(label, transformationResult);
+                        return transformationResult;
                     } else {
                         logger.warn("Transformation of type {} did not return a valid result", type);
-                        ret = insertInLabel(label, failbackValue);
+                        return failbackValue;
                     }
                 } catch (TransformationException e) {
                     Throwable cause = e.getCause();
                     logger.warn("Failed transforming the value '{}' with pattern '{}': {}", value, formatPattern,
                             cause instanceof ScriptException ? cause.getMessage() : e.getMessage());
-                    ret = insertInLabel(label, failbackValue);
+                    return failbackValue;
                 }
-            } else if (labelMappedOption != null) {
-                ret = labelMappedOption;
             }
         }
         return ret;

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -78,6 +78,7 @@ import org.openhab.core.transform.util.ItemDisplayStateUtil;
 import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.State;
 import org.openhab.core.types.StateDescription;
+import org.openhab.core.types.StateOption;
 import org.openhab.core.types.UnDefType;
 import org.openhab.core.types.util.UnitUtils;
 import org.openhab.core.ui.items.ItemUIProvider;
@@ -108,6 +109,7 @@ import org.slf4j.LoggerFactory;
  * @author Danny Baumann - widget label source support
  * @author Laurent Garnier - Consider Colortemperaturepicker element as possible default widget
  * @author Mark Herwege - Implement sitemap registry
+ * @author Florian Hotze - Refactor getLabel(Widget w) to use {@link ItemDisplayStateUtil}
  */
 @NonNullByDefault
 @Component(immediate = true, configurationPid = "org.openhab.sitemap", //
@@ -338,97 +340,93 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     @Override
     public @Nullable String getLabel(Widget w) {
         String label = getLabelFromWidget(w).label;
-
         String itemName = w.getItem();
+
+        // If no item is associated, just transform the label
         if (itemName == null || itemName.isBlank()) {
             return transform(label, null);
         }
 
-        State state = null;
-        StateDescription stateDescription = null;
+        // If no format pattern is defined, we don't want to display any value
         String formatPattern = getFormatPattern(w);
-
-        if (formatPattern != null && label.indexOf("[") < 0) {
-            label = label + " [" + formatPattern + "]";
+        if (formatPattern == null) {
+            return label;
         }
 
-        // now insert the value, if the state is a string or decimal value and there is some formatting pattern defined
-        // in the label or state description (i.e. it contains at least a %)
+        // If the pattern is empty, we don't want to display any value
+        if (formatPattern.isEmpty()) {
+            return stripPatternFromLabel(label);
+        }
+
+        // Fetch item and its state
+        @Nullable
+        Item item = null;
         try {
-            final Item item = getItem(itemName);
-
-            // There is a known issue in the implementation of the method getStateDescription() of class Item
-            // in the following case:
-            // - the item provider returns as expected a state description without pattern but with for
-            // example a min value because a min value is set in the item definition but no label with
-            // pattern is set.
-            // - the channel state description provider returns as expected a state description with a pattern
-            // In this case, the result is no display of value by UIs because no pattern is set in the
-            // returned StateDescription. What is expected is the display of a value using the pattern
-            // provided by the channel state description provider.
-            stateDescription = item.getStateDescription();
-
-            if (formatPattern != null) {
-                state = item.getState();
-
-                if (formatPattern.contains("%d")) {
-                    if (!(state instanceof UnDefType) && !(state instanceof Number)) {
-                        // States which do not provide a Number will be converted to DecimalType.
-                        // e.g.: GroupItem can provide a count of items matching the active state
-                        // for some group functions.
-                        state = item.getStateAs(DecimalType.class);
-                    }
-
-                    // for fraction digits in state we don't want to risk format exceptions,
-                    // so treat everything as floats:
-                    formatPattern = formatPattern.replace("%d", "%.0f");
-                }
-            }
+            item = getItem(itemName);
         } catch (ItemNotFoundException e) {
             logger.warn("Cannot retrieve item '{}' for widget {}", itemName, w.getClass().getSimpleName());
         }
 
-        String value = null;
-        if (formatPattern != null) {
-            if (formatPattern.isEmpty()) {
-                label = label.substring(0, label.indexOf("[")).trim();
-            } else {
-                if (state == null || state instanceof UnDefType) {
-                    Matcher matcher = EXTRACT_TRANSFORM_FUNCTION_PATTERN.matcher(formatPattern);
-                    if (matcher.find()) {
-                        String type = matcher.group(1);
-                        String function = matcher.group(2);
-                        value = transform(label, "-");
-                    } else {
-                        value = formatUndefined(formatPattern);
-                    }
-                } else if (!(state instanceof QuantityType) && formatPattern.contains("%unit%")) {
-                    formatPattern = formatPattern.replace("%unit%", "").trim();
-                }
+        State itemState = item != null ? item.getState() : null;
+        State state = itemState != null ? itemState : UnDefType.NULL;
+        @Nullable
+        StateDescription stateDescription = item != null ? item.getStateDescription() : null;
+
+        // Handle specific pattern requirements
+        String effectivePattern = formatPattern;
+        if (effectivePattern.contains("%d")) {
+            if (!(state instanceof UnDefType) && !(state instanceof Number) && item != null) {
+                // States which do not provide a Number will be converted to DecimalType.
+                // e.g.: GroupItem can provide a count of items matching the active state
+                // for some group functions.
+                state = item.getStateAs(DecimalType.class);
             }
+
+            // for fraction digits in state we don't want to risk format exceptions,
+            // so treat everything as floats:
+            effectivePattern = effectivePattern.replace("%d", "%.0f");
         }
 
-        if (value == null) {
-            value = ItemDisplayStateUtil.formatState(itemName, formatPattern,
-                    stateDescription != null ? stateDescription.getOptions() : Collections.emptyList(),
-                    state == null ? UnDefType.NULL : state, timeZoneProvider.getTimeZone());
-        }
+        // Determine the display value
+        String value = getDisplayValue(itemName, label, effectivePattern, state,
+                stateDescription != null ? stateDescription.getOptions() : Collections.emptyList());
 
-        label = label.trim();
+        // Build the final label by combining the base label and the formatted value
+        return insertValueIntoLabel(label, value);
+    }
+
+    private String stripPatternFromLabel(String label) {
         int index = label.indexOf("[");
-        if (index >= 0) {
-            if (formatPattern != null && !formatPattern.isEmpty()) {
-                label = label.substring(0, index + 1) + formatPattern + "]";
-            } else {
-                return label.substring(0, index).trim();
+        return index >= 0 ? label.substring(0, index).trim() : label.trim();
+    }
+
+    private String insertValueIntoLabel(String label, @Nullable String value) {
+        return stripPatternFromLabel(label) + " [" + (value != null ? value : "-") + "]";
+    }
+
+    private String getDisplayValue(String itemName, String label, String pattern, State state,
+            List<StateOption> options) {
+        if (state instanceof UnDefType) {
+            Matcher matcher = EXTRACT_TRANSFORM_FUNCTION_PATTERN.matcher(pattern);
+            if (matcher.find()) {
+                return transform(label, "-");
+            }
+            return formatUndefined(pattern);
+        }
+
+        String effectivePattern = pattern;
+        if (state instanceof DecimalType) {
+            // for DecimalTypes we don't want to risk format exceptions, if pattern contains unit
+            // placeholder
+            if (effectivePattern.contains(UnitUtils.UNIT_PLACEHOLDER)) {
+                effectivePattern = effectivePattern.replaceAll(UnitUtils.UNIT_PLACEHOLDER, "").stripTrailing();
             }
         }
 
-        if (value == null) {
-            value = "-";
-        }
+        String formatted = ItemDisplayStateUtil.formatState(itemName, effectivePattern, options, state,
+                timeZoneProvider.getTimeZone());
 
-        return insertInLabel(label, value);
+        return formatted != null ? formatted : "-";
     }
 
     @Override
@@ -557,14 +555,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         }
     }
 
-    private String insertInLabel(String label, Object o) {
-        int index = label.indexOf("[");
-        if (index >= 0) {
-            return label.substring(0, index + 1) + o + "]";
-        }
-        return label;
-    }
-
     /*
      * check if there is a status value being displayed on the right side of the
      * label (the right side is signified by being enclosed in square brackets [].
@@ -574,7 +564,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
      * we return the label with the mapped option value if provided (not null).
      */
     private String transform(String label, @Nullable String transformFailbackValue) {
-        String ret = label;
         String formatPattern = getFormatPattern(label);
         if (formatPattern != null) {
             Matcher matcher = EXTRACT_TRANSFORM_FUNCTION_PATTERN.matcher(formatPattern);
@@ -599,7 +588,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                 }
             }
         }
-        return ret;
+        return label;
     }
 
     @Override

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -73,8 +73,7 @@ import org.openhab.core.sitemap.Switch;
 import org.openhab.core.sitemap.Widget;
 import org.openhab.core.sitemap.registry.SitemapFactory;
 import org.openhab.core.transform.TransformationException;
-import org.openhab.core.transform.TransformationHelper;
-import org.openhab.core.transform.TransformationService;
+import org.openhab.core.transform.util.ItemDisplayStateUtil;
 import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.State;
 import org.openhab.core.types.StateDescription;
@@ -652,23 +651,12 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                 String value = matcher.group(3);
                 String failbackValue = transformFailbackValue != null ? transformFailbackValue : value;
                 try {
-                    TransformationService transformation = TransformationHelper.getTransformationService(type);
-                    if (transformation != null) {
-                        try {
-                            String transformationResult = transformation.transform(function, value);
-                            if (transformationResult != null) {
-                                ret = insertInLabel(label, transformationResult);
-                            } else {
-                                logger.warn("Transformation of type {} did not return a valid result", type);
-                                ret = insertInLabel(label, failbackValue);
-                            }
-                        } catch (RuntimeException e) {
-                            throw new TransformationException("Transformation service of type '" + type
-                                    + "' threw an exception: " + e.getMessage(), e);
-                        }
+                    String transformationResult = ItemDisplayStateUtil.transform(type, function, value);
+                    if (transformationResult != null) {
+                        ret = insertInLabel(label, transformationResult);
                     } else {
-                        throw new TransformationException(
-                                "Transformation service of type '" + type + "' is not available.");
+                        logger.warn("Transformation of type {} did not return a valid result", type);
+                        ret = insertInLabel(label, failbackValue);
                     }
                 } catch (TransformationException e) {
                     Throwable cause = e.getCause();

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/StateDescriptionServiceImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/StateDescriptionServiceImplTest.java
@@ -105,6 +105,26 @@ public class StateDescriptionServiceImplTest {
     }
 
     @Test
+    public void testMinValueMaxValueStepMergedWithPatternTwoDescriptionProviders() {
+        StateDescriptionFragment stateDescriptionFragment1 = StateDescriptionFragmentBuilder.create()
+                .withMinimum(new BigDecimal(-1)) //
+                .withMaximum(new BigDecimal(-1)) //
+                .withStep(new BigDecimal(-1)).build();
+        registerStateDescriptionFragmentProvider(stateDescriptionFragment1, -1);
+
+        StateDescriptionFragment stateDescriptionFragment2 = StateDescriptionFragmentBuilder.create()
+                .withPattern("pattern2").build();
+        registerStateDescriptionFragmentProvider(stateDescriptionFragment2, -2);
+
+        StateDescription stateDescription = Objects.requireNonNull(item.getStateDescription());
+
+        assertThat(stateDescription.getMinimum(), is(stateDescriptionFragment1.getMinimum()));
+        assertThat(stateDescription.getMaximum(), is(stateDescriptionFragment1.getMaximum()));
+        assertThat(stateDescription.getStep(), is(stateDescriptionFragment1.getStep()));
+        assertThat(stateDescription.getPattern(), is(stateDescriptionFragment2.getPattern()));
+    }
+
+    @Test
     public void testIsReadOnlyWhenTwoDescriptionProvidersHigherRankingIsNotReadOnly() {
         StateDescriptionFragment stateDescriptionFragment1 = StateDescriptionFragmentBuilder.create().build();
         registerStateDescriptionFragmentProvider(stateDescriptionFragment1, -1);


### PR DESCRIPTION
Resolves #4697.

This adds a new query param to the GET `/rest/persistence/items/{itemname}` endpoint that enables transformation of the persisted states according to the state description of the Item, so that display states can be shown in charts.
It also adds a unit field to the response DTO.
Extracting the display state calculation into its own utility class is also a required step for adding a WS with similar functionality as the itemstates SSE endpoint.