### PR TITLE
Fix keyword-identifier collisions in DSL rules

### DIFF
--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/Rules.xtext
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/Rules.xtext
@@ -214,3 +214,11 @@ terminal TIME:
 SIGNED_INT:
 	'-'? INT
 ;
+
+@Override
+ValidID:
+	ID | 'rule' | 'uid' | 'when' | 'or' | 'but' | 'only' | 'and' | 'then' | 'end' |
+	'changed' | 'triggered' | 'from' | 'to' | 'started' |
+	'cron' | 'is' | 'midnight' | 'noon' | 'timeOnly' | 'offset' | 'between' | 'in' |
+	'weekday' | 'weekend' | 'holiday' | 'not' | 'ms' | 'executions'
+;


### PR DESCRIPTION
Fix #5498
