### PR TITLE
Rules DSL: Support arithmetic operations directly on Number Item's State

### DIFF
--- a/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/lib/NumberExtensionsTest.java
+++ b/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/lib/NumberExtensionsTest.java
@@ -28,9 +28,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
+import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.Units;
+import org.openhab.core.types.State;
 import org.openhab.core.types.Type;
 
 /**
@@ -53,12 +55,12 @@ public class NumberExtensionsTest {
 
     @Test
     public void operatorPlusNumberNumber() {
-        assertThat(NumberExtensions.operator_plus(DECIMAL1, DECIMAL2), is(BigDecimal.valueOf(3)));
+        assertThat(NumberExtensions.operator_plus((Number) DECIMAL1, (Number) DECIMAL2), is(BigDecimal.valueOf(3)));
     }
 
     @Test
     public void operatorPlusNumberQuantityOne() {
-        assertThat(NumberExtensions.operator_plus(Q_ONE_1, DECIMAL2), is(BigDecimal.valueOf(3)));
+        assertThat(NumberExtensions.operator_plus((Number) Q_ONE_1, (Number) DECIMAL2), is(BigDecimal.valueOf(3)));
     }
 
     @Test
@@ -68,7 +70,7 @@ public class NumberExtensionsTest {
 
     @Test
     public void operatorMinusNumber() {
-        assertThat(NumberExtensions.operator_minus(DECIMAL1), is(BigDecimal.valueOf(-1)));
+        assertThat(NumberExtensions.operator_minus((Number) DECIMAL1), is(BigDecimal.valueOf(-1)));
     }
 
     @Test
@@ -78,12 +80,12 @@ public class NumberExtensionsTest {
 
     @Test
     public void operatorMinusNumberNumber() {
-        assertThat(NumberExtensions.operator_minus(DECIMAL2, DECIMAL1), is(BigDecimal.ONE));
+        assertThat(NumberExtensions.operator_minus((Number) DECIMAL2, (Number) DECIMAL1), is(BigDecimal.ONE));
     }
 
     @Test
     public void operatorMinusNumberQuantityOne() {
-        assertThat(NumberExtensions.operator_minus(Q_ONE_2, DECIMAL1), is(BigDecimal.ONE));
+        assertThat(NumberExtensions.operator_minus((Number) Q_ONE_2, (Number) DECIMAL1), is(BigDecimal.ONE));
     }
 
     @Test
@@ -93,7 +95,8 @@ public class NumberExtensionsTest {
 
     @Test
     public void operatorMultiplyNumberQuantity() {
-        assertThat(NumberExtensions.operator_multiply(DECIMAL2, Q_LENGTH_2_CM), is(QuantityType.valueOf("4 cm")));
+        assertThat(NumberExtensions.operator_multiply((Number) DECIMAL2, Q_LENGTH_2_CM),
+                is(QuantityType.valueOf("4 cm")));
     }
 
     @Test
@@ -103,7 +106,8 @@ public class NumberExtensionsTest {
 
     @Test
     public void operatorDivideQuantityNumber() {
-        assertThat(NumberExtensions.operator_divide(Q_LENGTH_1_M, DECIMAL2), is(QuantityType.valueOf("0.5 m")));
+        assertThat(NumberExtensions.operator_divide(Q_LENGTH_1_M, (Number) DECIMAL2),
+                is(QuantityType.valueOf("0.5 m")));
     }
 
     @Test
@@ -113,7 +117,43 @@ public class NumberExtensionsTest {
 
     @Test
     public void operatorDivideNumberQuantity() {
-        assertThat(NumberExtensions.operator_divide(DECIMAL1, Q_LENGTH_2_CM), is(QuantityType.valueOf("0.5 one/cm")));
+        assertThat(NumberExtensions.operator_divide((Number) DECIMAL1, Q_LENGTH_2_CM),
+                is(QuantityType.valueOf("0.5 one/cm")));
+    }
+
+    @Test
+    public void operatorMinusStateState() {
+        assertThat(NumberExtensions.operator_minus((State) DECIMAL2, (State) DECIMAL1), is(BigDecimal.ONE));
+    }
+
+    @Test
+    public void operatorMinusQuantityStateState() {
+        assertThat(NumberExtensions.operator_minus((State) Q_LENGTH_1_M, (State) Q_LENGTH_2_CM),
+                is(QuantityType.valueOf("0.98 m")));
+    }
+
+    @Test
+    public void operatorMultiplyStateNumber() {
+        assertThat(NumberExtensions.operator_multiply((State) DECIMAL2, BigDecimal.valueOf(1.5)),
+                is(BigDecimal.valueOf(3.0)));
+    }
+
+    @Test
+    public void operatorMultiplyQuantityStateNumber() {
+        assertThat(NumberExtensions.operator_multiply((State) Q_LENGTH_2_CM, (Number) DECIMAL2),
+                is(QuantityType.valueOf("4 cm")));
+    }
+
+    @Test
+    public void operatorDivideNumberState() {
+        assertThat(NumberExtensions.operator_divide(BigDecimal.TEN, (State) DECIMAL2),
+                is(new BigDecimal("5.00000000")));
+    }
+
+    @Test
+    public void operatorNonNumericState() {
+        assertThrows(IllegalArgumentException.class,
+                () -> NumberExtensions.operator_multiply(OnOffType.ON, (Number) DECIMAL2));
     }
 
     @Test

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/lib/NumberExtensions.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/lib/NumberExtensions.java
@@ -20,6 +20,7 @@ import javax.measure.quantity.Dimensionless;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.Units;
+import org.openhab.core.types.State;
 import org.openhab.core.types.Type;
 
 /**
@@ -89,6 +90,60 @@ public class NumberExtensions {
         BigDecimal xValue = numberToBigDecimal(x);
         BigDecimal yValue = numberToBigDecimal(y);
         return xValue.divide(yValue, 8, RoundingMode.HALF_UP);
+    }
+
+    // Calculation operators for states
+
+    public static Number operator_plus(State x, State y) {
+        return plus(stateToNumber(x), stateToNumber(y));
+    }
+
+    public static Number operator_plus(State x, Number y) {
+        return plus(stateToNumber(x), y);
+    }
+
+    public static Number operator_plus(Number x, State y) {
+        return plus(x, stateToNumber(y));
+    }
+
+    public static Number operator_minus(State x) {
+        return minus(stateToNumber(x));
+    }
+
+    public static Number operator_minus(State x, State y) {
+        return minus(stateToNumber(x), stateToNumber(y));
+    }
+
+    public static Number operator_minus(State x, Number y) {
+        return minus(stateToNumber(x), y);
+    }
+
+    public static Number operator_minus(Number x, State y) {
+        return minus(x, stateToNumber(y));
+    }
+
+    public static Number operator_multiply(State x, State y) {
+        return multiply(stateToNumber(x), stateToNumber(y));
+    }
+
+    public static Number operator_multiply(State x, Number y) {
+        return multiply(stateToNumber(x), y);
+    }
+
+    public static Number operator_multiply(Number x, State y) {
+        return multiply(x, stateToNumber(y));
+    }
+
+    public static Number operator_divide(State x, State y) {
+        return divide(stateToNumber(x), stateToNumber(y));
+    }
+
+    public static Number operator_divide(State x, Number y) {
+        return divide(stateToNumber(x), y);
+    }
+
+    public static Number operator_divide(Number x, State y) {
+        return divide(x, stateToNumber(y));
     }
 
     // Comparison operations between numbers
@@ -407,5 +462,63 @@ public class NumberExtensions {
 
     private static boolean isAbstractUnitOne(QuantityType<?> left) {
         return Units.ONE.equals(left.getUnit());
+    }
+
+    private static Number stateToNumber(State state) {
+        if (state == null) {
+            return null;
+        }
+        if (state instanceof Number number) {
+            return number;
+        }
+        throw new IllegalArgumentException(
+                "State '" + state + "' of type '" + state.getClass().getSimpleName() + "' cannot be used as a number");
+    }
+
+    private static Number plus(Number x, Number y) {
+        if (x instanceof QuantityType<?> qx && y instanceof QuantityType<?> qy) {
+            return operator_plus(qx, qy);
+        }
+        return operator_plus(x, y);
+    }
+
+    private static Number minus(Number x) {
+        if (x instanceof QuantityType<?> qx) {
+            return operator_minus(qx);
+        }
+        return operator_minus(x);
+    }
+
+    private static Number minus(Number x, Number y) {
+        if (x instanceof QuantityType<?> qx && y instanceof QuantityType<?> qy) {
+            return operator_minus(qx, qy);
+        }
+        return operator_minus(x, y);
+    }
+
+    private static Number multiply(Number x, Number y) {
+        if (x instanceof QuantityType<?> qx && y instanceof QuantityType<?> qy) {
+            return operator_multiply(qx, qy);
+        }
+        if (x instanceof QuantityType<?> qx) {
+            return operator_multiply(qx, y);
+        }
+        if (y instanceof QuantityType<?> qy) {
+            return operator_multiply(x, qy);
+        }
+        return operator_multiply(x, y);
+    }
+
+    private static Number divide(Number x, Number y) {
+        if (x instanceof QuantityType<?> qx && y instanceof QuantityType<?> qy) {
+            return operator_divide(qx, qy);
+        }
+        if (x instanceof QuantityType<?> qx) {
+            return operator_divide(qx, y);
+        }
+        if (y instanceof QuantityType<?> qy) {
+            return operator_divide(x, qy);
+        }
+        return operator_divide(x, y);
     }
 }


### PR DESCRIPTION
Currently to perform numeric calculations in Rules DSL / DSL script, one has to do this:

```java
(MyItem.state as Number)- (MyOtherItem.state as Number)

(MyItem.state as Number) * 1.5
```

This PR makes it easier by allowing:

```java
MyItem.state - MyOtherItem.state
or
MyItem.state * 1.5
```