### PR TITLE
Sitemap DTO fix backward compatibility

### DIFF
--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
@@ -746,22 +746,22 @@ public class SitemapResource
             }
         }
         if (widget instanceof Switch switchWidget) {
-            bean.mappings = switchWidget.getMappings().stream().map(mapping -> {
+            bean.mappings.addAll(switchWidget.getMappings().stream().map(mapping -> {
                 MappingDTO mappingBean = new MappingDTO();
                 mappingBean.command = mapping.getCmd();
                 mappingBean.releaseCommand = mapping.getReleaseCmd();
                 mappingBean.label = mapping.getLabel();
                 mappingBean.icon = mapping.getIcon();
                 return mappingBean;
-            }).toList();
+            }).toList());
         }
         if (widget instanceof Selection selectionWidget) {
-            bean.mappings = selectionWidget.getMappings().stream().map(mapping -> {
+            bean.mappings.addAll(selectionWidget.getMappings().stream().map(mapping -> {
                 MappingDTO mappingBean = new MappingDTO();
                 mappingBean.command = mapping.getCmd();
                 mappingBean.label = mapping.getLabel();
                 return mappingBean;
-            }).toList();
+            }).toList());
         }
         if (widget instanceof Input inputWidget) {
             bean.inputHint = inputWidget.getInputHint();

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
@@ -53,12 +53,13 @@ public class WidgetDTO extends AbstractWidgetDTO {
     public EnrichedItemDTO item;
     public PageDTO linkedPage;
 
-    // only for frames and button grids, other linkable widgets link to a page
-    public final List<WidgetDTO> widgets = new ArrayList<>();
-
-    // Kept for backward compatibility with legacy sitemap clients (specifically legacy iOS app)
-    public String name; // Not used
-    public final List<MappingDTO> mappings = new ArrayList<>(); // Legacy clients may expect field to be non-null
+    // Kept for backward compatibility with legacy sitemap clients (specifically legacy iOS app).
+    // Legacy sitemap clients expect a non-empty widgets and mappings array, even if the widget has no child widgets and
+    // no mappings. This should be considered a workaround and should be removed in the future when legacy sitemap
+    // clients are no longer supported.
+    public final List<WidgetDTO> widgets = new ArrayList<>(); // only for frames and button grids, other linkable
+                                                              // widgets link to a page
+    public final List<MappingDTO> mappings = new ArrayList<>();
 
     public WidgetDTO() {
     }

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.openhab.core.io.rest.core.item.EnrichedItemDTO;
 import org.openhab.core.sitemap.dto.AbstractWidgetDTO;
+import org.openhab.core.sitemap.dto.MappingDTO;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -54,6 +55,10 @@ public class WidgetDTO extends AbstractWidgetDTO {
 
     // only for frames and button grids, other linkable widgets link to a page
     public final List<WidgetDTO> widgets = new ArrayList<>();
+
+    // Kept for backward compatibility with legacy sitemap clients (specifically legacy iOS app)
+    public String name; // Not used
+    public final List<MappingDTO> mappings = new ArrayList<>(); // Legacy clients may expect field to be non-null
 
     public WidgetDTO() {
     }

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/AbstractWidgetDTO.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/AbstractWidgetDTO.java
@@ -13,7 +13,6 @@
 package org.openhab.core.sitemap.dto;
 
 import java.math.BigDecimal;
-import java.util.List;
 
 /**
  * This is a data transfer object that is used to serialize widgets.
@@ -41,7 +40,6 @@ public abstract class AbstractWidgetDTO {
     public Boolean staticIcon;
 
     // widget-specific attributes
-    public List<MappingDTO> mappings;
     public Boolean switchSupport;
     public Boolean releaseOnly;
     public Integer refresh;

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/WidgetDefinitionDTO.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/WidgetDefinitionDTO.java
@@ -26,6 +26,8 @@ public class WidgetDefinitionDTO extends AbstractWidgetDTO {
 
     public String item;
 
+    public List<MappingDTO> mappings;
+
     public List<RuleDTO> visibilityRules;
     public List<RuleDTO> iconRules;
     public List<RuleDTO> labelColorRules;


### PR DESCRIPTION
See https://github.com/openhab/openhab-core/pull/5459#issuecomment-4524475505
See https://community.openhab.org/t/openhab-5-2-milestone-discussion/168410/140?u=mherwege

This puts the mappings and name fields back in the DTO for all widgets for backward compatibility.

I did not fully test this but I expect this to solve the issue.

I leave this as a draft until we establish this is absolutely needed.

@lolodomo FYI