### PR TITLE
Reduce log level for loading/unloading isolated models

### DIFF
--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
@@ -111,7 +111,11 @@ public class ModelRepositoryImpl implements ModelRepository {
 
     public boolean addOrRefreshModel(String name, final InputStream originalInputStream, @Nullable List<String> errors,
             @Nullable List<String> warnings) {
-        logger.info("Loading DSL model '{}'", name);
+        if (isIsolatedModel(name)) {
+            logger.debug("Loading DSL model '{}'", name);
+        } else {
+            logger.info("Loading DSL model '{}'", name);
+        }
         Resource resource = null;
         byte[] bytes;
         try (InputStream inputStream = originalInputStream) {
@@ -183,7 +187,11 @@ public class ModelRepositoryImpl implements ModelRepository {
 
     @Override
     public boolean removeModel(String name) {
-        logger.info("Unloading DSL model '{}'", name);
+        if (isIsolatedModel(name)) {
+            logger.debug("Unloading DSL model '{}'", name);
+        } else {
+            logger.info("Unloading DSL model '{}'", name);
+        }
         return removeResource(name);
     }
 

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -246,9 +246,17 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
             return false;
         }
         if (kind == Kind.CREATE) {
-            logger.info("Adding YAML model {}", modelName);
+            if (isIsolatedModel(modelName)) {
+                logger.debug("Adding YAML model {}", modelName);
+            } else {
+                logger.info("Adding YAML model {}", modelName);
+            }
         } else {
-            logger.info("Updating YAML model {}", modelName);
+            if (isIsolatedModel(modelName)) {
+                logger.debug("Updating YAML model {}", modelName);
+            } else {
+                logger.info("Updating YAML model {}", modelName);
+            }
         }
         JsonNode readOnlyNode = fileContent.get(READ_ONLY);
         boolean readOnly = readOnlyNode == null || readOnlyNode.asBoolean(false);
@@ -354,7 +362,11 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
         if (removedModel == null) {
             return;
         }
-        logger.info("Removing YAML model {}", modelName);
+        if (isIsolatedModel(modelName)) {
+            logger.debug("Removing YAML model {}", modelName);
+        } else {
+            logger.info("Removing YAML model {}", modelName);
+        }
         int version = removedModel.getVersion();
         for (Map.Entry<String, @Nullable JsonNode> modelEntry : removedModel.getNodes().entrySet()) {
             String elementName = modelEntry.getKey();


### PR DESCRIPTION
When copying DSL or YAML models from the UI for items, things or sitemaps, logs are created every time for loading/unloading the isolated temporary model.

This PR reduces the log level for loading/unloading isolated models to debug, keeping it at info level for normal models to reduce noise in the server log.

The log level is kept as is for errors or warning in the parsed code.