### PR TITLE
Include rule UID in log message when rule execution fails

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -1406,7 +1406,8 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
                         updateContext(ruleUID, action.getId(), outputs);
                     }
                 } catch (Throwable t) {
-                    String errMessage = "Failed to execute action: " + action.getId() + "(" + t.getMessage() + ")";
+                    String errMessage = "Failed to execute action '" + action.getId() + "' of rule '" + ruleUID + "': "
+                            + t.getMessage();
                     if (stopOnFirstFail) {
                         logger.debug("Action {}-{} threw an exception: ", ruleUID, action.getId(), t);
                         throw new RuntimeException(errMessage, t);


### PR DESCRIPTION
There's not much to be said - the action ID is usually a number that is autogenerated, and doesn't mean much when you want to figure out what rule failed. Including the rule UID makes the error much more meaningful.