### PR TITLE
automation.module.ScriptTransformationServiceFactory: Remove OSGi service

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationServiceFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationServiceFactory.java
@@ -38,7 +38,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  *
  * @author Jimmy Tanagra - Initial contribution
  */
-@Component(immediate = true, service = { ScriptTransformationServiceFactory.class })
+@Component
 @NonNullByDefault
 public class ScriptTransformationServiceFactory {
 


### PR DESCRIPTION
This removes service `org.openhab.core.automation.module.script.ScriptTransformationServiceFactory` because it is not referenced from anywhere.  The component is implicitly Immediate, because it has no services.  Before:
```
openhab> scr:info org.openhab.core.automation.module.script.ScriptTransformationServiceFactory
Component Description: org.openhab.core.automation.module.script.ScriptTransformationServiceFactory
===================================================================================================
Class:         org.openhab.core.automation.module.script.ScriptTransformationServiceFactory
Bundle:        165 (org.openhab.core.automation.module.script:5.2.0.202605270258)
Enabled:       true
Immediate:     true                   
Services:      [org.openhab.core.automation.module.script.ScriptTransformationServiceFactory]
Scope:         singleton
Config PID(s): [org.openhab.core.automation.module.script.ScriptTransformationServiceFactory], Policy: optional
Base Props:    (2 entries)
  $000.target<String> = (component.factory=org.openhab.core.automation.module.script.transformation.factory)
  osgi.ds.satisfying.condition.target<String> = (osgi.condition.id=true)

Component Configuration Id: 230
-------------------------------
State:        ACTIVE
Service:      326 [org.openhab.core.automation.module.script.ScriptTransformationServiceFactory]
Config Props: (4 entries)
  $000.target<String> = (component.factory=org.openhab.core.automation.module.script.transformation.factory)
  component.id<Long> = 230
  component.name<String> = org.openhab.core.automation.module.script.ScriptTransformationServiceFactory
  osgi.ds.satisfying.condition.target<String> = (osgi.condition.id=true)
References:   (total 3)
  - $000: org.osgi.service.component.ComponentFactory SATISFIED 1..1 static
    target=(component.factory=org.openhab.core.automation.module.script.transformation.factory) scope=bundle collectionType=service (1 binding):
    * Bound to [325] from bundle 165 (org.openhab.core.automation.module.script:5.2.0.202605270258)
  - ScriptEngineFactory: org.openhab.core.automation.module.script.ScriptEngineFactory SATISFIED 0..n dynamic
    target=(*) scope=bundle (2 bindings):
    * Bound to [429] from bundle 212 (org.openhab.core.model.script.runtime:5.2.0.202605270300)
    * Bound to [571] from bundle 277 (org.openhab.automation.groovyscripting:5.2.0.202605260327)
  - osgi.ds.satisfying.condition: org.osgi.service.condition.Condition SATISFIED 1..1 dynamic
    target=(osgi.condition.id=true) scope=bundle (1 binding):
    * Bound to [6] from bundle 0 (org.eclipse.osgi:3.18.0.v20220516-2155)
```
After:
```
openhab> scr:info org.openhab.core.automation.module.script.ScriptTransformationServiceFactory
Component Description: org.openhab.core.automation.module.script.ScriptTransformationServiceFactory
===================================================================================================
Class:         org.openhab.core.automation.module.script.ScriptTransformationServiceFactory
Bundle:        165 (org.openhab.core.automation.module.script:5.2.0.202605271406)
Enabled:       true
Immediate:     true
Services:      <<none>>
Config PID(s): [org.openhab.core.automation.module.script.ScriptTransformationServiceFactory], Policy: optional
Base Props:    (2 entries)
  $000.target<String> = (component.factory=org.openhab.core.automation.module.script.transformation.factory)
  osgi.ds.satisfying.condition.target<String> = (osgi.condition.id=true)

Component Configuration Id: 97
------------------------------
State:        ACTIVE
Config Props: (4 entries)
  $000.target<String> = (component.factory=org.openhab.core.automation.module.script.transformation.factory)
  component.id<Long> = 97
  component.name<String> = org.openhab.core.automation.module.script.ScriptTransformationServiceFactory
  osgi.ds.satisfying.condition.target<String> = (osgi.condition.id=true)
References:   (total 3)
  - $000: org.osgi.service.component.ComponentFactory SATISFIED 1..1 static
    target=(component.factory=org.openhab.core.automation.module.script.transformation.factory) scope=bundle collectionType=service (1 binding):
    * Bound to [473] from bundle 165 (org.openhab.core.automation.module.script:5.2.0.202605271406)
  - ScriptEngineFactory: org.openhab.core.automation.module.script.ScriptEngineFactory SATISFIED 0..n dynamic
    target=(*) scope=bundle (2 bindings):
    * Bound to [423] from bundle 212 (org.openhab.core.model.script.runtime:5.2.0.202605270300)
    * Bound to [518] from bundle 277 (org.openhab.automation.groovyscripting:5.2.0.202605260327)
  - osgi.ds.satisfying.condition: org.osgi.service.condition.Condition SATISFIED 1..1 dynamic
    target=(osgi.condition.id=true) scope=bundle (1 binding):
    * Bound to [6] from bundle 0 (org.eclipse.osgi:3.18.0.v20220516-2155)

```