### PR TITLE
Make all sitemap DTOs schema names specific to Sitemaps

### DIFF
--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/PageDTO.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/PageDTO.java
@@ -22,7 +22,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  *
  * @author Kai Kreuzer - Initial contribution
  */
-@Schema(name = "Page")
+@Schema(name = "SitemapPage")
 public class PageDTO {
 
     public String id;

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
@@ -33,7 +33,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * @author Laurent Garnier - New fields row, column, command, releaseCommand and stateless for Button element
  * @author Mark Herwege - Extends abstract widget DTO
  */
-@Schema(name = "Widget")
+@Schema(name = "SitemapWidget")
 public class WidgetDTO extends AbstractWidgetDTO {
 
     public String widgetId;

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/ButtonDefinitionDTO.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/ButtonDefinitionDTO.java
@@ -19,7 +19,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  *
  * @author Mark Herwege - Initial contribution
  */
-@Schema(name = "ButtonDefinition")
+@Schema(name = "SitemapButtonDefinition")
 public class ButtonDefinitionDTO {
 
     public Integer row;

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/ConditionDTO.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/ConditionDTO.java
@@ -19,7 +19,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  *
  * @author Mark Herwege - Initial contribution
  */
-@Schema(name = "Condition")
+@Schema(name = "SitemapCondition")
 public class ConditionDTO {
 
     public String item;

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/MappingDTO.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/MappingDTO.java
@@ -22,7 +22,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * @author Laurent Garnier - Replace field position by fields row and column
  * @author Laurent Garnier - New field releaseCommand
  */
-@Schema(name = "Mapping")
+@Schema(name = "SitemapMapping")
 public class MappingDTO {
 
     public Integer row;

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/RuleDTO.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/RuleDTO.java
@@ -21,7 +21,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  *
  * @author Mark Herwege - Initial contribution
  */
-@Schema(name = "Rule")
+@Schema(name = "SitemapRule")
 public class RuleDTO {
 
     public List<ConditionDTO> conditions;

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/WidgetDefinitionDTO.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/WidgetDefinitionDTO.java
@@ -21,7 +21,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  *
  * @author Mark Herwege - Initial contribution
  */
-@Schema(name = "WidgetDefinition")
+@Schema(name = "SitemapWidgetDefinition")
 public class WidgetDefinitionDTO extends AbstractWidgetDTO {
 
     public String item;


### PR DESCRIPTION
See comment: https://github.com/openhab/openhab-core/pull/5459#issuecomment-4327172050

To avoid REST api schema with the same name, all sitemap related schema names now start with `Sitemap`.
