### PR TITLE
Fix registration of sitemap providers to its registry

### DIFF
--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/internal/DslSitemapProvider.java
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/internal/DslSitemapProvider.java
@@ -84,7 +84,6 @@ import org.openhab.core.sitemap.Webview;
 import org.openhab.core.sitemap.Widget;
 import org.openhab.core.sitemap.registry.SitemapFactory;
 import org.openhab.core.sitemap.registry.SitemapProvider;
-import org.openhab.core.sitemap.registry.SitemapRegistry;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -112,28 +111,24 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
     private final Logger logger = LoggerFactory.getLogger(DslSitemapProvider.class);
 
     private final ModelRepository modelRepo;
-    private final SitemapRegistry sitemapRegistry;
     private final SitemapFactory sitemapFactory;
 
     private final Map<String, Collection<Sitemap>> sitemapCache = new ConcurrentHashMap<>();
 
     @Activate
     public DslSitemapProvider(final @Reference ModelRepository modelRepo,
-            final @Reference SitemapRegistry sitemapRegistry, final @Reference SitemapFactory sitemapFactory) {
+            final @Reference SitemapFactory sitemapFactory) {
         this.modelRepo = modelRepo;
-        this.sitemapRegistry = sitemapRegistry;
         this.sitemapFactory = sitemapFactory;
         sitemapCache.clear();
         refreshSitemapModels(SITEMAP_MODEL_NAME);
         refreshSitemapModels(SITEMAPS_MODEL_NAME);
-        sitemapRegistry.addSitemapProvider(this);
         modelRepo.addModelRepositoryChangeListener(this);
     }
 
     @Deactivate
     protected void deactivate() {
         modelRepo.removeModelRepositoryChangeListener(this);
-        sitemapRegistry.removeSitemapProvider(this);
         sitemapCache.clear();
     }
 

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/registry/SitemapRegistryImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/registry/SitemapRegistryImpl.java
@@ -14,10 +14,10 @@ package org.openhab.core.sitemap.internal.registry;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.common.registry.AbstractRegistry;
-import org.openhab.core.common.registry.Provider;
 import org.openhab.core.sitemap.Sitemap;
 import org.openhab.core.sitemap.registry.SitemapProvider;
 import org.openhab.core.sitemap.registry.SitemapRegistry;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -29,17 +29,8 @@ import org.osgi.service.component.annotations.Component;
 @Component(service = SitemapRegistry.class, immediate = true)
 public class SitemapRegistryImpl extends AbstractRegistry<Sitemap, String, SitemapProvider> implements SitemapRegistry {
 
+    @Activate
     public SitemapRegistryImpl() {
-        super(null);
-    }
-
-    @Override
-    public void addSitemapProvider(Provider<Sitemap> provider) {
-        addProvider(provider);
-    }
-
-    @Override
-    public void removeSitemapProvider(Provider<Sitemap> provider) {
-        removeProvider(provider);
+        super(SitemapProvider.class);
     }
 }

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/registry/SitemapRegistry.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/registry/SitemapRegistry.java
@@ -13,7 +13,6 @@
 package org.openhab.core.sitemap.registry;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.core.common.registry.Provider;
 import org.openhab.core.common.registry.Registry;
 import org.openhab.core.sitemap.Sitemap;
 
@@ -25,18 +24,4 @@ import org.openhab.core.sitemap.Sitemap;
  */
 @NonNullByDefault
 public interface SitemapRegistry extends Registry<Sitemap, String> {
-
-    /**
-     * Add a sitemap provider to the registry.
-     *
-     * @param provider
-     */
-    public void addSitemapProvider(Provider<Sitemap> provider);
-
-    /**
-     * Remove a sitemap provider from the registry.
-     *
-     * @param provider
-     */
-    public void removeSitemapProvider(Provider<Sitemap> provider);
 }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -53,7 +53,6 @@ import org.openhab.core.sitemap.Webview;
 import org.openhab.core.sitemap.Widget;
 import org.openhab.core.sitemap.registry.SitemapFactory;
 import org.openhab.core.sitemap.registry.SitemapProvider;
-import org.openhab.core.sitemap.registry.SitemapRegistry;
 import org.openhab.core.ui.components.ManagedSitemapProvider;
 import org.openhab.core.ui.components.RootUIComponent;
 import org.openhab.core.ui.components.UIComponent;
@@ -61,7 +60,6 @@ import org.openhab.core.ui.components.UIComponentRegistry;
 import org.openhab.core.ui.components.UIComponentRegistryFactory;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
@@ -100,20 +98,11 @@ public class UIComponentSitemapProvider extends AbstractProvider<Sitemap>
     private @Nullable UIComponentRegistryFactory componentRegistryFactory;
     private @Nullable UIComponentRegistry sitemapComponentRegistry;
 
-    private final SitemapRegistry sitemapRegistry;
     private final SitemapFactory sitemapFactory;
 
     @Activate
-    public UIComponentSitemapProvider(final @Reference SitemapRegistry sitemapRegistry,
-            final @Reference SitemapFactory sitemapFactory) {
-        this.sitemapRegistry = sitemapRegistry;
+    public UIComponentSitemapProvider(final @Reference SitemapFactory sitemapFactory) {
         this.sitemapFactory = sitemapFactory;
-        sitemapRegistry.addSitemapProvider(this);
-    }
-
-    @Deactivate
-    protected void deactivate() {
-        sitemapRegistry.removeSitemapProvider(this);
     }
 
     @Override


### PR DESCRIPTION
Align with how it is implemented for any other registry/providers.

YAML files containing sitemaps are now properly loaded.
