### PR TITLE
rule.runtime.RuleRuntimeActivator: use one activator method

### DIFF
--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/RuleRuntimeActivator.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/RuleRuntimeActivator.java
@@ -17,11 +17,9 @@ import org.openhab.core.model.core.ModelParser;
 import org.openhab.core.model.rule.RulesStandaloneSetup;
 import org.openhab.core.model.script.ScriptServiceUtil;
 import org.openhab.core.model.script.engine.ScriptEngine;
-import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -33,20 +31,11 @@ import org.slf4j.LoggerFactory;
 @Component(immediate = true, service = { ModelParser.class, RuleRuntimeActivator.class })
 public class RuleRuntimeActivator implements ModelParser {
 
-    private final Logger logger = LoggerFactory.getLogger(RuleRuntimeActivator.class);
-    private final ScriptServiceUtil scriptServiceUtil;
-    private final ScriptEngine scriptEngine;
-
     @Activate
     public RuleRuntimeActivator(final @Reference ScriptEngine scriptEngine,
             final @Reference ScriptServiceUtil scriptServiceUtil) {
-        this.scriptEngine = scriptEngine;
-        this.scriptServiceUtil = scriptServiceUtil;
-    }
-
-    public void activate(BundleContext bc) throws Exception {
         RulesStandaloneSetup.doSetup(scriptServiceUtil, scriptEngine);
-        logger.debug("Registered 'rule' configuration parser");
+        LoggerFactory.getLogger(RuleRuntimeActivator.class).debug("Registered 'rule' configuration parser");
     }
 
     public void deactivate() throws Exception {


### PR DESCRIPTION
Before this change the component org.openhab.core.model.rule.runtime.internal.RuleRuntimeActivator had two activators - two methods, which were executed, when the bundle was loaded.
    
https://docs.osgi.org/specification/osgi.cmpn/7.0.0/service.component.html#d0e36881 says that a method with signature `void activate(BundleContext context)` is “is virtually identical to a Bundle Activator” in immediate components.  The constructor of RuleRuntimeActivator has @Activator annotation. So there were two activators, where one is sufficient.
    
Before and after this change, in both cases after cleaning the cache, the rule:
```
rule a
when
  System reached start level 100
then
  var l = org.openhab.core.model.script.ScriptServiceUtil.itemRegistry
  var i = org.openhab.core.model.script.ScriptServiceUtil.instance
  logError("U", l.toString + " " + i)
end
```
prints
```
2026-05-25 07:20:48.557 [ERROR] [org.openhab.core.model.script.U     ] - org.openhab.core.internal.items.ItemRegistryImpl@b95faed org.openhab.core.model.script.ScriptServiceUtil@3c3a35f9
```

The class variable `logger` is removed, as it is used only once in the constructor, and after the class is constructed the reference to the logger can be recycled by the GC.
