### PR TITLE
model.script.ScriptItemRefresher: do not expose itself as unused service

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptItemRefresher.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptItemRefresher.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * @author Oliver Libutzki - Initial contribution
  * @author Kai Kreuzer - added delayed execution
  */
-@Component(service = ScriptItemRefresher.class, immediate = true)
+@Component(service = {})
 public class ScriptItemRefresher implements ItemRegistryChangeListener {
 
     private final Logger logger = LoggerFactory.getLogger(ScriptItemRefresher.class);


### PR DESCRIPTION
The OSGI service ScriptItemRefresher.class is not used by openHAB - it is not referenced from anywhere.  When a component has no services, then it is implied that the component is `immediate = true`: 

https://docs.osgi.org/specification/osgi.cmpn/7.0.0/service.component.html#org.osgi.service.component.annotations.Component 12.13.4.6.:

> **boolean immediate**
> If not specified, the default is false if the factory() property is specified or the service() property is not specified or specified with a non-empty value and true otherwise. 
