### PR TITLE
core.unit.CurrencyService - remove unused OSGi service

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/library/unit/CurrencyService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/library/unit/CurrencyService.java
@@ -48,7 +48,7 @@ import tech.units.indriya.format.SimpleUnitFormat;
  *
  * @author Jan N. Klug - Initial contribution
  */
-@Component(service = CurrencyService.class, immediate = true, configurationPid = CurrencyService.CONFIGURATION_PID, property = {
+@Component(configurationPid = CurrencyService.CONFIGURATION_PID, property = {
         Constants.SERVICE_PID + "=org.openhab.units", //
         "service.config.label=Unit Settings", //
         "service.config.category=system", //


### PR DESCRIPTION
This removes OSGi service `org.openhab.core.internal.library.unit.CurrencyService`, because it is not referenced from anywhere.  By removing all services from a non-factory component, the component is made implicitly Immediate.

Before:
```
openhab> scr:info org.openhab.core.internal.library.unit.CurrencyService
Component Description: org.openhab.core.internal.library.unit.CurrencyService
=============================================================================
Class:         org.openhab.core.internal.library.unit.CurrencyService
Bundle:        156 (org.openhab.core:5.2.0.202605260249)
Enabled:       true
Immediate:     true
Services:      [org.openhab.core.internal.library.unit.CurrencyService]
Scope:         singleton
Config PID(s): [org.openhab.units], Policy: optional
Base Props:    (5 entries)
  osgi.ds.satisfying.condition.target<String> = (osgi.condition.id=true)
  service.config.category<String> = system
  service.config.description.uri<String> = system:units
  service.config.label<String> = Unit Settings
  service.pid<String> = org.openhab.units

Component Configuration Id: 20
------------------------------
State:        ACTIVE
Service:      170 [org.openhab.core.internal.library.unit.CurrencyService]
Config Props: (7 entries)
  component.id<Long> = 20
  component.name<String> = org.openhab.core.internal.library.unit.CurrencyService
  osgi.ds.satisfying.condition.target<String> = (osgi.condition.id=true)
  service.config.category<String> = system
  service.config.description.uri<String> = system:units
  service.config.label<String> = Unit Settings
  service.pid<String> = org.openhab.units
References:   (total 2)
  - CurrencyProvider: org.openhab.core.library.unit.CurrencyProvider SATISFIED 0..n dynamic
    target=(*) scope=bundle (2 bindings):
    * Bound to [171] from bundle 156 (org.openhab.core:5.2.0.202605260249)
    * Bound to [172] from bundle 156 (org.openhab.core:5.2.0.202605260249)
  - osgi.ds.satisfying.condition: org.osgi.service.condition.Condition SATISFIED 1..1 dynamic
    target=(osgi.condition.id=true) scope=bundle (1 binding):
    * Bound to [6] from bundle 0 (org.eclipse.osgi:3.18.0.v20220516-2155)

```
After:
```
openhab> scr:info org.openhab.core.internal.library.unit.CurrencyService
Component Description: org.openhab.core.internal.library.unit.CurrencyService
=============================================================================
Class:         org.openhab.core.internal.library.unit.CurrencyService
Bundle:        156 (org.openhab.core:5.2.0.202605270547)
Enabled:       true
Immediate:     true
Services:      <<none>>
Config PID(s): [org.openhab.units], Policy: optional
Base Props:    (5 entries)
  osgi.ds.satisfying.condition.target<String> = (osgi.condition.id=true)
  service.config.category<String> = system
  service.config.description.uri<String> = system:units                                                         
  service.config.label<String> = Unit Settings
  service.pid<String> = org.openhab.units

Component Configuration Id: 20
------------------------------
State:        ACTIVE
Config Props: (7 entries)
  component.id<Long> = 20
  component.name<String> = org.openhab.core.internal.library.unit.CurrencyService
  osgi.ds.satisfying.condition.target<String> = (osgi.condition.id=true)
  service.config.category<String> = system
  service.config.description.uri<String> = system:units
  service.config.label<String> = Unit Settings
  service.pid<String> = org.openhab.units
References:   (total 2)
  - CurrencyProvider: org.openhab.core.library.unit.CurrencyProvider SATISFIED 0..n dynamic
    target=(*) scope=bundle (2 bindings):
    * Bound to [166] from bundle 156 (org.openhab.core:5.2.0.202605270547)
    * Bound to [167] from bundle 156 (org.openhab.core:5.2.0.202605270547)
  - osgi.ds.satisfying.condition: org.osgi.service.condition.Condition SATISFIED 1..1 dynamic
    target=(osgi.condition.id=true) scope=bundle (1 binding):
    * Bound to [6] from bundle 0 (org.eclipse.osgi:3.18.0.v20220516-2155)

```
