### PR TITLE
Allow empty sitemap in DSL

### DIFF
--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -8,7 +8,7 @@ SitemapModel:
 
 ModelSitemap:
     name=ID ('label=' label=STRING)? ('icon=' icon=STRING)? '{'
-    (children+=ModelWidget)+
+    (children+=ModelWidget)*
     '}';
 
 ModelWidget:

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
@@ -83,6 +83,16 @@ class SitemapValidator extends AbstractSitemapValidator {
     }
 
     @Check
+    def void checkAtLeastOneWidget(ModelSitemap sitemap) {
+        if (sitemap.children === null || sitemap.children.size === 0) {
+            val node = NodeModelUtils.getNode(sitemap)
+            val line = node.startLine
+            warning(errorString("Sitemap should have at least one widget", line),
+                    SitemapPackage.Literals.MODEL_SITEMAP.getEStructuralFeature(SitemapPackage.MODEL_SITEMAP__NAME))
+        }
+    }
+    
+    @Check
     def void checkDuplicates(ModelWidget w) {
         val seen = new HashSet<String>
         val duplicates = new HashSet<String>


### PR DESCRIPTION
In The current DSL sitemap definition, parsing will fail if there is no widget defined inside the sitemap. An empty sitemap is refused.

This leads to problems in DSL generation from the UI in the following workflow:

- create a new sitemap from the UI.
- switch to the DSL code tab (the API is called and returns 500).
- the first DSL line with the new sitemap name does not appear as there are no widgets yet, the error pops up, what has already been configured in the UI is not visible.
- you would expect the first line with sitemap name, so you can add widgets through textual (DSL) configuration at this point.

Before using the API to generate DSL code, this was working with the DSL generation code in the UI.

Note that this does work for YAML sitemap serialization and parsing (PR in process).

There is no reason not to allow an empty sitemap. BasicUI parses an empty sitemap just fine. The registry allows a sitemap without widgets.
This PR makes having a widget in the DSL sitemap definition optional, and includes a validation check. If there is no widget a warning will be generated but the sitemap will not be refused.

@lolodomo FYI