### PR TITLE
model.script.ScriptInterpreter::doEvaluate() - simplify

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/interpreter/ScriptInterpreter.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/interpreter/ScriptInterpreter.xtend
@@ -136,13 +136,10 @@ class ScriptInterpreter extends XbaseInterpreter {
     }
 
     override protected doEvaluate(XExpression expression, IEvaluationContext context, CancelIndicator indicator) {
-        if (expression === null) {
-            return null
-        } else if (expression instanceof QuantityLiteral) {
+        if (expression instanceof QuantityLiteral) {
             return doEvaluate(expression, context, indicator)
-        } else {
-            return super.doEvaluate(expression, context, indicator)
         }
+        return super.doEvaluate(expression, context, indicator)
     }
 
     def  protected  Object doEvaluate(QuantityLiteral literal, IEvaluationContext context, CancelIndicator indicator) {


### PR DESCRIPTION
Parameter `expression` cannot be `null`.

`super.doEvaluate(expression, context, indicator)` does not handle the case `expression == null`, so apparently this can never happen.  Even if expression is `null`, it will be handled by [XbaseInterpreter.doEvaluate()](https://github.com/eclipse-xtext/xtext/blob/70d6b74025a6b717728062ac7651618debebda3b/org.eclipse.xtext.xbase/src/org/eclipse/xtext/xbase/interpreter/impl/XbaseInterpreter.java#L237).

`null` is `XNullLiteral` in Xbase input, and thus not the same as `null` in Java.