### PR TITLE
Fix handling of DSL .script files at openHAB startup

### DIFF
--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
@@ -227,6 +227,7 @@ public class ModelRepositoryImpl implements ModelRepository {
 
     @Override
     public void reloadAllModelsOfType(final String modelType) {
+        logger.debug("reloadAllModelsOfType {}", modelType);
         synchronized (resourceSet) {
             // Make a copy to avoid ConcurrentModificationException
             List<Resource> resourceListCopy = new ArrayList<>(resourceSet.getResources());

--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
@@ -179,6 +179,7 @@ public class DSLRuleProvider
         List<Rule> oldRules;
         List<Rule> newRules = new ArrayList<>();
         if ("rules".equalsIgnoreCase(ruleModelType)) {
+            logger.debug("modelChanged {} {}", type, modelFileName);
             boolean isolated = isIsolatedModel(modelFileName);
             String ruleModelName = modelFileName.substring(0, modelFileName.lastIndexOf("."));
             switch (type) {
@@ -231,6 +232,7 @@ public class DSLRuleProvider
                     logger.debug("Unknown event type.");
             }
         } else if ("script".equals(ruleModelType)) {
+            logger.debug("modelChanged {} {}", type, modelFileName);
             switch (type) {
                 case ADDED:
                 case MODIFIED:
@@ -590,7 +592,20 @@ public class DSLRuleProvider
 
     @Override
     public void onReadyMarkerAdded(ReadyMarker readyMarker) {
+        for (String modelFileName : modelRepository.getAllModelNamesOfType("script")) {
+            logger.debug("onReadyMarkerAdded handle script {}", modelFileName);
+            EObject model = modelRepository.getModel(modelFileName);
+            if (model instanceof Script script) {
+                boolean isolated = isIsolatedModel(modelFileName);
+                List<Rule> newRules = List.of(toRule(modelFileName, script));
+                List<Rule> oldRules = rulesMap.put(modelFileName, newRules);
+                if (!isolated) {
+                    notifyProviderChangeListeners(calcChanges(modelFileName, oldRules, newRules));
+                }
+            }
+        }
         for (String modelFileName : modelRepository.getAllModelNamesOfType("rules")) {
+            logger.debug("onReadyMarkerAdded handle rule {}", modelFileName);
             EObject model = modelRepository.getModel(modelFileName);
             if (model instanceof RuleModel ruleModel) {
                 boolean isolated = isIsolatedModel(modelFileName);


### PR DESCRIPTION
The DSL Rule provider must handle rules and scripts in onReadyMarkerAdded.
Until now, only .rules files were handled, not .script files. As a result, .script files were ignored by the rule provider.
Sometimes it worked well because there was a call to reloadAllModelsOfType for all scripts when the rule provider was ready and the .script files were then handled by the provider in modelChanged.
If this last call was done while the rule provider was not yet ready, the .script files were ignored because the rule provider was not yet setup to handle model changes.
So all of this depends on timing conditions at openHAB startup.
With that change, the .script files will always be considered by the DSL rule provider.
