### PR TITLE
Allow multiple sitemaps in a DSL file

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/fileformat/FileFormatResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/fileformat/FileFormatResource.java
@@ -468,7 +468,6 @@ public class FileFormatResource implements RESTResource {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK", content = {
                             @Content(mediaType = "text/vnd.openhab.dsl.sitemap", schema = @Schema(example = DSL_SITEMAPS_EXAMPLE)) }),
-                    @ApiResponse(responseCode = "400", description = "Payload invalid."),
                     @ApiResponse(responseCode = "404", description = "One or more sitemaps not found in registry."),
                     @ApiResponse(responseCode = "415", description = "Unsupported media type.") })
     public Response createFileFormatForSitemaps(final @Context HttpHeaders httpHeaders,
@@ -479,13 +478,6 @@ public class FileFormatResource implements RESTResource {
         if (serializer == null) {
             return Response.status(Response.Status.UNSUPPORTED_MEDIA_TYPE)
                     .entity("Unsupported media type '" + acceptHeader + "'!").build();
-        }
-
-        if ("text/vnd.openhab.dsl.sitemap".equals(acceptHeader) && (sitemapNames == null || sitemapNames.size() != 1)) {
-            // DSL format only supports one sitemap at a time
-            return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("For media type 'text/vnd.openhab.dsl.sitemap', exactly one sitemap name must be provided!")
-                    .build();
         }
 
         List<Sitemap> sitemaps;
@@ -577,11 +569,6 @@ public class FileFormatResource implements RESTResource {
                             .entity("Unsupported media type '" + acceptHeader + "'!").build();
                 } else if (sitemaps.isEmpty()) {
                     return Response.status(Response.Status.BAD_REQUEST).entity("No sitemaps loaded from input").build();
-                } else if (sitemaps.size() != 1) {
-                    // DSL format only supports one sitemap at a time
-                    return Response.status(Response.Status.BAD_REQUEST).entity(
-                            "For media type 'text/vnd.openhab.dsl.sitemap', the JSON payload must contain exactly one sitemap definition!")
-                            .build();
                 }
                 sitemapSerializer.setSitemapsToBeSerialized(genId, sitemaps);
                 sitemapSerializer.generateFormat(genId, outputStream);

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/ModelParser.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/ModelParser.java
@@ -25,7 +25,7 @@ public interface ModelParser {
     /**
      * Returns the file extensions of the models this parser registers for.
      *
-     * @return file extension of model files
+     * @return file extensions of model files as a comma-separated list
      */
     String getExtension();
 }

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserver.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserver.java
@@ -95,27 +95,35 @@ public class FolderObserver implements WatchService.WatchEventListener {
 
     @Reference(cardinality = ReferenceCardinality.AT_LEAST_ONE, policy = ReferencePolicy.DYNAMIC)
     protected void addModelParser(ModelParser modelParser) {
-        String extension = modelParser.getExtension();
-        logger.debug("Adding parser for '{}' extension", extension);
-        parsers.add(extension);
+        String extensionList = modelParser.getExtension();
+        String extensions[] = extensionList.split(",");
+        for (String extension : extensions) {
+            logger.debug("Adding parser for '{}' extension", extension);
+            parsers.add(extension);
+        }
 
         if (activated) {
-            processIgnoredPaths(extension);
-            readyService.markReady(new ReadyMarker(READYMARKER_TYPE, extension));
-            logger.debug("Marked extension '{}' as ready", extension);
+            for (String extension : extensions) {
+                processIgnoredPaths(extension);
+                readyService.markReady(new ReadyMarker(READYMARKER_TYPE, extension));
+                logger.debug("Marked extension '{}' as ready", extension);
+            }
         } else {
             logger.debug("{} is not yet activated", FolderObserver.class.getSimpleName());
         }
     }
 
     protected void removeModelParser(ModelParser modelParser) {
-        String extension = modelParser.getExtension();
-        logger.debug("Removing parser for '{}' extension", extension);
-        parsers.remove(extension);
+        String extensionList = modelParser.getExtension();
+        String extensions[] = extensionList.split(",");
+        for (String extension : extensions) {
+            logger.debug("Removing parser for '{}' extension", extension);
+            parsers.remove(extension);
 
-        Set<String> removed = modelRepository.removeAllModelsOfType(extension);
-        ignoredPaths
-                .addAll(removed.stream().map(namePathMap::get).filter(Objects::nonNull).collect(Collectors.toSet()));
+            Set<String> removed = modelRepository.removeAllModelsOfType(extension);
+            ignoredPaths.addAll(
+                    removed.stream().map(namePathMap::get).filter(Objects::nonNull).collect(Collectors.toSet()));
+        }
     }
 
     @Activate
@@ -137,6 +145,7 @@ public class FolderObserver implements WatchService.WatchEventListener {
             }
 
             Path folderPath = watchPath.resolve(folderName);
+            logger.debug("Extensions set in config for folder {}: {}", folderName, config.get(folderName));
             Set<String> validExtensions = Set.of(((String) config.get(folderName)).split(","));
             if (Files.exists(folderPath) && Files.isDirectory(folderPath)) {
                 folderFileExtMap.put(folderName, validExtensions);

--- a/bundles/org.openhab.core.model.sitemap.runtime/src/org/openhab/core/model/sitemap/runtime/internal/SitemapRuntimeActivator.java
+++ b/bundles/org.openhab.core.model.sitemap.runtime/src/org/openhab/core/model/sitemap/runtime/internal/SitemapRuntimeActivator.java
@@ -36,6 +36,6 @@ public class SitemapRuntimeActivator implements ModelParser {
 
     @Override
     public String getExtension() {
-        return "sitemap";
+        return "sitemap,sitemaps";
     }
 }

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/GenerateSitemap.mwe2
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/GenerateSitemap.mwe2
@@ -18,7 +18,7 @@ import org.eclipse.xtext.xtext.generator.model.project.*
 var rootPath = ".."
 var projectName = "org.openhab.core.model.sitemap"
 var languageName = "org.openhab.core.model.sitemap.Sitemap"
-var fileExtensions = "sitemap"
+var fileExtensions = "sitemap,sitemaps"
 var encoding = "UTF-8"
 
 Workflow {

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.properties
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.properties
@@ -1,3 +1,3 @@
 grammarURI=classpath:/org/openhab/model/sitemap/Sitemap.xtext
-file.extensions=sitemap
+file.extensions=sitemap,sitemaps
 projectName=org.openhab.core.model.sitemap

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -4,10 +4,10 @@ import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 generate sitemap "https://openhab.org/model/Sitemap"
 
 SitemapModel:
-    'sitemap' ModelSitemap;
+    {SitemapModel} (sitemaps += ModelSitemap)*;
 
 ModelSitemap:
-    name=ID ('label=' label=STRING)? ('icon=' icon=STRING)? '{'
+    'sitemap' name=ID ('label=' label=STRING)? ('icon=' icon=STRING)? '{'
     (children+=ModelWidget)*
     '}';
 

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/internal/DslSitemapProvider.java
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/internal/DslSitemapProvider.java
@@ -14,6 +14,7 @@ package org.openhab.core.model.sitemap.internal;
 
 import static org.openhab.core.model.core.ModelCoreConstants.isIsolatedModel;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +59,7 @@ import org.openhab.core.model.sitemap.sitemap.ModelVisibilityRule;
 import org.openhab.core.model.sitemap.sitemap.ModelVisibilityRuleList;
 import org.openhab.core.model.sitemap.sitemap.ModelWebview;
 import org.openhab.core.model.sitemap.sitemap.ModelWidget;
+import org.openhab.core.model.sitemap.sitemap.SitemapModel;
 import org.openhab.core.sitemap.Button;
 import org.openhab.core.sitemap.ButtonDefinition;
 import org.openhab.core.sitemap.Buttongrid;
@@ -102,7 +104,9 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
         implements SitemapProvider, ModelRepositoryChangeListener {
 
     private static final String SITEMAP_MODEL_NAME = "sitemap";
-    protected static final String SITEMAP_FILEEXT = "." + SITEMAP_MODEL_NAME;
+    private static final String SITEMAP_FILEEXT = "." + SITEMAP_MODEL_NAME;
+    private static final String SITEMAPS_MODEL_NAME = "sitemaps";
+    private static final String SITEMAPS_FILEEXT = "." + SITEMAPS_MODEL_NAME;
     protected static final String MODEL_TYPE_PREFIX = "Model";
 
     private final Logger logger = LoggerFactory.getLogger(DslSitemapProvider.class);
@@ -119,7 +123,9 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
         this.modelRepo = modelRepo;
         this.sitemapRegistry = sitemapRegistry;
         this.sitemapFactory = sitemapFactory;
-        refreshSitemapModels();
+        sitemapCache.clear();
+        refreshSitemapModels(SITEMAP_MODEL_NAME);
+        refreshSitemapModels(SITEMAPS_MODEL_NAME);
         sitemapRegistry.addSitemapProvider(this);
         modelRepo.addModelRepositoryChangeListener(this);
     }
@@ -146,24 +152,26 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
         return sitemapCache.getOrDefault(modelName, List.of()).stream().toList();
     }
 
-    private void refreshSitemapModels() {
-        sitemapCache.clear();
-        Iterable<String> sitemapFilenames = modelRepo.getAllModelNamesOfType(SITEMAP_MODEL_NAME);
-        for (String filename : sitemapFilenames) {
-            ModelSitemap modelSitemap = (ModelSitemap) modelRepo.getModel(filename);
-            if (modelSitemap != null) {
-                sitemapCache.put(filename, parseModelSitemap(modelSitemap));
+    private void refreshSitemapModels(String type) {
+        for (String filename : modelRepo.getAllModelNamesOfType(type)) {
+            EObject model = modelRepo.getModel(filename);
+            if (model instanceof SitemapModel sitemapModel) {
+                List<Sitemap> newSitemaps = new ArrayList<>();
+                for (ModelSitemap modelSitemap : sitemapModel.getSitemaps()) {
+                    newSitemaps.add(parseModelSitemap(modelSitemap));
+                }
+                sitemapCache.put(filename, newSitemaps);
             }
         }
     }
 
-    private Collection<Sitemap> parseModelSitemap(ModelSitemap modelSitemap) {
+    private Sitemap parseModelSitemap(ModelSitemap modelSitemap) {
         Sitemap sitemap = sitemapFactory.createSitemap(modelSitemap.getName());
         sitemap.setLabel(modelSitemap.getLabel());
         sitemap.setIcon(modelSitemap.getIcon());
         List<Widget> widgets = sitemap.getWidgets();
         modelSitemap.getChildren().forEach(child -> addWidget(widgets, child, sitemap));
-        return List.of(sitemap);
+        return sitemap;
     }
 
     private void addWidget(List<Widget> widgets, ModelWidget modelWidget, Parent parent) {
@@ -369,7 +377,7 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
 
     @Override
     public void modelChanged(String modelName, EventType type) {
-        if (!modelName.endsWith(SITEMAP_FILEEXT)) {
+        if (!modelName.endsWith(SITEMAP_FILEEXT) && !modelName.endsWith(SITEMAPS_FILEEXT)) {
             return;
         }
 
@@ -381,10 +389,10 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
                 });
             }
         } else {
-            EObject modelSitemapObject = modelRepo.getModel(modelName);
+            EObject model = modelRepo.getModel(modelName);
             // if the sitemap file is empty it will not be in the repo and thus there is no need to cache it here
-            if (modelSitemapObject instanceof ModelSitemap modelSitemap) {
-                Map<String, Sitemap> newSitemaps = parseModelSitemap(modelSitemap).stream()
+            if (model instanceof SitemapModel sitemapModel) {
+                Map<String, Sitemap> newSitemaps = sitemapModel.getSitemaps().stream().map(this::parseModelSitemap)
                         .collect(Collectors.toMap(Sitemap::getName, Function.identity()));
                 if (!isIsolatedModel(modelName)) {
                     Map<String, Sitemap> oldSitemaps = sitemapCache.getOrDefault(modelName, Set.of()).stream()

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/internal/fileconverter/DslSitemapConverter.java
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/internal/fileconverter/DslSitemapConverter.java
@@ -125,11 +125,10 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
         if (sitemaps.isEmpty()) {
             return;
         }
-        if (sitemaps.size() > 1) {
-            logger.warn("Only one sitemap at a time can be serialized to DSL");
-            return;
+        SitemapModel model = SitemapFactory.eINSTANCE.createSitemapModel();
+        for (Sitemap sitemap : sitemaps) {
+            model.getSitemaps().add(buildModelSitemap(sitemap));
         }
-        SitemapModel model = buildModelSitemap(sitemaps.getFirst());
         elementsToGenerate.put(id, model);
     }
 
@@ -137,7 +136,7 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
     public void generateFormat(String id, OutputStream out) {
         SitemapModel model = elementsToGenerate.remove(id);
         if (model != null) {
-            modelRepository.generateFileFormat(out, "sitemap", model);
+            modelRepository.generateFileFormat(out, "sitemaps", model);
         }
     }
 
@@ -411,7 +410,7 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
     @Override
     public @Nullable String startParsingFormat(String syntax, List<String> errors, List<String> warnings) {
         ByteArrayInputStream inputStream = new ByteArrayInputStream(syntax.getBytes());
-        return modelRepository.createIsolatedModel("sitemap", inputStream, errors, warnings);
+        return modelRepository.createIsolatedModel("sitemaps", inputStream, errors, warnings);
     }
 
     @Override


### PR DESCRIPTION
New file extension ".sitemaps" is added.
A .sitemaps file can contain one or several sitemap definitions. .sitemap extension is kept for backward compatibility.
