### PR TITLE
Update GenericEventTrigger label and requirements

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/GenericTriggers.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/GenericTriggers.json
@@ -2,8 +2,8 @@
 	"triggers": [
 		{
 			"uid": "core.GenericEventTrigger",
-			"label": "Basic Event Trigger",
-			"description": "Triggers Rules on Events",
+			"label": "Generic Event Trigger",
+			"description": "Triggers rules on matching events",
 			"visibility": "HIDDEN",
 			"configDescriptions": [
 				{
@@ -11,7 +11,7 @@
 					"type": "TEXT",
 					"label": "Topic",
 					"description": "the topic, as a file-system style glob (*, ** and {} operators). will match all events if empty",
-					"required": true,
+					"required": false,
 					"default": ""
 				},
 				{
@@ -19,7 +19,7 @@
 					"type": "TEXT",
 					"label": "Source",
 					"description": "the source of the event (e.g. org.openhab.core.expire, etc.). will match all events if empty",
-					"required": true,
+					"required": false,
 					"default": ""
 				},
 				{
@@ -27,7 +27,7 @@
 					"type": "TEXT",
 					"label": "Event Type",
 					"description": "the event type the trigger should listen to. multiple types can be specified comma-separated. will match all events if empty",
-					"required": true,
+					"required": false,
 					"default": ""
 				},
 				{
@@ -35,7 +35,7 @@
 					"type": "TEXT",
 					"label": "Event Payload",
 					"description": "A regex to match the event's serialized payload. will match all events if empty",
-					"required": true,
+					"required": false,
 					"default": ""
 				}
 			],


### PR DESCRIPTION
This fixes the configuration parameters' requirements for `GenericEventTrigger`, so that the UI doesn't require them all to be populated. The trigger itself has no such requirement, and it would probably be rare if all fields were used. They are all filters, so there's a limit to how much filtering might be needed.

I also took the liberty of changing the label from "Basic" to "Generic", both because I think it's more descriptive, and because it matches the actual name of the trigger, making everything less confusing.

Fixes #5542 

Disclaimer: I did this using GitHub so that I don't have to switch branch locally, which means that I don't get to control the sign-off.
