### PR TITLE
Various YAML fixes

### DIFF
--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/GenericItemProvider.java
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/GenericItemProvider.java
@@ -173,7 +173,7 @@ public class GenericItemProvider extends AbstractProvider<Item>
     }
 
     public Collection<Item> getAllFromModel(String modelName) {
-        return itemsMap.getOrDefault(modelName, List.of());
+        return List.copyOf(itemsMap.getOrDefault(modelName, List.of()));
     }
 
     public Map<String, String> getStateFormattersFromModel(String modelName) {

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/fileconverter/DslItemConverter.java
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/fileconverter/DslItemConverter.java
@@ -17,6 +17,7 @@ import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -305,7 +306,7 @@ public class DslItemConverter extends AbstractItemSerializer implements ItemPars
 
     @Override
     public @Nullable String startParsingFormat(String syntax, List<String> errors, List<String> warnings) {
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(syntax.getBytes());
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(syntax.getBytes(StandardCharsets.UTF_8));
         return modelRepository.createIsolatedModel("items", inputStream, errors, warnings);
     }
 

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/internal/fileconverter/DslSitemapConverter.java
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/internal/fileconverter/DslSitemapConverter.java
@@ -14,6 +14,7 @@ package org.openhab.core.model.sitemap.internal.fileconverter;
 
 import java.io.ByteArrayInputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -389,7 +390,7 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
 
     @Override
     public @Nullable String startParsingFormat(String syntax, List<String> errors, List<String> warnings) {
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(syntax.getBytes());
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(syntax.getBytes(StandardCharsets.UTF_8));
         return modelRepository.createIsolatedModel("sitemaps", inputStream, errors, warnings);
     }
 

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
@@ -89,7 +89,7 @@ class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implement
 
     BundleResolver bundleResolver;
 
-    Map<String, Collection<Thing>> thingsMap = new ConcurrentHashMap
+    Map<String, List<Thing>> thingsMap = new ConcurrentHashMap
 
     List<ThingHandlerFactory> thingHandlerFactories = new CopyOnWriteArrayList<ThingHandlerFactory>()
 
@@ -122,7 +122,7 @@ class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implement
     }
 
     def Collection<Thing> getAllFromModel(String modelName) {
-        thingsMap.getOrDefault(modelName, List.of())
+        List.copyOf(thingsMap.getOrDefault(modelName, List.of()))
     }
 
     def private void createThingsFromModel(String modelName) {

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/fileconverter/DslThingConverter.java
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/fileconverter/DslThingConverter.java
@@ -125,7 +125,7 @@ public class DslThingConverter extends AbstractThingSerializer implements ThingP
             String syntax = new String(outputStream.toByteArray()).replaceAll(":\"([a-zA-Z0-9_][a-zA-Z0-9_-]*)\"",
                     ":$1");
             try {
-                out.write(syntax.getBytes());
+                out.write(syntax.getBytes(StandardCharsets.UTF_8));
             } catch (IOException e) {
                 logger.warn("Exception when writing the generated syntax {}", e.getMessage());
             }

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/config/YamlConfigDescriptionDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/config/YamlConfigDescriptionDTO.java
@@ -56,7 +56,7 @@ public class YamlConfigDescriptionDTO {
     }
 
     /**
-     * Creates a new instance based on the specified {@link ConfiConfigDescriptiongDescriptionParameterGroup}.
+     * Creates a new instance based on the specified {@link ConfigDescription}.
      *
      * @param configDescription the {@link ConfigDescription}.
      */

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/config/YamlConfigDescriptionDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/config/YamlConfigDescriptionDTO.java
@@ -118,7 +118,7 @@ public class YamlConfigDescriptionDTO {
      * Create a new {@link ConfigDescription} from this {@link YamlConfigDescriptionDTO}.
      *
      * @return The new {@link ConfigDescription} instance.
-     * @throws UnsupportedOperationException If {@code url} is {@code null} or invalid.
+     * @throws UnsupportedOperationException If {@code uri} is {@code null} or invalid.
      */
     public @NonNull ConfigDescription map() {
         if (uri == null) {

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/config/YamlConfigDescriptionDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/config/YamlConfigDescriptionDTO.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.model.yaml.internal.config;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
+import org.openhab.core.config.core.ConfigDescriptionParameter;
+import org.openhab.core.config.core.ConfigDescriptionParameterGroup;
+import org.openhab.core.config.core.dto.ConfigDescriptionDTO;
+import org.openhab.core.config.core.dto.ConfigDescriptionParameterDTO;
+import org.openhab.core.config.core.dto.ConfigDescriptionParameterGroupDTO;
+import org.openhab.core.model.yaml.internal.util.ConfigDescriptionParameterGroupsDeserializer;
+import org.openhab.core.model.yaml.internal.util.ConfigDescriptionParametersDeserializer;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * This is a data transfer object used to (de)serialize a {@link ConfigDescription} in a YAML configuration.
+ *
+ * @author Ravi Nadahar - Initial contribution
+ */
+public class YamlConfigDescriptionDTO {
+
+    public String uri;
+    @JsonAlias({ "parameters" })
+    @JsonDeserialize(using = ConfigDescriptionParametersDeserializer.class)
+    public Map<String, YamlConfigDescriptionParameterDTO> params;
+    @JsonAlias({ "parameterGroups" })
+    @JsonDeserialize(using = ConfigDescriptionParameterGroupsDeserializer.class)
+    public Map<String, YamlConfigDescriptionParameterGroupDTO> paramGroups;
+
+    /**
+     * Creates a new instance.
+     */
+    public YamlConfigDescriptionDTO() {
+    }
+
+    /**
+     * Creates a new instance based on the specified {@link ConfiConfigDescriptiongDescriptionParameterGroup}.
+     *
+     * @param configDescription the {@link ConfigDescription}.
+     */
+    public YamlConfigDescriptionDTO(@NonNull ConfigDescription configDescription) {
+        this.uri = toDecodedString(configDescription.getUID());
+        List<@NonNull ConfigDescriptionParameter> fromParams = configDescription.getParameters();
+        if (!fromParams.isEmpty()) {
+            Map<String, YamlConfigDescriptionParameterDTO> params = new LinkedHashMap<>();
+            for (ConfigDescriptionParameter param : fromParams) {
+                params.put(param.getName(), new YamlConfigDescriptionParameterDTO(param));
+            }
+            this.params = params;
+        }
+        List<@NonNull ConfigDescriptionParameterGroup> fromParamGroups = configDescription.getParameterGroups();
+        if (!fromParamGroups.isEmpty()) {
+            Map<String, YamlConfigDescriptionParameterGroupDTO> paramGroups = new LinkedHashMap<>();
+            for (ConfigDescriptionParameterGroup paramGroup : fromParamGroups) {
+                paramGroups.put(paramGroup.getName(), new YamlConfigDescriptionParameterGroupDTO(paramGroup));
+            }
+            this.paramGroups = paramGroups;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(paramGroups, params, uri);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof YamlConfigDescriptionDTO)) {
+            return false;
+        }
+        YamlConfigDescriptionDTO other = (YamlConfigDescriptionDTO) obj;
+        return Objects.equals(paramGroups, other.paramGroups) && Objects.equals(params, other.params)
+                && Objects.equals(uri, other.uri);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder(getClass().getSimpleName()).append(" [");
+        if (uri != null) {
+            builder.append("uri=").append(uri).append(", ");
+        }
+        if (params != null) {
+            builder.append("params=").append(params).append(", ");
+        }
+        if (paramGroups != null) {
+            builder.append("paramGroups=").append(paramGroups);
+        }
+        builder.append("]");
+        return builder.toString();
+    }
+
+    /**
+     * Create a new {@link ConfigDescription} from this {@link YamlConfigDescriptionDTO}.
+     *
+     * @return The new {@link ConfigDescription} instance.
+     * @throws UnsupportedOperationException If {@code url} is {@code null} or invalid.
+     */
+    public @NonNull ConfigDescription map() {
+        if (uri == null) {
+            throw new UnsupportedOperationException("A " + getClass().getSimpleName()
+                    + " without an URI can't be mapped to a ConfigDescription: " + toString());
+        }
+        try {
+            ConfigDescriptionBuilder builder = ConfigDescriptionBuilder.create(URI.create(uri));
+            if (params != null) {
+                for (Entry<String, YamlConfigDescriptionParameterDTO> paramEntry : params.entrySet()) {
+                    builder.withParameter(paramEntry.getValue().map(paramEntry.getKey()));
+                }
+            }
+            if (paramGroups != null) {
+                for (Entry<String, YamlConfigDescriptionParameterGroupDTO> paramGroupEntry : paramGroups.entrySet()) {
+                    builder.withParameterGroup(paramGroupEntry.getValue().map(paramGroupEntry.getKey()));
+                }
+            }
+            return builder.build();
+        } catch (IllegalArgumentException e) {
+            throw new UnsupportedOperationException("A " + getClass().getSimpleName()
+                    + " without a valid URI can't be mapped to a ConfigDescription: " + toString(), e);
+        }
+    }
+
+    /**
+     * Create a new {@link ConfigDescriptionDTO} from this {@link YamlConfigDescriptionDTO}.
+     *
+     * @return The new {@link ConfigDescriptionDTO} instance.
+     */
+    public @NonNull ConfigDescriptionDTO toConfigDescriptionDTO() {
+        ConfigDescriptionDTO result = new ConfigDescriptionDTO();
+        result.uri = uri;
+        if (params != null) {
+            List<ConfigDescriptionParameterDTO> parameters = new ArrayList<>();
+            for (Entry<String, YamlConfigDescriptionParameterDTO> paramEntry : params.entrySet()) {
+                parameters.add(paramEntry.getValue().toConfigDescriptionParameterDTO(paramEntry.getKey()));
+            }
+            result.parameters = parameters;
+        }
+        if (paramGroups != null) {
+            List<ConfigDescriptionParameterGroupDTO> parameterGroups = new ArrayList<>();
+            for (Entry<String, YamlConfigDescriptionParameterGroupDTO> paramGroupEntry : paramGroups.entrySet()) {
+                parameterGroups
+                        .add(paramGroupEntry.getValue().toConfigDescriptionParameterGroupDTO(paramGroupEntry.getKey()));
+            }
+            result.parameterGroups = parameterGroups;
+        }
+        return result;
+    }
+
+    private static String toDecodedString(URI uri) {
+        // Combine these partials because URI.toString() does not decode
+        return uri.getScheme() + ":" + uri.getSchemeSpecificPart();
+    }
+}

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/config/YamlConfigDescriptionParameterDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/config/YamlConfigDescriptionParameterDTO.java
@@ -25,6 +25,7 @@ import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.FilterCriteria;
 import org.openhab.core.config.core.ParameterOption;
+import org.openhab.core.config.core.dto.ConfigDescriptionParameterDTO;
 import org.openhab.core.config.core.dto.FilterCriteriaDTO;
 import org.openhab.core.config.core.dto.ParameterOptionDTO;
 
@@ -32,7 +33,7 @@ import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * This is a data transfer object used to serialize a parameter of a configuration description in a YAML configuration.
+ * This is a data transfer object used to (de)serialize a {@link ConfigDescriptionParameter} in a YAML configuration.
  *
  * @author Ravi Nadahar - Initial contribution
  */
@@ -211,6 +212,71 @@ public class YamlConfigDescriptionParameterDTO {
     }
 
     /**
+     * Create a new {@link ConfigDescriptionParameter} from this {@link YamlConfigDescriptionParameterDTO} using the
+     * specified name.
+     *
+     * @param name the name to use.
+     * @return The new {@link ConfigDescriptionParameter}.
+     */
+    public @NonNull ConfigDescriptionParameter map(@NonNull String name) {
+        ConfigDescriptionParameterBuilder builder = ConfigDescriptionParameterBuilder.create(name, type)
+                .withAdvanced(advanced).withContext(context).withDefault(defaultValue).withDescription(description)
+                .withGroupName(groupName).withLabel(label).withLimitToOptions(limitToOptions).withMaximum(max)
+                .withMinimum(min).withMultiple(multiple).withMultipleLimit(multipleLimit).withPattern(pattern)
+                .withReadOnly(readOnly).withRequired(required).withStepSize(step).withUnit(unit)
+                .withUnitLabel(unitLabel).withVerify(verify);
+        if (filterCriteria != null) {
+            List<FilterCriteria> parameterfilterCriteria = new ArrayList<>(filterCriteria.size());
+            for (FilterCriteriaDTO filterCriterionDto : filterCriteria) {
+                parameterfilterCriteria.add(new FilterCriteria(filterCriterionDto.name, filterCriterionDto.value));
+            }
+            builder.withFilterCriteria(parameterfilterCriteria);
+        }
+        if (options != null) {
+            List<ParameterOption> parameterOptions = new ArrayList<>(options.size());
+            for (ParameterOptionDTO optionDto : options) {
+                parameterOptions.add(new ParameterOption(optionDto.value, optionDto.label));
+            }
+            builder.withOptions(parameterOptions);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Create a new {@link ConfigDescriptionParameterDTO} from this {@link YamlConfigDescriptionParameterDTO} using the
+     * specified name.
+     *
+     * @param name the name to use.
+     * @return The new {@link ConfigDescriptionParameterDTO}.
+     */
+    public @NonNull ConfigDescriptionParameterDTO toConfigDescriptionParameterDTO(@NonNull String name) {
+        ConfigDescriptionParameterDTO result = new ConfigDescriptionParameterDTO();
+        result.name = name;
+        result.type = type;
+        result.context = context;
+        result.defaultValue = defaultValue;
+        result.description = description;
+        result.label = label;
+        result.required = required;
+        result.min = min;
+        result.max = max;
+        result.stepsize = step;
+        result.pattern = pattern;
+        result.readOnly = readOnly;
+        result.multiple = multiple;
+        result.multipleLimit = multipleLimit;
+        result.groupName = groupName;
+        result.advanced = advanced;
+        result.verify = verify;
+        result.limitToOptions = limitToOptions;
+        result.unit = unit;
+        result.unitLabel = unitLabel;
+        result.options = options;
+        result.filterCriteria = filterCriteria;
+        return result;
+    }
+
+    /**
      * Creates a {@link List} of {@link ConfigDescriptionParameter}s from a {@link Map} of parameter names and
      * {@link YamlConfigDescriptionParameterDTO}s, to be used during deserialization.
      *
@@ -221,42 +287,78 @@ public class YamlConfigDescriptionParameterDTO {
     public static @NonNull List<@NonNull ConfigDescriptionParameter> mapConfigDescriptions(
             @NonNull Map<@NonNull String, @NonNull YamlConfigDescriptionParameterDTO> configDescriptionDtos) {
         List<ConfigDescriptionParameter> result = new ArrayList<>(configDescriptionDtos.size());
-        List<FilterCriteriaDTO> filterCriteriaDtos;
-        List<FilterCriteria> filterCriterias;
-        List<ParameterOptionDTO> parameterOptionDtos;
-        List<ParameterOption> parameterOptions;
-        ConfigDescriptionParameterBuilder builder;
-        YamlConfigDescriptionParameterDTO parameterDto;
-        for (Entry<String, YamlConfigDescriptionParameterDTO> parameterEntry : configDescriptionDtos.entrySet()) {
-            parameterDto = parameterEntry.getValue();
-            builder = ConfigDescriptionParameterBuilder.create(parameterEntry.getKey(), parameterDto.type)
-                    .withAdvanced(parameterDto.advanced).withContext(parameterDto.context)
-                    .withDefault(parameterDto.defaultValue).withDescription(parameterDto.description)
-                    .withGroupName(parameterDto.groupName).withLabel(parameterDto.label)
-                    .withLimitToOptions(parameterDto.limitToOptions).withMaximum(parameterDto.max)
-                    .withMinimum(parameterDto.min).withMultiple(parameterDto.multiple)
-                    .withMultipleLimit(parameterDto.multipleLimit).withPattern(parameterDto.pattern)
-                    .withReadOnly(parameterDto.readOnly).withRequired(parameterDto.required)
-                    .withStepSize(parameterDto.step).withUnit(parameterDto.unit).withUnitLabel(parameterDto.unitLabel)
-                    .withVerify(parameterDto.verify);
-            filterCriteriaDtos = parameterDto.filterCriteria;
-            if (filterCriteriaDtos != null) {
-                filterCriterias = new ArrayList<>(filterCriteriaDtos.size());
-                for (FilterCriteriaDTO filterCriteriaDto : filterCriteriaDtos) {
-                    filterCriterias.add(new FilterCriteria(filterCriteriaDto.name, filterCriteriaDto.value));
-                }
-                builder.withFilterCriteria(filterCriterias);
-            }
-            parameterOptionDtos = parameterDto.options;
-            if (parameterOptionDtos != null) {
-                parameterOptions = new ArrayList<>(parameterOptionDtos.size());
-                for (ParameterOptionDTO optionDto : parameterOptionDtos) {
-                    parameterOptions.add(new ParameterOption(optionDto.value, optionDto.label));
-                }
-                builder.withOptions(parameterOptions);
-            }
-            result.add(builder.build());
+        for (@NonNull
+        Entry<@NonNull String, @NonNull YamlConfigDescriptionParameterDTO> parameterEntry : configDescriptionDtos
+                .entrySet()) {
+            result.add(parameterEntry.getValue().map(parameterEntry.getKey()));
         }
         return result;
+    }
+
+    /**
+     * A variant of {@link YamlConfigDescriptionParameterDTO} where it is specified as a array/list element instead of a
+     * map value.
+     */
+    public static class YamlConfigDescriptionParameterListEntryDTO {
+
+        public String name;
+        public String context;
+        @JsonProperty("default")
+        @JsonAlias("defaultValue")
+        public String defaultValue;
+        public String description;
+        public String label;
+        public boolean required;
+        public Type type;
+        public BigDecimal min;
+        public BigDecimal max;
+        @JsonAlias({ "stepsize" })
+        public BigDecimal step;
+        public String pattern;
+        public Boolean readOnly;
+        public Boolean multiple;
+        public Integer multipleLimit;
+        public String groupName;
+        public Boolean advanced;
+        public Boolean verify;
+        public Boolean limitToOptions;
+        public String unit;
+        public String unitLabel;
+
+        public List<ParameterOptionDTO> options;
+        public List<FilterCriteriaDTO> filterCriteria;
+
+        /**
+         * Convert this {@link YamlConfigDescriptionParameterListEntryDTO} to a corresponding
+         * {@link YamlConfigDescriptionParameterDTO), where the name is missing. The name must be handled/kept
+         * independently.
+         *
+         * @return The resulting {@link YamlConfigDescriptionParameterDTO}.
+         */
+        public YamlConfigDescriptionParameterDTO toYamlConfigDescriptionParameterDTO() {
+            YamlConfigDescriptionParameterDTO result = new YamlConfigDescriptionParameterDTO();
+            result.context = context;
+            result.defaultValue = defaultValue;
+            result.description = description;
+            result.label = label;
+            result.required = required;
+            result.type = type;
+            result.min = min;
+            result.max = max;
+            result.step = step;
+            result.pattern = pattern;
+            result.readOnly = readOnly;
+            result.multiple = multiple;
+            result.multipleLimit = multipleLimit;
+            result.groupName = groupName;
+            result.advanced = advanced;
+            result.verify = verify;
+            result.limitToOptions = limitToOptions;
+            result.unit = unit;
+            result.unitLabel = unitLabel;
+            result.options = options;
+            result.filterCriteria = filterCriteria;
+            return result;
+        }
     }
 }

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/config/YamlConfigDescriptionParameterGroupDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/config/YamlConfigDescriptionParameterGroupDTO.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.model.yaml.internal.config;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.openhab.core.config.core.ConfigDescriptionParameterGroup;
+import org.openhab.core.config.core.ConfigDescriptionParameterGroupBuilder;
+import org.openhab.core.config.core.dto.ConfigDescriptionParameterGroupDTO;
+
+/**
+ * This is a data transfer object used to (de)serialize a {@link ConfigDescriptionParameterGroup} in a YAML
+ * configuration.
+ *
+ * @author Ravi Nadahar - Initial contribution
+ */
+public class YamlConfigDescriptionParameterGroupDTO {
+
+    public String context;
+    public Boolean advanced;
+    public String label;
+    public String description;
+
+    /**
+     * Creates a new instance.
+     */
+    public YamlConfigDescriptionParameterGroupDTO() {
+    }
+
+    /**
+     * Creates a new instance based on the specified {@link ConfigDescriptionParameterGroup}.
+     *
+     * @param parameterGroup the {@link ConfigDescriptionParameterGroup}.
+     */
+    public YamlConfigDescriptionParameterGroupDTO(@NonNull ConfigDescriptionParameterGroup parameterGroup) {
+        this.context = parameterGroup.getContext();
+        this.advanced = parameterGroup.isAdvanced();
+        this.label = parameterGroup.getLabel();
+        this.description = parameterGroup.getDescription();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(advanced, context, description, label);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof YamlConfigDescriptionParameterGroupDTO)) {
+            return false;
+        }
+        YamlConfigDescriptionParameterGroupDTO other = (YamlConfigDescriptionParameterGroupDTO) obj;
+        return Objects.equals(advanced, other.advanced) && Objects.equals(context, other.context)
+                && Objects.equals(description, other.description) && Objects.equals(label, other.label);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder(getClass().getSimpleName()).append(" [");
+        if (label != null) {
+            builder.append("label=").append(label);
+        }
+        if (context != null) {
+            builder.append(", ").append("context=").append(context);
+        }
+        if (advanced != null) {
+            builder.append(", ").append("advanced=").append(advanced);
+        }
+        if (description != null) {
+            builder.append(", ").append("description=").append(description);
+        }
+        builder.append("]");
+        return builder.toString();
+    }
+
+    /**
+     * Create a new {@link ConfigDescriptionParameterGroup} from this {@link YamlConfigDescriptionParameterGroupDTO}
+     * using the specified name.
+     *
+     * @param name the name to use.
+     * @return The new {@link ConfigDescriptionParameterGroup}.
+     */
+    public @NonNull ConfigDescriptionParameterGroup map(@NonNull String name) {
+        return ConfigDescriptionParameterGroupBuilder.create(name).withContext(context).withAdvanced(advanced)
+                .withLabel(label).withDescription(description).build();
+    }
+
+    /**
+     * Create a new {@link ConfigDescriptionParameterGroupDTO} from this {@link YamlConfigDescriptionParameterGroupDTO}
+     * using the specified name.
+     *
+     * @param name the name to use.
+     * @return The new {@link ConfigDescriptionParameterGroupDTO}.
+     */
+    public @NonNull ConfigDescriptionParameterGroupDTO toConfigDescriptionParameterGroupDTO(@NonNull String name) {
+        ConfigDescriptionParameterGroupDTO result = new ConfigDescriptionParameterGroupDTO();
+        result.name = name;
+        result.context = context;
+        result.advanced = advanced;
+        result.label = label;
+        result.description = description;
+        return result;
+    }
+
+    /**
+     * A variant of {@link YamlConfigDescriptionParameterGroupDTO} where it is specified as a array/list element instead
+     * of a map value.
+     */
+    public static class YamlConfigDescriptionParameterGroupListEntryDTO {
+
+        public String name;
+        public String context;
+        public Boolean advanced;
+        public String label;
+        public String description;
+
+        /**
+         * Convert this {@link YamlConfigDescriptionParameterGroupListEntryDTO} to a corresponding
+         * {@link YamlConfigDescriptionParameterGroupDTO), where the name is missing. The name must be handled/kept
+         * independently.
+         *
+         * @return The resulting {@link YamlConfigDescriptionParameterGroupDTO}.
+         */
+        public YamlConfigDescriptionParameterGroupDTO toYamlConfigDescriptionParameterGroupDTO() {
+            YamlConfigDescriptionParameterGroupDTO result = new YamlConfigDescriptionParameterGroupDTO();
+            result.context = context;
+            result.advanced = advanced;
+            result.label = label;
+            result.description = description;
+            return result;
+        }
+    }
+}

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/pages/YamlPageDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/pages/YamlPageDTO.java
@@ -20,9 +20,9 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.config.core.dto.ConfigDescriptionDTO;
 import org.openhab.core.model.yaml.YamlElement;
 import org.openhab.core.model.yaml.YamlElementName;
+import org.openhab.core.model.yaml.internal.config.YamlConfigDescriptionDTO;
 import org.openhab.core.model.yaml.internal.util.FlexibleDateDeserializer;
 import org.openhab.core.ui.components.UIComponent;
 
@@ -42,7 +42,7 @@ public class YamlPageDTO implements YamlElement, Cloneable {
     public Map<String, Object> config;
     public Map<String, List<UIComponent>> slots;
     public Set<String> tags;
-    public ConfigDescriptionDTO props;
+    public YamlConfigDescriptionDTO props;
     @JsonDeserialize(using = FlexibleDateDeserializer.class)
     public @Nullable Date timestamp;
 

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/pages/YamlPageProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/pages/YamlPageProvider.java
@@ -154,7 +154,7 @@ public class YamlPageProvider extends AbstractProvider<RootUIComponent>
             page.addTags(dto.tags);
         }
         if (dto.props != null) {
-            page.setProps(dto.props);
+            page.setProps(dto.props.toConfigDescriptionDTO());
         }
         Date timestamp = dto.timestamp;
         if (timestamp != null) {

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/util/ConfigDescriptionParameterGroupsDeserializer.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/util/ConfigDescriptionParameterGroupsDeserializer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.model.yaml.internal.util;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.openhab.core.model.yaml.internal.config.YamlConfigDescriptionParameterGroupDTO;
+import org.openhab.core.model.yaml.internal.config.YamlConfigDescriptionParameterGroupDTO.YamlConfigDescriptionParameterGroupListEntryDTO;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+/**
+ * A Jackson deserializer for a collection of configuration description parameter groups that can be specified in either
+ * array/list or object/map form.
+ *
+ * @author Ravi Nadahar - Initial contribution
+ */
+public class ConfigDescriptionParameterGroupsDeserializer
+        extends StdDeserializer<Map<String, YamlConfigDescriptionParameterGroupDTO>> {
+
+    private static final long serialVersionUID = 1L;
+
+    public ConfigDescriptionParameterGroupsDeserializer() {
+        super(Map.class);
+    }
+
+    @Override
+    public Map<String, YamlConfigDescriptionParameterGroupDTO> deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException {
+        ObjectMapper mapper = (ObjectMapper) p.getCodec();
+
+        if (p.hasToken(JsonToken.START_ARRAY)) {
+            return convertArrayToStandardDTO(
+                    mapper.readValue(p, new TypeReference<List<YamlConfigDescriptionParameterGroupListEntryDTO>>() {
+                    }));
+        }
+
+        return mapper.readValue(p, new TypeReference<Map<String, YamlConfigDescriptionParameterGroupDTO>>() {
+        });
+    }
+
+    private Map<String, YamlConfigDescriptionParameterGroupDTO> convertArrayToStandardDTO(
+            List<YamlConfigDescriptionParameterGroupListEntryDTO> list) {
+        Map<String, YamlConfigDescriptionParameterGroupDTO> result = new LinkedHashMap<>();
+        for (YamlConfigDescriptionParameterGroupListEntryDTO entry : list) {
+            result.put(entry.name, entry.toYamlConfigDescriptionParameterGroupDTO());
+        }
+        return result;
+    }
+}

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/util/ConfigDescriptionParametersDeserializer.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/util/ConfigDescriptionParametersDeserializer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.model.yaml.internal.util;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.openhab.core.model.yaml.internal.config.YamlConfigDescriptionParameterDTO;
+import org.openhab.core.model.yaml.internal.config.YamlConfigDescriptionParameterDTO.YamlConfigDescriptionParameterListEntryDTO;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+/**
+ * A Jackson deserializer for a collection of configuration description parameters that can be specified in either
+ * array/list or object/map form.
+ *
+ * @author Ravi Nadahar - Initial contribution
+ */
+public class ConfigDescriptionParametersDeserializer
+        extends StdDeserializer<Map<String, YamlConfigDescriptionParameterDTO>> {
+
+    private static final long serialVersionUID = 1L;
+
+    public ConfigDescriptionParametersDeserializer() {
+        super(Map.class);
+    }
+
+    @Override
+    public Map<String, YamlConfigDescriptionParameterDTO> deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException {
+        ObjectMapper mapper = (ObjectMapper) p.getCodec();
+
+        if (p.hasToken(JsonToken.START_ARRAY)) {
+            return convertArrayToStandardDTO(
+                    mapper.readValue(p, new TypeReference<List<YamlConfigDescriptionParameterListEntryDTO>>() {
+                    }));
+        }
+
+        return mapper.readValue(p, new TypeReference<Map<String, YamlConfigDescriptionParameterDTO>>() {
+        });
+    }
+
+    private Map<String, YamlConfigDescriptionParameterDTO> convertArrayToStandardDTO(
+            List<YamlConfigDescriptionParameterListEntryDTO> list) {
+        Map<String, YamlConfigDescriptionParameterDTO> result = new LinkedHashMap<>();
+        for (YamlConfigDescriptionParameterListEntryDTO entry : list) {
+            result.put(entry.name, entry.toYamlConfigDescriptionParameterDTO());
+        }
+        return result;
+    }
+}

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/widgets/YamlWidgetDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/widgets/YamlWidgetDTO.java
@@ -20,9 +20,9 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.config.core.dto.ConfigDescriptionDTO;
 import org.openhab.core.model.yaml.YamlElement;
 import org.openhab.core.model.yaml.YamlElementName;
+import org.openhab.core.model.yaml.internal.config.YamlConfigDescriptionDTO;
 import org.openhab.core.model.yaml.internal.util.FlexibleDateDeserializer;
 import org.openhab.core.ui.components.UIComponent;
 
@@ -42,7 +42,7 @@ public class YamlWidgetDTO implements YamlElement, Cloneable {
     public Map<String, Object> config;
     public Map<String, List<UIComponent>> slots;
     public Set<String> tags;
-    public ConfigDescriptionDTO props;
+    public YamlConfigDescriptionDTO props;
     @JsonDeserialize(using = FlexibleDateDeserializer.class)
     public @Nullable Date timestamp;
 

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/widgets/YamlWidgetProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/widgets/YamlWidgetProvider.java
@@ -49,7 +49,7 @@ public class YamlWidgetProvider extends AbstractProvider<RootUIComponent>
 
     private final Logger logger = LoggerFactory.getLogger(YamlWidgetProvider.class);
 
-    private final Map<String, Collection<RootUIComponent>> widgetsMap = new ConcurrentHashMap<>();
+    private final Map<String, List<RootUIComponent>> widgetsMap = new ConcurrentHashMap<>();
 
     @Deactivate
     public void deactivate() {
@@ -69,7 +69,7 @@ public class YamlWidgetProvider extends AbstractProvider<RootUIComponent>
     }
 
     public Collection<RootUIComponent> getAllFromModel(String modelName) {
-        return widgetsMap.getOrDefault(modelName, List.of());
+        return List.copyOf(widgetsMap.getOrDefault(modelName, List.of()));
     }
 
     @Override

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/widgets/YamlWidgetProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/widgets/YamlWidgetProvider.java
@@ -156,7 +156,7 @@ public class YamlWidgetProvider extends AbstractProvider<RootUIComponent>
             widget.addTags(dto.tags);
         }
         if (dto.props != null) {
-            widget.setProps(dto.props);
+            widget.setProps(dto.props.toConfigDescriptionDTO());
         }
         Date timestamp = dto.timestamp;
         if (timestamp != null) {

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/widgets/YamlWidgetProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/widgets/YamlWidgetProvider.java
@@ -68,6 +68,10 @@ public class YamlWidgetProvider extends AbstractProvider<RootUIComponent>
                 .map(name -> widgetsMap.getOrDefault(name, List.of())).flatMap(Collection::stream).toList();
     }
 
+    public Collection<RootUIComponent> getAllFromModel(String modelName) {
+        return widgetsMap.getOrDefault(modelName, List.of());
+    }
+
     @Override
     public Class<YamlWidgetDTO> getElementClass() {
         return YamlWidgetDTO.class;

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/widgets/converter/YamlWidgetParser.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/widgets/converter/YamlWidgetParser.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.model.yaml.internal.widgets.converter;
+
+import java.io.ByteArrayInputStream;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.model.yaml.YamlModelRepository;
+import org.openhab.core.model.yaml.internal.widgets.YamlWidgetProvider;
+import org.openhab.core.ui.components.RootUIComponent;
+import org.openhab.core.ui.components.converter.RootUIComponentParser;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * {@link YamlWidgetParser} is the YAML parser for UI Widget objects.
+ *
+ * @author Ravi Nadahar - Initial contribution
+ */
+@NonNullByDefault
+@Component(immediate = true, service = { RootUIComponentParser.class })
+public class YamlWidgetParser implements RootUIComponentParser {
+
+    private final YamlModelRepository modelRepository;
+    private final YamlWidgetProvider widgetProvider;
+
+    @Activate
+    public YamlWidgetParser(@Reference YamlModelRepository modelRepository,
+            @Reference YamlWidgetProvider widgetProvider) {
+        this.modelRepository = modelRepository;
+        this.widgetProvider = widgetProvider;
+    }
+
+    @Override
+    public String getParserFormat() {
+        return "YAML";
+    }
+
+    @Override
+    public @Nullable String startParsingFormat(String syntax, List<String> errors, List<String> warnings) {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(syntax.getBytes());
+        return modelRepository.createIsolatedModel(inputStream, errors, warnings);
+    }
+
+    @Override
+    public Collection<RootUIComponent> getParsedObjects(String modelName) {
+        return widgetProvider.getAllFromModel(modelName);
+    }
+
+    @Override
+    public void finishParsingFormat(String modelName) {
+        modelRepository.removeIsolatedModel(modelName);
+    }
+}

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/widgets/converter/YamlWidgetParser.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/widgets/converter/YamlWidgetParser.java
@@ -13,6 +13,7 @@
 package org.openhab.core.model.yaml.internal.widgets.converter;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 
@@ -52,7 +53,7 @@ public class YamlWidgetParser implements RootUIComponentParser {
 
     @Override
     public @Nullable String startParsingFormat(String syntax, List<String> errors, List<String> warnings) {
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(syntax.getBytes());
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(syntax.getBytes(StandardCharsets.UTF_8));
         return modelRepository.createIsolatedModel(inputStream, errors, warnings);
     }
 

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/fileconverter/SitemapParser.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/fileconverter/SitemapParser.java
@@ -41,10 +41,13 @@ public interface SitemapParser extends ObjectParser<Sitemap> {
     String startParsingFormat(String syntax, List<String> errors, List<String> warnings);
 
     /**
-     * Get the {@link Sitemap} objects found when parsing the format.
+     * Get a copy of the collection of {@link Sitemap} objects that were found when parsing the format.
      *
      * @param modelName the model name used when parsing.
      * @return The {@link Collection} of {@link Sitemap}s.
+     *
+     * @implNote It's important that a copy of the {@link Collection} is returned, so that invoking
+     *           {@link #finishParsingFormat(String)} doesn't modify the returned result.
      */
     @Override
     Collection<Sitemap> getParsedObjects(String modelName);

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/fileconverter/ThingParser.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/fileconverter/ThingParser.java
@@ -42,10 +42,13 @@ public interface ThingParser extends ObjectParser<Thing> {
     String startParsingFormat(String syntax, List<String> errors, List<String> warnings);
 
     /**
-     * Get the {@link Thing} objects found when parsing the format.
+     * Get a copy of the collection of {@link Thing} objects that were found when parsing the format.
      *
      * @param modelName the model name used when parsing.
      * @return The {@link Collection} of {@link Thing}s.
+     *
+     * @implNote It's important that a copy of the {@link Collection} is returned, so that invoking
+     *           {@link #finishParsingFormat(String)} doesn't modify the returned result.
      */
     @Override
     Collection<Thing> getParsedObjects(String modelName);

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/converter/RootUIComponentParser.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/converter/RootUIComponentParser.java
@@ -16,10 +16,9 @@ import java.util.Collection;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.ui.components.RootUIComponent;
-import org.openhab.core.ui.components.UIComponent;
 
 /**
- * {@link RootUIComponentParser} is the interface to implement by any format parser for {@link RootUIComponentParser}
+ * {@link RootUIComponentParser} is the interface to implement by any format parser for {@link RootUIComponent}
  * objects.
  *
  * @author Ravi Nadahar - Initial contribution
@@ -31,7 +30,7 @@ public interface RootUIComponentParser extends UIComponentParser {
      * Get a copy of the collection of {@link RootUIComponent} objects that were found when parsing the format.
      *
      * @param modelName the model name used when parsing.
-     * @return The {@link Collection} of {@link UIComponent}s.
+     * @return The {@link Collection} of {@link RootUIComponent}s.
      *
      * @implNote It's important that a copy of the {@link Collection} is returned, so that invoking
      *           {@link #finishParsingFormat(String)} doesn't modify the returned result.

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/converter/RootUIComponentParser.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/converter/RootUIComponentParser.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.ui.components.converter;
+
+import java.util.Collection;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.ui.components.RootUIComponent;
+import org.openhab.core.ui.components.UIComponent;
+
+/**
+ * {@link RootUIComponentParser} is the interface to implement by any format parser for {@link RootUIComponentParser}
+ * objects.
+ *
+ * @author Ravi Nadahar - Initial contribution
+ */
+@NonNullByDefault
+public interface RootUIComponentParser extends UIComponentParser {
+
+    /**
+     * Get the {@link RootUIComponent} objects that were found when parsing the format.
+     *
+     * @param modelName the model name used when parsing.
+     * @return The {@link Collection} of {@link UIComponent}s.
+     */
+    @Override
+    Collection<? extends RootUIComponent> getParsedObjects(String modelName);
+}

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/converter/RootUIComponentParser.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/converter/RootUIComponentParser.java
@@ -28,10 +28,13 @@ import org.openhab.core.ui.components.UIComponent;
 public interface RootUIComponentParser extends UIComponentParser {
 
     /**
-     * Get the {@link RootUIComponent} objects that were found when parsing the format.
+     * Get a copy of the collection of {@link RootUIComponent} objects that were found when parsing the format.
      *
      * @param modelName the model name used when parsing.
      * @return The {@link Collection} of {@link UIComponent}s.
+     *
+     * @implNote It's important that a copy of the {@link Collection} is returned, so that invoking
+     *           {@link #finishParsingFormat(String)} doesn't modify the returned result.
      */
     @Override
     Collection<? extends RootUIComponent> getParsedObjects(String modelName);

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/converter/UIComponentParser.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/converter/UIComponentParser.java
@@ -41,10 +41,13 @@ public interface UIComponentParser extends ObjectParser<UIComponent> {
     String startParsingFormat(String syntax, List<String> errors, List<String> warnings);
 
     /**
-     * Get the {@link UIComponent} objects that were found when parsing the format.
+     * Get a copy of the collection of {@link UIComponent} objects that were found when parsing the format.
      *
      * @param modelName the model name used when parsing.
      * @return The {@link Collection} of {@link UIComponent}s.
+     *
+     * @implNote It's important that a copy of the {@link Collection} is returned, so that invoking
+     *           {@link #finishParsingFormat(String)} doesn't modify the returned result.
      */
     @Override
     Collection<? extends UIComponent> getParsedObjects(String modelName);

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/converter/UIComponentParser.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/converter/UIComponentParser.java
@@ -10,54 +10,42 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.converter;
+package org.openhab.core.ui.components.converter;
 
 import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.converter.ObjectParser;
+import org.openhab.core.ui.components.UIComponent;
 
 /**
- * A generic interface for parsers that parse strings into specific object types like Things, Items, Rules etc.
- *
- * @param <T> The object type.
+ * {@link UIComponentParser} is the interface to implement by any format parser for {@link UIComponent} objects.
  *
  * @author Ravi Nadahar - Initial contribution
  */
 @NonNullByDefault
-public interface ObjectParser<T> {
+public interface UIComponentParser extends ObjectParser<UIComponent> {
 
     /**
-     * Get the name of the format.
-     *
-     * @return The format name.
-     */
-    String getParserFormat();
-
-    /**
-     * Parse the provided syntax in format without impacting any object registries.
+     * Parse the provided {@code syntax} string without impacting the model.
      *
      * @param syntax the syntax in format.
      * @param errors the {@link List} to use to report errors.
      * @param warnings the {@link List} to be used to report warnings.
      * @return The model name used for parsing if the parsing succeeded without errors; {@code null} otherwise.
      */
+    @Override
     @Nullable
     String startParsingFormat(String syntax, List<String> errors, List<String> warnings);
 
     /**
-     * Get the objects found when parsing the format.
+     * Get the {@link UIComponent} objects that were found when parsing the format.
      *
-     * @param modelName the model name whose objects to get.
-     * @return The {@link Collection} of objects.
+     * @param modelName the model name used when parsing.
+     * @return The {@link Collection} of {@link UIComponent}s.
      */
-    Collection<? extends T> getParsedObjects(String modelName);
-
-    /**
-     * Release the resources from a previously started format parsing.
-     *
-     * @param modelName the model name whose resources to release.
-     */
-    void finishParsingFormat(String modelName);
+    @Override
+    Collection<? extends UIComponent> getParsedObjects(String modelName);
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/converter/ObjectParser.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/converter/ObjectParser.java
@@ -47,10 +47,13 @@ public interface ObjectParser<T> {
     String startParsingFormat(String syntax, List<String> errors, List<String> warnings);
 
     /**
-     * Get the objects found when parsing the format.
+     * Get a copy of the collection of objects that were found when parsing the format.
      *
      * @param modelName the model name whose objects to get.
      * @return The {@link Collection} of objects.
+     *
+     * @implNote It's important that a copy of the {@link Collection} is returned, so that invoking
+     *           {@link #finishParsingFormat(String)} doesn't modify the returned result.
      */
     Collection<? extends T> getParsedObjects(String modelName);
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/fileconverter/ItemParser.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/fileconverter/ItemParser.java
@@ -43,10 +43,13 @@ public interface ItemParser extends ObjectParser<Item> {
     String startParsingFormat(String syntax, List<String> errors, List<String> warnings);
 
     /**
-     * Get the {@link Item} objects found when parsing the format.
+     * Get a copy of the collection {@link Item} objects that were found when parsing the format.
      *
      * @param modelName the model name used when parsing.
      * @return The {@link Collection} of {@link Item}s.
+     *
+     * @implNote It's important that a copy of the {@link Collection} is returned, so that invoking
+     *           {@link #finishParsingFormat(String)} doesn't modify the returned result.
      */
     @Override
     Collection<Item> getParsedObjects(String modelName);


### PR DESCRIPTION
While working on an upcoming PR to handle "the new YAML format" from the community marketplace, I encountered some issues with the current implementation:

* The Widget (and UI Page) YAML definitions use DTOs made for GSON, not Jackson, which leads to annotations not working, among other things. Importing example widgets of mine therefore failed, e.g. because `default` isn't mapped to `defaultValue`.
* The "list/array" form of the configuration description parameters is inconsistent with the way they are specified in rule templates (where they have "map/object" form). That's very confusing when it is in fact the same data otherwise.
* `ObjectParser.getParsedObjects()` returns a collection that is "unstable" from all but one implementation, which means that when `finishParsingFormat()` is called, the already retrieved collection is magically emptied (because it's linked to the underlyinig `Map`). This is very impractical, and surprising, when parsing.

I've addressed all these issues in the PR. I've created new YAML specific DTOs `YamlConfigDescriptionDTO` and `YamlConfigDescriptionParameterGroupDTO`. `YamlConfigDescriptionDTO` can deserialize parameter and parameter groups in either "list/array" or "map/object" form, but will serialize to "map/object" form. I've replaced the DTOs used for configuration description for both UI Widgets and UI Pages with this new implementation.

I've created a `YamlWidgetParser`, which is one step on the way to fully integrate UI Widgets in the REST API "file conversion" endpoints. I did not make the serialization part because I don't need it for the marketplace handling, and I don't know whether there are pitfalls there that I'm not familiar with.

It should be said that there are some "holes" in the logic regarding `UIComponent`s and `RootUIComponent`s. Currently, a `RootUIComponent` is just a `UIComponent` that supports a configuration. It makes no sense to me, it should rather be a `ConfigurableUIComponent` or similar, if at all needed. Perhaps all `UIComponent` implementations could support having a configuration, I don't really know the consequences. In addition, there are no "implementation types" here, so "everything" is pretty much a `RootUIComponent`. That means that we can't differentiate, and the current `widget:` tag can, as far as I can tell, be used to import all kind of UI components. Whether that "loophole" matters or not, I don't know, but it's there anyway.

Finally, I tried to make sure that `ObjectParser.getParsedObjects()` don't return live views, and create copies instead. I've also added JavaDoc comments to try to make it clear that future implementations should do the same.