### PR TITLE
ThingValidator.xtend does not need INVALID_NAME

### DIFF
--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/GenerateThing.mwe2
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/GenerateThing.mwe2
@@ -50,7 +50,6 @@ Workflow {
       name = languageName
       fileExtensions = fileExtensions
       serializer = {
-        generateStub = true
         generateXtendStub = false
       }
     }

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/validation/ThingValidator.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/validation/ThingValidator.xtend
@@ -28,8 +28,6 @@ import org.openhab.core.thing.ThingUID
  */
 class ThingValidator extends AbstractThingValidator {
 
-  public static val INVALID_NAME = 'invalidName'
-
 	@Check
 	def check_thing_has_valid_id(ModelThing thing) {
 		if (thing.nested) {


### PR DESCRIPTION
.mwe2:StandardLanguage: `serializer = { generateStub = true }` is the default
