### PR TITLE
Serialize row/column as first properties of a Button widget (DSL site…

### DIFF
--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -168,10 +168,10 @@ ModelButtongrid:
     ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelButton:
-    'Button' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
+    'Button' (('row=' row=INT) | ('column=' column=INT) |
+    ('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
     ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
-    ('row=' row=INT) | ('column=' column=INT) | (stateless?='stateless') |
-    ('click=' cmd=Command) | ('release=' releaseCmd=Command) |
+    (stateless?='stateless') | ('click=' cmd=Command) | ('release=' releaseCmd=Command) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |


### PR DESCRIPTION
…map)

The generated buttons before:
```
		Buttongrid item=DemoString buttons=[2:2:HOME="Go Home"=material:home] {
			Button item=DemoSwitch label=Off icon=switch-off row=1 column=1 stateless click=ON visibility=[DemoSwitch != ON]
			Button item=DemoSwitch label=On icon=switch-on row=1 column=1 stateless click=OFF visibility=[DemoSwitch == ON]
			Button item=DemoString label=Start row=1 column=2 stateless click=START
			Button item=DemoString label=Stop row=1 column=3 click=STOP
		}
```

And now:
```
		Buttongrid item=DemoString buttons=[2:2:HOME="Go Home"=material:home] {
			Button row=1 column=1 item=DemoSwitch label=Off icon=switch-off stateless click=ON visibility=[DemoSwitch != ON]
			Button row=1 column=1 item=DemoSwitch label=On icon=switch-on stateless click=OFF visibility=[DemoSwitch == ON]
			Button row=1 column=2 item=DemoString label=Start stateless click=START
			Button row=1 column=3 item=DemoString label=Stop click=STOP
		}
```
