### PR TITLE
[automation] Revert #4919 "Remove prefixes from context entries before injecting ctx into execution context"

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -202,8 +202,14 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
 
         // Add the rule's UID to the context and make it available as "ctx".
         // Note: We don't use "context" here as it doesn't work on all JVM versions!
-        final Map<String, Object> contextNew = new HashMap<>();
-        // add the single context entries without their prefix to contextNew
+        final Map<String, Object> contextNew = new HashMap<>(context);
+        contextNew.put("ruleUID", this.ruleUID);
+        executionContext.setAttribute("ctx", contextNew, ScriptContext.ENGINE_SCOPE);
+
+        // Add the rule's UID to the global namespace.
+        executionContext.setAttribute("ruleUID", this.ruleUID, ScriptContext.ENGINE_SCOPE);
+
+        // add the single context entries without their prefix to the scope
         for (Entry<String, ?> entry : context.entrySet()) {
             Object value = entry.getValue();
             String key = entry.getKey();
@@ -211,15 +217,6 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
             if (dotIndex != -1) {
                 key = key.substring(dotIndex + 1);
             }
-            contextNew.put(key, value);
-        }
-        contextNew.put("ruleUID", this.ruleUID);
-        executionContext.setAttribute("ctx", contextNew, ScriptContext.ENGINE_SCOPE);
-
-        // add the single contextNew entries to the scope
-        for (Entry<String, ?> entry : contextNew.entrySet()) {
-            Object value = entry.getValue();
-            String key = entry.getKey();
             executionContext.setAttribute(key, value, ScriptContext.ENGINE_SCOPE);
         }
     }


### PR DESCRIPTION
As has been discussed in #4919, it has caused loss of data if more than one key has the same name and the rule has multiple modules.

https://github.com/openhab/openhab-js/pull/527 has been created to make sure that there are no change for JavaScript users as a result of the reversal.

According to @jimtng and @HolgerHees, no changes were made in the Ruby or Python add-ons in response to #4919, so no changes should be needed for the reversal either..?

DSL has no support for this yet, which is what I was working on in #5607 when I discovered this, so I don't think there should be anything else that is affected.