### PR TITLE
[DSL] Make context information available for rules/scripts

### DIFF
--- a/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
+++ b/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
@@ -13,7 +13,6 @@
 package org.openhab.core.model.script.runtime.internal.engine;
 
 import java.io.Reader;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -183,20 +182,21 @@ public class DSLScriptEngine implements javax.script.ScriptEngine {
             }
         }
 
-        Map<String, Object> ctx = new LinkedHashMap<>();
+        Map<String, @Nullable Object> ctx = new LinkedHashMap<>();
         Event eventObject = null;
-        Map<String, Map<String, Object>> inputs = new HashMap<>();
+        Map<String, Map<String, @Nullable Object>> inputs = new LinkedHashMap<>();
         Object ctxObject = context.getAttribute("ctx");
         if (ctxObject instanceof Map<?, ?> untypedCtx) {
             String stem;
             Matcher m;
-            Map<String, Object> map;
+            Map<String, @Nullable Object> map;
             Object value;
             for (Entry<?, ?> entry : untypedCtx.entrySet()) {
-                if (entry.getKey() instanceof String key && (value = entry.getValue()) != null) {
+                if (entry.getKey() instanceof String key) {
+                    value = entry.getValue();
                     if (key.indexOf('.') >= 0 && (m = KEY_SPLITTER.matcher(key)).matches()) {
                         map = Objects.requireNonNull(
-                                inputs.compute(m.group("prefix"), (k, v) -> v == null ? new HashMap<>() : v));
+                                inputs.compute(m.group("prefix"), (k, v) -> v == null ? new LinkedHashMap<>() : v));
                         map.put(stem = m.group("stem"), value);
                         if ("event".equals(stem) && value instanceof Event ev) {
                             eventObject = ev;

--- a/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
+++ b/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
@@ -185,7 +185,7 @@ public class DSLScriptEngine implements javax.script.ScriptEngine {
 
         Map<String, Object> ctx = new LinkedHashMap<>();
         Event eventObject = null;
-        Map<String, Map<String, Object>> modulesInputs = new HashMap<>();
+        Map<String, Map<String, Object>> inputs = new HashMap<>();
         Object ctxObject = context.getAttribute("ctx");
         if (ctxObject instanceof Map<?, ?> untypedCtx) {
             String stem;
@@ -196,7 +196,7 @@ public class DSLScriptEngine implements javax.script.ScriptEngine {
                 if (entry.getKey() instanceof String key && (value = entry.getValue()) != null) {
                     if (key.indexOf('.') >= 0 && (m = KEY_SPLITTER.matcher(key)).matches()) {
                         map = Objects.requireNonNull(
-                                modulesInputs.compute(m.group("prefix"), (k, v) -> v == null ? new HashMap<>() : v));
+                                inputs.compute(m.group("prefix"), (k, v) -> v == null ? new HashMap<>() : v));
                         map.put(stem = m.group("stem"), value);
                         if ("event".equals(stem) && value instanceof Event ev) {
                             eventObject = ev;
@@ -210,7 +210,7 @@ public class DSLScriptEngine implements javax.script.ScriptEngine {
         }
         evalContext.newValue(QualifiedName.create("ctx"), ctx);
         evalContext.newValue(QualifiedName.create("eventObject"), eventObject);
-        evalContext.newValue(QualifiedName.create("modulesInputs"), modulesInputs);
+        evalContext.newValue(QualifiedName.create("inputs"), inputs);
 
         Map<String, Object> cachePreset = scriptExtensionAccessor.findPreset("cache",
                 (String) context.getAttribute("oh.engine-identifier", ScriptContext.ENGINE_SCOPE));

--- a/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
+++ b/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
@@ -13,8 +13,14 @@
 package org.openhab.core.model.script.runtime.internal.engine;
 
 import java.io.Reader;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.script.Bindings;
 import javax.script.ScriptContext;
@@ -32,6 +38,7 @@ import org.eclipse.xtext.xbase.XExpression;
 import org.eclipse.xtext.xbase.interpreter.IEvaluationContext;
 import org.eclipse.xtext.xbase.interpreter.impl.DefaultEvaluationContext;
 import org.openhab.core.automation.module.script.ScriptExtensionAccessor;
+import org.openhab.core.events.Event;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.events.ItemEvent;
 import org.openhab.core.model.script.engine.Script;
@@ -71,6 +78,8 @@ public class DSLScriptEngine implements javax.script.ScriptEngine {
             "triggeringItem", ScriptJvmModelInferrer.VAR_TRIGGERING_ITEM, //
             "triggeringGroup", ScriptJvmModelInferrer.VAR_TRIGGERING_GROUP, //
             "input", ScriptJvmModelInferrer.VAR_INPUT);
+
+    private static final Pattern KEY_SPLITTER = Pattern.compile("(?<prefix>[^.]+)\\.(?<stem>.+)");
 
     private final Logger logger = LoggerFactory.getLogger(DSLScriptEngine.class);
 
@@ -174,6 +183,35 @@ public class DSLScriptEngine implements javax.script.ScriptEngine {
             }
         }
 
+        Map<String, Object> ctx = new LinkedHashMap<>();
+        Event eventObject = null;
+        Map<String, Map<String, Object>> modulesInputs = new HashMap<>();
+        Object ctxObject = context.getAttribute("ctx");
+        if (ctxObject instanceof Map<?, ?> untypedCtx) {
+            String stem;
+            Matcher m;
+            Map<String, Object> map;
+            Object value;
+            for (Entry<?, ?> entry : untypedCtx.entrySet()) {
+                if (entry.getKey() instanceof String key && (value = entry.getValue()) != null) {
+                    if (key.indexOf('.') >= 0 && (m = KEY_SPLITTER.matcher(key)).matches()) {
+                        map = Objects.requireNonNull(
+                                modulesInputs.compute(m.group("prefix"), (k, v) -> v == null ? new HashMap<>() : v));
+                        map.put(stem = m.group("stem"), value);
+                        if ("event".equals(stem) && value instanceof Event ev) {
+                            eventObject = ev;
+                        }
+                    } else if ("event".equals(key) && value instanceof Event ev) {
+                        eventObject = ev;
+                    }
+                    ctx.put(key, value);
+                }
+            }
+        }
+        evalContext.newValue(QualifiedName.create("ctx"), ctx);
+        evalContext.newValue(QualifiedName.create("eventObject"), eventObject);
+        evalContext.newValue(QualifiedName.create("modulesInputs"), modulesInputs);
+
         Map<String, Object> cachePreset = scriptExtensionAccessor.findPreset("cache",
                 (String) context.getAttribute("oh.engine-identifier", ScriptContext.ENGINE_SCOPE));
         evalContext.newValue(QualifiedName.create(ScriptJvmModelInferrer.VAR_SHARED_CACHE),
@@ -181,13 +219,13 @@ public class DSLScriptEngine implements javax.script.ScriptEngine {
         evalContext.newValue(QualifiedName.create(ScriptJvmModelInferrer.VAR_PRIVATE_CACHE),
                 cachePreset.get("privateCache"));
         // now add specific implicit vars, where we have to map the right content
-        Object value = context.getAttribute(OUTPUT_EVENT);
-        if (value instanceof ChannelTriggeredEvent event) {
+        ctxObject = context.getAttribute(OUTPUT_EVENT);
+        if (ctxObject instanceof ChannelTriggeredEvent event) {
             evalContext.newValue(QualifiedName.create(ScriptJvmModelInferrer.VAR_RECEIVED_EVENT), event.getEvent());
             evalContext.newValue(QualifiedName.create(ScriptJvmModelInferrer.VAR_TRIGGERING_CHANNEL),
                     event.getChannel().getAsString());
         }
-        if (value instanceof ItemEvent event) {
+        if (ctxObject instanceof ItemEvent event) {
             evalContext.newValue(QualifiedName.create(ScriptJvmModelInferrer.VAR_TRIGGERING_ITEM_NAME),
                     event.getItemName());
             Object group = context.getAttribute(ScriptJvmModelInferrer.VAR_TRIGGERING_GROUP);
@@ -196,7 +234,7 @@ public class DSLScriptEngine implements javax.script.ScriptEngine {
                         groupItem.getName());
             }
         }
-        if (value instanceof ThingStatusInfoChangedEvent event) {
+        if (ctxObject instanceof ThingStatusInfoChangedEvent event) {
             evalContext.newValue(QualifiedName.create(ScriptJvmModelInferrer.VAR_TRIGGERING_THING),
                     event.getThingUID().toString());
             evalContext.newValue(QualifiedName.create(ScriptJvmModelInferrer.VAR_PREVIOUS_STATUS),

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
@@ -27,6 +27,8 @@ import org.openhab.core.items.Item
 import org.openhab.core.types.Command
 import org.openhab.core.types.State
 import org.openhab.core.automation.module.script.rulesupport.shared.ValueCache
+import java.util.Map
+import org.openhab.core.events.Event
 
 /**
  * <p>Infers a JVM model from the source model.</p> 
@@ -137,6 +139,9 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
 
             members += script.toMethod("_script", null) [
                 static = true
+                parameters += script.toParameter("eventObject", typeRef(Event))
+                parameters += script.toParameter("ctx", typeRef(Map, typeRef(String), typeRef(Object)))
+                parameters += script.toParameter("modulesInputs", typeRef(Map, typeRef(String), typeRef(Map, typeRef(String), typeRef(Object))))                
                 val inputTypeRef = typeRef(String)
                 parameters += script.toParameter(VAR_INPUT, inputTypeRef)
                 val groupTypeRef = typeRef(Item)

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
@@ -141,7 +141,7 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
                 static = true
                 parameters += script.toParameter("eventObject", typeRef(Event))
                 parameters += script.toParameter("ctx", typeRef(Map, typeRef(String), typeRef(Object)))
-                parameters += script.toParameter("modulesInputs", typeRef(Map, typeRef(String), typeRef(Map, typeRef(String), typeRef(Object))))                
+                parameters += script.toParameter("inputs", typeRef(Map, typeRef(String), typeRef(Map, typeRef(String), typeRef(Object))))
                 val inputTypeRef = typeRef(String)
                 parameters += script.toParameter(VAR_INPUT, inputTypeRef)
                 val groupTypeRef = typeRef(Item)


### PR DESCRIPTION
Rules in OH comes with some "context information" containing data from other modules in the rule that is forwarded to the `Action` when executed, including the `Event` object for `Trigger`s. This information is available from most add-on scripting languages, but not from DSL. This PR addresses that, and makes it available to DSL scripts as well.

The PR will be extra useful if #5481 is merged, because it includes the ability to run other rules from DSL. The combination of both PRs will allow DSL rules to "transfer context" from the executing rule to the executed rule.

edit: Reviewer(s): There's not really a need to read through all the comments. It's mostly just a lot of discussions about the naming that don't conclude with everything. Reading the first two posts and looking at the code should give you (most of) the information you need.
