### PR TITLE
rule.runtime.internal.RuleRuntimeActivator: do not expose unused OSGI service `RuleRuntimeActivator.class`

### DIFF
--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/RuleRuntimeActivator.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/RuleRuntimeActivator.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - Initial contribution
  */
 @NonNullByDefault
-@Component(immediate = true, service = { ModelParser.class, RuleRuntimeActivator.class })
+@Component(immediate = true)
 public class RuleRuntimeActivator implements ModelParser {
 
     private final Logger logger = LoggerFactory.getLogger(RuleRuntimeActivator.class);


### PR DESCRIPTION
The default value of `@Component(services=…)` are all immediately implemented interfaces:

https://docs.osgi.org/specification/osgi.cmpn/7.0.0/service.component.html#org.osgi.service.component.annotations.Component 112.13.4.2: if services is not specified, the service types for this Component are all the directly implemented interfaces of the class being annotated.

The service `RuleRuntimeActivator.class` is not used from anywhere, so there is no need to expose it. After this change only the service ModelParser is offered by component RuleRuntimeActivator.