### PR TITLE
Disable Graal language cache

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/Activator.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/Activator.java
@@ -38,6 +38,11 @@ public final class Activator implements BundleActivator {
     @Override
     public void start(@Nullable BundleContext bc) throws Exception {
         logger.info("Starting openHAB {} ({})", OpenHAB.getVersion(), OpenHAB.buildString());
+
+        // Force disabling of the Graal language cache that doesn't update after the initial gathering
+        System.setProperty("truffle.engine.DisableLanguageCache", "true");
+
+        // Configure the addons service configuration to allow multiple consumers
         ServiceReference<ConfigurationAdmin> ref;
         if (bc != null && (ref = bc.getServiceReference(ConfigurationAdmin.class)) != null) {
             ConfigurationAdmin ca = bc.getService(ref);


### PR DESCRIPTION
This change has been explained in greater detail [in a forum post](https://community.openhab.org/t/running-org-openhab-demo-app-with-org-openhab-automation-jsscripting-enabled/162466/21). The gist of it is that Graal has a static cache over installed languages that is frozen the first time it's retrieved. No changes after that point is registered, which is incompatible with OH's dynamic behavior of adding and removing add-ons, starting and stopping bundles etc. The fact that the cache is static also means that its lifetime is that of the JVM itself, nothing other than restarting the JVM will make it refresh. It also creates a race condition between Graal based add-ons where "the late one" might register too late to be cached, and thus "exist".

Unfortunately, just disabling the cache isn't enough, because what can be retrieved when the cache is off seems "unstable", not thread-safe and classloader dependent. I've therefor made some alterations to the JS and Python add-ons that must be considered in combination with this PR.

I also with for the combination to be tested. I use neither language myself, so I don't really know how to thoroughly test that there are no side effects from doing this. I will reference the add-ons PR when it has been created.