### PR TITLE
RulesJvmModelInferrer: do not add things as possibly valid identifiers in DSL Rules

### DIFF
--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
@@ -17,7 +17,6 @@ import java.time.ZonedDateTime
 import java.util.Set
 import org.openhab.core.items.Item
 import org.openhab.core.items.ItemRegistry
-import org.openhab.core.thing.ThingRegistry
 import org.openhab.core.types.Command
 import org.openhab.core.types.State
 import org.openhab.core.model.rule.rules.ChangedEventTrigger
@@ -62,9 +61,6 @@ class RulesJvmModelInferrer extends ScriptJvmModelInferrer {
     @Inject
     ItemRegistry itemRegistry
 
-    @Inject
-    ThingRegistry thingRegistry
-
     /**
      * Is called for each instance of the first argument's type contained in a resource.
      * 
@@ -106,18 +102,6 @@ class RulesJvmModelInferrer extends ScriptJvmModelInferrer {
                     ]
                 } else {
                     logger.warn("Duplicate field: '{}'. Ignoring '{}'.", item.name, item.class.name)
-                }
-            ]
-
-            val things = thingRegistry?.getAll()
-            things?.forEach [ thing |
-                val name = thing.getUID().toString()
-                if (fieldNames.add(name)) {
-                    members += ruleModel.toField(name, typeRef(thing.class)) [
-                        static = true
-                    ]
-                } else {
-                    logger.warn("Duplicate field: '{}'. Ignoring '{}'.", name, thing.class.name)
                 }
             ]
 


### PR DESCRIPTION
as they contain colon and colon invalidates the ID in Xbase.

The idea of the removed code is, I guess, during script parsing and execution to declare thing uids as valid identifiers.

The lines above the removed lines declare as valid identifiers static enums, like  `ON`, and item names.

During Script/Rule body execution `ScriptInterpreter._invokeFeature()` does
```
        val sourceElement = jvmField.sourceElements.head
        if (sourceElement !== null) {
            val value = context.getValue(QualifiedName.create(jvmField.simpleName))
            value ?: {

                // Looks like we have a state, command or item field
                val fieldName = jvmField.simpleName
                fieldName.stateOrCommand ?: fieldName.item
            }
…
    def protected Item getItem(String name) {
        try {
            return itemRegistry.getItem(name);
        } catch (ItemNotFoundException e) {
            return null;
        }
    }
```
This means, if an identifier cannot be resoled by the Xbase type system, it is tried to resove the identifier as enum value (State or Command).  If this does not work, then it is tried to resolve the identifier as item name and if the latter does not work, `null` is returned.  At run time it is not tried to resolve the identifier as thing uid.

Typing ThingUID is the script is anyway invalid syntax, as the ThingUID includes a single `:` and this just does not work in Xbase grammars.


Before and after this change
```
rule U
when
  Thing "mqtt:topic:d" changed
then
  logError("THING", "d changed")
  logError("trigger", triggeringThing.toString)
  logError("previous", previousThingStatus.toString)
  logError("new", newThingStatus.toString)
end
```
prints:
```
2026-04-25 14:50:33.160 [ERROR] [org.openhab.core.model.script.THING ] - d changed
2026-04-25 14:50:33.163 [ERROR] [rg.openhab.core.model.script.trigger] - mqtt:topic:d
2026-04-25 14:50:33.166 [ERROR] [g.openhab.core.model.script.previous] - ONLINE
2026-04-25 14:50:33.168 [ERROR] [org.openhab.core.model.script.new   ] - OFFLINE
```

In ScriptJvmModelInferrer.xtend:`dispatch void infer` are added states, commands, and item names by `members +=`, too.  But in contrast to `RulesJvmModelInferrer`,  `ScriptJvmModelInferrer` does not try to add thing UIDs.