### PR TITLE
[voice] Add additional rules to the StandardInterpreter

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/StandardInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/StandardInterpreter.java
@@ -109,7 +109,7 @@ public class StandardInterpreter extends AbstractRuleBasedInterpreter {
 
                     itemRule(seq(turn, the), /* item */ onOff),
 
-                    itemRule(seq(turn, onOff) /* item */),
+                    itemRule(seq(turn, onOff, the) /* item */),
 
                     /* IncreaseDecreaseType */
 
@@ -130,6 +130,10 @@ public class StandardInterpreter extends AbstractRuleBasedInterpreter {
                     itemRule(seq(put, the), /* item */ cmd("up", UpDownType.UP)),
 
                     itemRule(seq(put, the), /* item */ cmd("down", UpDownType.DOWN)),
+
+                    itemRule(seq(cmd("open", UpDownType.UP), the) /* item */),
+
+                    itemRule(seq(cmd("close", UpDownType.DOWN), the) /* item */),
 
                     /* NextPreviousType */
 
@@ -175,11 +179,10 @@ public class StandardInterpreter extends AbstractRuleBasedInterpreter {
             Expression einAnAus = alt(cmd("ein", OnOffType.ON), cmd("an", OnOffType.ON), cmd("aus", OnOffType.OFF));
             Expression denDieDas = opt(alt("den", "die", "das"));
             Expression schalte = alt("schalt", "schalte", "mach");
-            Expression pause = alt("pause", "stoppe");
+            Expression pause = alt("pause", "stoppe", "pausiere");
             Expression mache = alt("mach", "mache", "fahre");
             Expression spiele = alt("spiele", "spiel", "starte");
             Expression zu = alt("zu", "zum", "zur");
-            Expression the = opt("the");
             Expression naechste = alt("nächste", "nächstes", "nächster");
             Expression vorherige = alt("vorherige", "vorheriges", "vorheriger");
             Expression farbe = alt(cmd("weiß", HSBType.WHITE), cmd("pink", HSBType.fromRGB(255, 96, 208)),
@@ -198,10 +201,10 @@ public class StandardInterpreter extends AbstractRuleBasedInterpreter {
                     itemRule(seq(cmd(alt("dimme"), IncreaseDecreaseType.DECREASE), denDieDas) /* item */),
 
                     itemRule(seq(schalte, denDieDas),
-                            /* item */ cmd(alt("dunkler", "weniger"), IncreaseDecreaseType.DECREASE)),
+                            /* item */ cmd(alt("dunkler", "weniger", "leiser"), IncreaseDecreaseType.DECREASE)),
 
                     itemRule(seq(schalte, denDieDas),
-                            /* item */ cmd(alt("heller", "mehr"), IncreaseDecreaseType.INCREASE)),
+                            /* item */ cmd(alt("heller", "mehr", "lauter"), IncreaseDecreaseType.INCREASE)),
 
                     /* ColorType */
 
@@ -213,6 +216,10 @@ public class StandardInterpreter extends AbstractRuleBasedInterpreter {
 
                     itemRule(seq(mache, denDieDas), /* item */ cmd("runter", UpDownType.DOWN)),
 
+                    itemRule(seq(cmd("öffne", UpDownType.UP), denDieDas /* item */)),
+
+                    itemRule(seq(cmd("schließe", UpDownType.DOWN), denDieDas /* item */)),
+
                     /* NextPreviousType */
 
                     itemRule("wechsle",
@@ -222,9 +229,9 @@ public class StandardInterpreter extends AbstractRuleBasedInterpreter {
 
                     /* PlayPauseType */
 
-                    itemRule(seq(cmd(spiele, PlayPauseType.PLAY), the) /* item */),
+                    itemRule(seq(cmd(spiele, PlayPauseType.PLAY), denDieDas) /* item */),
 
-                    itemRule(seq(cmd(pause, PlayPauseType.PAUSE), the) /* item */)
+                    itemRule(seq(cmd(pause, PlayPauseType.PAUSE), denDieDas) /* item */)
 
             );
 

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/StandardInterpreterTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/StandardInterpreterTest.java
@@ -95,6 +95,8 @@ public class StandardInterpreterTest {
         computerScreenItem.setLabel("Computer Screen");
         List<Item> items = List.of(computerItem, computerScreenItem);
         when(itemRegistryMock.getItems()).thenReturn(items);
+
+        // "computer" should only match computerItem, not computerScreenItem
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn off computer"));
         verify(eventPublisherMock, times(1))
                 .post(ItemEventFactory.createCommandEvent(computerItem.getName(), OnOffType.OFF));
@@ -102,18 +104,20 @@ public class StandardInterpreterTest {
 
     @Test
     public void noNameCollisionOnSingleExactMatchForGroups() throws InterpretationException {
-        var computerItem = Mockito.spy(new GroupItem("computer"));
-        computerItem.setLabel("Computer");
+        var computerGroup = Mockito.spy(new GroupItem("computer"));
+        computerGroup.setLabel("Computer");
         var computerSwitchItem = new SwitchItem("computer_power");
         computerSwitchItem.setLabel("Power");
-        var screenItem = Mockito.spy(new GroupItem("screen"));
-        screenItem.setLabel("Computer Screen");
+        var screenGroup = Mockito.spy(new GroupItem("screen"));
+        screenGroup.setLabel("Computer Screen");
         var screenSwitchItem = new SwitchItem("screen_power");
         screenSwitchItem.setLabel("Power");
-        when(computerItem.getMembers()).thenReturn(Set.of(computerSwitchItem));
-        when(screenItem.getMembers()).thenReturn(Set.of(screenSwitchItem));
-        List<Item> items = List.of(computerItem, computerSwitchItem, screenItem, screenSwitchItem);
+        when(computerGroup.getMembers()).thenReturn(Set.of(computerSwitchItem));
+        when(screenGroup.getMembers()).thenReturn(Set.of(screenSwitchItem));
+        List<Item> items = List.of(computerGroup, computerSwitchItem, screenGroup, screenSwitchItem);
         when(itemRegistryMock.getItems()).thenReturn(items);
+
+        // "computer" should only match the computerSwitchItem member of computerGroup
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn off computer"));
         verify(eventPublisherMock, times(1))
                 .post(ItemEventFactory.createCommandEvent(computerSwitchItem.getName(), OnOffType.OFF));
@@ -121,24 +125,26 @@ public class StandardInterpreterTest {
 
     @Test
     public void noNameCollisionWhenDialogContext() throws InterpretationException {
-        var locationItem = Mockito.spy(new GroupItem("livingroom"));
-        locationItem.setLabel("Living room");
+        var locationGroup = Mockito.spy(new GroupItem("livingroom"));
+        locationGroup.setLabel("Living room");
         var computerItem = new SwitchItem("computer");
         computerItem.setLabel("Computer");
         var computerItem2 = new SwitchItem("computer2");
         computerItem2.setLabel("Computer");
-        when(locationItem.getMembers()).thenReturn(Set.of(computerItem));
+        when(locationGroup.getMembers()).thenReturn(Set.of(computerItem));
         var dialogContext = new DialogContext(null, null, sttService, ttsService, null, List.of(), audioSource,
-                audioSink, Locale.ENGLISH, "", locationItem.getName(), null, null, null, List.of());
-        List<Item> items = List.of(computerItem2, locationItem, computerItem);
+                audioSink, Locale.ENGLISH, "", locationGroup.getName(), null, null, null, List.of());
+        List<Item> items = List.of(computerItem2, locationGroup, computerItem);
         when(itemRegistryMock.getItems()).thenReturn(items);
+
+        // "computer" should only match the computerItem in the locationGroup
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn off computer", dialogContext));
         verify(eventPublisherMock, times(1))
                 .post(ItemEventFactory.createCommandEvent(computerItem.getName(), OnOffType.OFF));
     }
 
     @Test
-    public void resolveCollisionByCommandType() throws InterpretationException {
+    public void noNameCollisionOnSingleCommandTypeMatch() throws InterpretationException {
         // Both items have the same label "lamp"
         var switchItem = new SwitchItem("switch_lamp");
         switchItem.setLabel("lamp");

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/StandardInterpreterTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/StandardInterpreterTest.java
@@ -46,11 +46,13 @@ import org.openhab.core.items.MetadataKey;
 import org.openhab.core.items.MetadataRegistry;
 import org.openhab.core.items.events.ItemEventFactory;
 import org.openhab.core.library.items.DimmerItem;
+import org.openhab.core.library.items.RollershutterItem;
 import org.openhab.core.library.items.StringItem;
 import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.types.UpDownType;
 import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.CommandOption;
 import org.openhab.core.types.State;
@@ -392,5 +394,32 @@ public class StandardInterpreterTest {
         verify(eventPublisherMock, times(1))
                 .post(ItemEventFactory.createCommandEvent(virtualItem.getName(), new StringType("KEY_4")));
         reset(eventPublisherMock);
+    }
+
+    @Test
+    public void openCloseBlindsTest() throws InterpretationException {
+        var blindsItem = new RollershutterItem("blinds");
+        blindsItem.setLabel("blinds");
+        List<Item> items = List.of(blindsItem);
+        when(itemRegistryMock.getItems()).thenReturn(items);
+
+        assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "open blinds"));
+        verify(eventPublisherMock, times(1))
+                .post(ItemEventFactory.createCommandEvent(blindsItem.getName(), UpDownType.UP));
+
+        reset(eventPublisherMock);
+        assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "open the blinds"));
+        verify(eventPublisherMock, times(1))
+                .post(ItemEventFactory.createCommandEvent(blindsItem.getName(), UpDownType.UP));
+
+        reset(eventPublisherMock);
+        assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "close blinds"));
+        verify(eventPublisherMock, times(1))
+                .post(ItemEventFactory.createCommandEvent(blindsItem.getName(), UpDownType.DOWN));
+
+        reset(eventPublisherMock);
+        assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "close the blinds"));
+        verify(eventPublisherMock, times(1))
+                .post(ItemEventFactory.createCommandEvent(blindsItem.getName(), UpDownType.DOWN));
     }
 }

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/StandardInterpreterTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/StandardInterpreterTest.java
@@ -138,6 +138,30 @@ public class StandardInterpreterTest {
     }
 
     @Test
+    public void resolveCollisionByCommandType() throws InterpretationException {
+        // Both items have the same label "lamp"
+        var switchItem = new SwitchItem("switch_lamp");
+        switchItem.setLabel("lamp");
+        var rollershutterItem = new RollershutterItem("rollershutter_lamp");
+        rollershutterItem.setLabel("lamp");
+
+        List<Item> items = List.of(switchItem, rollershutterItem);
+        when(itemRegistryMock.getItems()).thenReturn(items);
+
+        // "turn on" should only match the SwitchItem
+        assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn on the lamp"));
+        verify(eventPublisherMock, times(1))
+                .post(ItemEventFactory.createCommandEvent(switchItem.getName(), OnOffType.ON));
+
+        reset(eventPublisherMock);
+
+        // "open" should only match the RollershutterItem
+        assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "open the lamp"));
+        verify(eventPublisherMock, times(1))
+                .post(ItemEventFactory.createCommandEvent(rollershutterItem.getName(), UpDownType.UP));
+    }
+
+    @Test
     public void allowUseItemSynonyms() throws InterpretationException {
         var computerItem = new SwitchItem("computer");
         computerItem.setLabel("Computer");


### PR DESCRIPTION
Adds the following rules:

* English: Add "open/close [the] <item>" rule
* English: Add "turn|switch on|off [the] <item>" rule
* German: Add "öffne/schließe [den|die|das] <item>" rule
* German: Add "mache [den|die|das] <item> lauter|leiser" rule

Adds a new test case for the StandardInterpreter to test for resolving name collisions by command type.