### PR TITLE
[voice] Implement LLM tools get state & send command for Items

### DIFF
--- a/bundles/org.openhab.core.voice/pom.xml
+++ b/bundles/org.openhab.core.voice/pom.xml
@@ -37,6 +37,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.transform</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
       <artifactId>org.openhab.core.test</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/VoiceManager.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/VoiceManager.java
@@ -37,6 +37,10 @@ import org.openhab.core.voice.text.InterpretationException;
  */
 @NonNullByDefault
 public interface VoiceManager {
+    /**
+     * The event source for events dispatched by the voice system.
+     */
+    String VOICE_SOURCE = "org.openhab.core.voice";
 
     /**
      * Speaks the passed string using the default TTS service and default audio sink.

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -114,8 +114,6 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, DialogProcessor.DialogEventListener,
         RegistryChangeListener<LLMTool> {
-    public static final String VOICE_SOURCE = "org.openhab.core.voice";
-
     private final Logger logger = LoggerFactory.getLogger(VoiceManagerImpl.class);
     private final ScheduledExecutorService scheduledExecutorService = ThreadPoolManager
             .getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON);

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -115,6 +115,7 @@ import org.slf4j.LoggerFactory;
 public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, DialogProcessor.DialogEventListener,
         RegistryChangeListener<LLMTool> {
 
+    public static final String VOICE_SOURCE = "org.openhab.core.voice";
     private final Logger logger = LoggerFactory.getLogger(VoiceManagerImpl.class);
     private final ScheduledExecutorService scheduledExecutorService = ThreadPoolManager
             .getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON);

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -114,8 +114,8 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, DialogProcessor.DialogEventListener,
         RegistryChangeListener<LLMTool> {
-
     public static final String VOICE_SOURCE = "org.openhab.core.voice";
+
     private final Logger logger = LoggerFactory.getLogger(VoiceManagerImpl.class);
     private final ScheduledExecutorService scheduledExecutorService = ThreadPoolManager
             .getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON);

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/conversation/ConversationManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/conversation/ConversationManagerImpl.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.voice.internal.text.conversation;
 
+import static org.openhab.core.voice.VoiceManager.VOICE_SOURCE;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
@@ -112,7 +114,7 @@ public class ConversationManagerImpl implements ConversationManager, Conversatio
             } else if (createIfMissing) {
                 logger.debug("Creating new conversation '{}'", id);
                 conversation = new Conversation(id);
-                eventPublisher.post(ConversationEventFactory.createConversationCreatedEvent(id, null));
+                eventPublisher.post(ConversationEventFactory.createConversationCreatedEvent(id, VOICE_SOURCE));
             } else {
                 return null;
             }
@@ -157,7 +159,7 @@ public class ConversationManagerImpl implements ConversationManager, Conversatio
         }
         if (!id.isBlank()) {
             conversationStorage.remove(id);
-            eventPublisher.post(ConversationEventFactory.createConversationRemovedEvent(id, null));
+            eventPublisher.post(ConversationEventFactory.createConversationRemovedEvent(id, VOICE_SOURCE));
         }
     }
 
@@ -175,7 +177,7 @@ public class ConversationManagerImpl implements ConversationManager, Conversatio
     @Override
     public void onMessageAdded(Conversation conversation, Conversation.Message message) {
         eventPublisher.post(ConversationEventFactory.createConversationMessageAddedEvent(conversation.getId(),
-                message.id(), message.role(), message.content(), null));
+                message.id(), message.role(), message.content(), VOICE_SOURCE));
         storeConversation(conversation);
     }
 
@@ -185,7 +187,7 @@ public class ConversationManagerImpl implements ConversationManager, Conversatio
             removeConversation(conversation.getId());
         } else {
             eventPublisher.post(ConversationEventFactory.createConversationMessagesRemovedEvent(conversation.getId(),
-                    sinceRemovedMessagesId, null));
+                    sinceRemovedMessagesId, VOICE_SOURCE));
             storeConversation(conversation);
         }
     }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemCommandLLMTool.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemCommandLLMTool.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.voice.internal.text.interpreter.llm;
 
+import static org.openhab.core.voice.internal.VoiceManagerImpl.VOICE_SOURCE;
+
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -116,7 +118,7 @@ public class ItemCommandLLMTool implements LLMTool {
             throw new LLMToolException("Failed to parse command '" + commandString + "' for item '" + itemName + "'");
         }
 
-        eventPublisher.post(ItemEventFactory.createCommandEvent(itemName, command));
+        eventPublisher.post(ItemEventFactory.createCommandEvent(itemName, command, VOICE_SOURCE));
 
         return "Successfully sent command '" + commandString + "' to item '" + itemName + "'.";
     }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemCommandLLMTool.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemCommandLLMTool.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.core.voice.internal.text.interpreter.llm;
 
-import static org.openhab.core.voice.internal.VoiceManagerImpl.VOICE_SOURCE;
+import static org.openhab.core.voice.VoiceManager.VOICE_SOURCE;
 
 import java.util.List;
 import java.util.Locale;

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemCommandLLMTool.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemCommandLLMTool.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.voice.internal.text.interpreter.llm;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.events.EventPublisher;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemNotFoundException;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.events.ItemEventFactory;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.TypeParser;
+import org.openhab.core.voice.security.ItemPermission;
+import org.openhab.core.voice.security.ItemPermissionResolver;
+import org.openhab.core.voice.text.interpreter.llm.LLMTool;
+import org.openhab.core.voice.text.interpreter.llm.LLMToolException;
+import org.openhab.core.voice.text.interpreter.llm.LLMToolParam;
+import org.openhab.core.voice.text.interpreter.llm.LLMToolParamType;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link ItemCommandLLMTool} is an {@link LLMTool} that allows to control items
+ * by sending commands to them.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = LLMTool.class, immediate = true)
+public class ItemCommandLLMTool implements LLMTool {
+    public static final String ID = "item-send-command";
+
+    private final ItemRegistry itemRegistry;
+    private final ItemPermissionResolver itemPermissionResolver;
+    private final EventPublisher eventPublisher;
+
+    @Activate
+    public ItemCommandLLMTool(final @Reference ItemRegistry itemRegistry,
+            final @Reference ItemPermissionResolver itemPermissionResolver,
+            final @Reference EventPublisher eventPublisher) {
+        this.itemRegistry = itemRegistry;
+        this.itemPermissionResolver = itemPermissionResolver;
+        this.eventPublisher = eventPublisher;
+    }
+
+    @Override
+    public String getUID() {
+        return ID;
+    }
+
+    @Override
+    public String getLabel(@Nullable Locale locale) {
+        return "Send Command to Item";
+    }
+
+    @Override
+    public String getShortDescription(@Nullable Locale locale) {
+        return "Sends a command to a specific item.";
+    }
+
+    @Override
+    public String getDescription(@Nullable Locale locale) {
+        return "This tool allows to control items by sending commands to them.";
+    }
+
+    @Override
+    public List<LLMToolParam> getParamDescriptions(@Nullable Locale locale) {
+        return List.of(
+                new LLMToolParam("itemName", LLMToolParamType.STRING, "The name of the item to control", List.of(),
+                        true),
+                new LLMToolParam("command", LLMToolParamType.STRING,
+                        "The command to send to the item (e.g., ON, OFF, a number)", List.of(), true));
+    }
+
+    @Override
+    public String call(Map<String, Object> params, @Nullable Locale locale) throws LLMToolException {
+        Object itemNameObj = params.get("itemName");
+        Object commandObj = params.get("command");
+
+        if (!(itemNameObj instanceof String itemName) || !(commandObj instanceof String commandString)) {
+            throw new LLMToolException("Missing or invalid required parameters 'itemName' and 'command'");
+        }
+
+        Item item;
+        try {
+            item = itemRegistry.getItem(itemName);
+        } catch (ItemNotFoundException e) {
+            throw new LLMToolException("Item not found: " + itemName, e);
+        }
+
+        var permission = itemPermissionResolver.getPermission(item);
+        if (permission == ItemPermission.NO_ACCESS) {
+            throw new LLMToolException("Item not found: " + itemName);
+        } else if (permission == ItemPermission.READ_ONLY) {
+            throw new LLMToolException("Item is read-only: " + itemName);
+        }
+
+        Command command = TypeParser.parseCommand(item.getAcceptedCommandTypes(), commandString);
+        if (command == null) {
+            throw new LLMToolException("Failed to parse command '" + commandString + "' for item '" + itemName + "'");
+        }
+
+        eventPublisher.post(ItemEventFactory.createCommandEvent(itemName, command));
+
+        return "Successfully sent command '" + commandString + "' to item '" + itemName + "'.";
+    }
+}

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMTool.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMTool.java
@@ -21,6 +21,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.voice.security.ItemPermission;
 import org.openhab.core.voice.security.ItemPermissionResolver;
 import org.openhab.core.voice.text.interpreter.llm.LLMTool;
 import org.openhab.core.voice.text.interpreter.llm.LLMToolException;
@@ -91,7 +92,7 @@ public class ItemStateLLMTool implements LLMTool {
             throw new LLMToolException("Item not found: " + itemName, e);
         }
 
-        if (!itemPermissionResolver.isAccessible(item)) {
+        if (itemPermissionResolver.getPermission(item) == ItemPermission.NO_ACCESS) {
             throw new LLMToolException("Item not found: " + itemName);
         }
 

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMTool.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMTool.java
@@ -18,9 +18,11 @@ import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.transform.util.ItemDisplayStateUtil;
 import org.openhab.core.voice.security.ItemPermission;
 import org.openhab.core.voice.security.ItemPermissionResolver;
 import org.openhab.core.voice.text.interpreter.llm.LLMTool;
@@ -43,12 +45,15 @@ public class ItemStateLLMTool implements LLMTool {
 
     private final ItemRegistry itemRegistry;
     private final ItemPermissionResolver itemPermissionResolver;
+    private final TimeZoneProvider timeZoneProvider;
 
     @Activate
     public ItemStateLLMTool(final @Reference ItemRegistry itemRegistry,
-            final @Reference ItemPermissionResolver itemPermissionResolver) {
+            final @Reference ItemPermissionResolver itemPermissionResolver,
+            final @Reference TimeZoneProvider timeZoneProvider) {
         this.itemRegistry = itemRegistry;
         this.itemPermissionResolver = itemPermissionResolver;
+        this.timeZoneProvider = timeZoneProvider;
     }
 
     @Override
@@ -68,7 +73,7 @@ public class ItemStateLLMTool implements LLMTool {
 
     @Override
     public String getDescription(@Nullable Locale locale) {
-        return "This tool allows to retrieve the current state of an item.";
+        return "This tool allows to retrieve the current state of an item. It returns the display state and the raw state if a display state is available, otherwise only the raw state.";
     }
 
     @Override
@@ -96,6 +101,13 @@ public class ItemStateLLMTool implements LLMTool {
             throw new LLMToolException("Item not found: " + itemName);
         }
 
-        return item.getState().toString();
+        String rawState = item.getState().toString();
+        String displayState = ItemDisplayStateUtil.getDisplayState(item, locale, timeZoneProvider.getTimeZone());
+
+        if (displayState != null && !displayState.equals(rawState)) {
+            return displayState + " (" + rawState + ")";
+        }
+
+        return rawState;
     }
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMTool.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMTool.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.voice.internal.text.interpreter.llm;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemNotFoundException;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.voice.security.ItemPermissionResolver;
+import org.openhab.core.voice.text.interpreter.llm.LLMTool;
+import org.openhab.core.voice.text.interpreter.llm.LLMToolException;
+import org.openhab.core.voice.text.interpreter.llm.LLMToolParam;
+import org.openhab.core.voice.text.interpreter.llm.LLMToolParamType;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link ItemStateLLMTool} is an {@link LLMTool} that allows to get the state of an item.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = LLMTool.class, immediate = true)
+public class ItemStateLLMTool implements LLMTool {
+    public static final String ID = "item-get-state";
+
+    private final ItemRegistry itemRegistry;
+    private final ItemPermissionResolver itemPermissionResolver;
+
+    @Activate
+    public ItemStateLLMTool(final @Reference ItemRegistry itemRegistry,
+            final @Reference ItemPermissionResolver itemPermissionResolver) {
+        this.itemRegistry = itemRegistry;
+        this.itemPermissionResolver = itemPermissionResolver;
+    }
+
+    @Override
+    public String getUID() {
+        return ID;
+    }
+
+    @Override
+    public String getLabel(@Nullable Locale locale) {
+        return "Get Item State";
+    }
+
+    @Override
+    public String getShortDescription(@Nullable Locale locale) {
+        return "Gets the current state of a specific item.";
+    }
+
+    @Override
+    public String getDescription(@Nullable Locale locale) {
+        return "This tool allows to retrieve the current state of an item.";
+    }
+
+    @Override
+    public List<LLMToolParam> getParamDescriptions(@Nullable Locale locale) {
+        return List.of(new LLMToolParam("itemName", LLMToolParamType.STRING, "The name of the item to get the state of",
+                List.of(), true));
+    }
+
+    @Override
+    public String call(Map<String, Object> params, @Nullable Locale locale) throws LLMToolException {
+        Object itemNameObj = params.get("itemName");
+
+        if (!(itemNameObj instanceof String itemName)) {
+            throw new LLMToolException("Missing or invalid required parameter 'itemName'");
+        }
+
+        Item item;
+        try {
+            item = itemRegistry.getItem(itemName);
+        } catch (ItemNotFoundException e) {
+            throw new LLMToolException("Item not found: " + itemName, e);
+        }
+
+        if (!itemPermissionResolver.isAccessible(item)) {
+            throw new LLMToolException("Item not found: " + itemName);
+        }
+
+        return item.getState().toString();
+    }
+}

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/rulebased/AbstractRuleBasedInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/rulebased/AbstractRuleBasedInterpreter.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.voice.text.interpreter.rulebased;
 
+import static org.openhab.core.voice.internal.VoiceManagerImpl.VOICE_SOURCE;
+
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -921,7 +923,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
             logger.debug("Cannot send command to read-only item {}", item.getName());
             return language.getString(READ_ONLY);
         }
-        eventPublisher.post(ItemEventFactory.createCommandEvent(item.getName(), command));
+        eventPublisher.post(ItemEventFactory.createCommandEvent(item.getName(), command, VOICE_SOURCE));
         return !isSilent ? language.getString(OK) : "";
     }
 

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/rulebased/AbstractRuleBasedInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/rulebased/AbstractRuleBasedInterpreter.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.core.voice.text.interpreter.rulebased;
 
-import static org.openhab.core.voice.internal.VoiceManagerImpl.VOICE_SOURCE;
+import static org.openhab.core.voice.VoiceManager.VOICE_SOURCE;
 
 import java.text.ParseException;
 import java.util.ArrayList;

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/StandardInterpreterTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/StandardInterpreterTest.java
@@ -126,7 +126,7 @@ public class StandardInterpreterTest {
         // "computer" should only match computerItem, not computerScreenItem
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn off computer"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(computerItem.getName(), OnOffType.OFF));
+                .post(ItemEventFactory.createCommandEvent(computerItem.getName(), OnOffType.OFF, any()));
     }
 
     @Test
@@ -147,7 +147,7 @@ public class StandardInterpreterTest {
         // "computer" should only match the computerSwitchItem member of computerGroup
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn off computer"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(computerSwitchItem.getName(), OnOffType.OFF));
+                .post(ItemEventFactory.createCommandEvent(computerSwitchItem.getName(), OnOffType.OFF, any()));
     }
 
     @Test
@@ -188,7 +188,7 @@ public class StandardInterpreterTest {
         conversation1.addMessage(ConversationRole.USER, "turn on light");
         InterpreterContext context1 = new InterpreterContext(conversation1, List.of(), "kitchen", null);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, context1));
-        verify(eventPublisherMock, times(1)).post(ItemEventFactory.createCommandEvent("light1", OnOffType.ON));
+        verify(eventPublisherMock, times(1)).post(ItemEventFactory.createCommandEvent("light1", OnOffType.ON, any()));
 
         reset(eventPublisherMock);
         // Match light2 by location context livingRoom
@@ -196,7 +196,7 @@ public class StandardInterpreterTest {
         conversation2.addMessage(ConversationRole.USER, "turn on light");
         InterpreterContext context2 = new InterpreterContext(conversation2, List.of(), "livingRoom", null);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, context2));
-        verify(eventPublisherMock, times(1)).post(ItemEventFactory.createCommandEvent("light2", OnOffType.ON));
+        verify(eventPublisherMock, times(1)).post(ItemEventFactory.createCommandEvent("light2", OnOffType.ON, any()));
     }
 
     @Test
@@ -213,14 +213,14 @@ public class StandardInterpreterTest {
         // "turn on" should only match the SwitchItem
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn on the lamp"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(switchItem.getName(), OnOffType.ON));
+                .post(ItemEventFactory.createCommandEvent(switchItem.getName(), OnOffType.ON, any()));
 
         reset(eventPublisherMock);
 
         // "open" should only match the RollershutterItem
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "open the lamp"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(rollershutterItem.getName(), UpDownType.UP));
+                .post(ItemEventFactory.createCommandEvent(rollershutterItem.getName(), UpDownType.UP, any()));
     }
 
     @Test
@@ -236,15 +236,15 @@ public class StandardInterpreterTest {
         when(itemRegistryMock.getAll()).thenReturn(items);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn off computer"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(computerItem.getName(), OnOffType.OFF));
+                .post(ItemEventFactory.createCommandEvent(computerItem.getName(), OnOffType.OFF, any()));
         reset(eventPublisherMock);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn off pc"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(computerItem.getName(), OnOffType.OFF));
+                .post(ItemEventFactory.createCommandEvent(computerItem.getName(), OnOffType.OFF, any()));
         reset(eventPublisherMock);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn off bedroom pc"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(computerItem.getName(), OnOffType.OFF));
+                .post(ItemEventFactory.createCommandEvent(computerItem.getName(), OnOffType.OFF, any()));
     }
 
     @Test
@@ -266,19 +266,19 @@ public class StandardInterpreterTest {
         when(itemRegistryMock.getAll()).thenReturn(items);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "set the brightness to low"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(brightness.getName(), new PercentType(10)));
+                .post(ItemEventFactory.createCommandEvent(brightness.getName(), new PercentType(10), any()));
         reset(eventPublisherMock);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "set brightness to medium"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(brightness.getName(), new PercentType(50)));
+                .post(ItemEventFactory.createCommandEvent(brightness.getName(), new PercentType(50), any()));
         reset(eventPublisherMock);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "set brightness high"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(brightness.getName(), new PercentType(90)));
+                .post(ItemEventFactory.createCommandEvent(brightness.getName(), new PercentType(90), any()));
         reset(eventPublisherMock);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "set brightness high two"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(brightness.getName(), new PercentType(100)));
+                .post(ItemEventFactory.createCommandEvent(brightness.getName(), new PercentType(100), any()));
     }
 
     @Test
@@ -302,7 +302,7 @@ public class StandardInterpreterTest {
         when(itemRegistryMock.getAll()).thenReturn(items);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "watch channel 4 on the tv"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(tvItem.getName(), new StringType("KEY_4")));
+                .post(ItemEventFactory.createCommandEvent(tvItem.getName(), new StringType("KEY_4"), any()));
         reset(eventPublisherMock);
     }
 
@@ -326,7 +326,7 @@ public class StandardInterpreterTest {
         when(itemRegistryMock.getAll()).thenReturn(items);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "watch channel 4 on the tv"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(tvItem.getName(), new StringType("KEY_4")));
+                .post(ItemEventFactory.createCommandEvent(tvItem.getName(), new StringType("KEY_4"), any()));
         reset(eventPublisherMock);
     }
 
@@ -350,7 +350,7 @@ public class StandardInterpreterTest {
         when(itemRegistryMock.getAll()).thenReturn(items);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "what time is it?"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(triggerItem.getName(), new StringType("time")));
+                .post(ItemEventFactory.createCommandEvent(triggerItem.getName(), new StringType("time"), any()));
         reset(eventPublisherMock);
     }
 
@@ -381,7 +381,7 @@ public class StandardInterpreterTest {
         when(itemRegistryMock.getAll()).thenReturn(items);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "what time is it?"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(triggerItem.getName(), new StringType("time")));
+                .post(ItemEventFactory.createCommandEvent(triggerItem.getName(), new StringType("time"), any()));
         reset(eventPublisherMock);
     }
 
@@ -396,7 +396,7 @@ public class StandardInterpreterTest {
         when(itemRegistryMock.getAll()).thenReturn(items);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "watch channel 4 on the tv"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(tvItem.getName(), new StringType("channel 4")));
+                .post(ItemEventFactory.createCommandEvent(tvItem.getName(), new StringType("channel 4"), any()));
         reset(eventPublisherMock);
     }
 
@@ -413,7 +413,7 @@ public class StandardInterpreterTest {
         when(itemRegistryMock.getAll()).thenReturn(items);
         assertEquals("", standardInterpreter.interpret(Locale.ENGLISH, "watch channel 4 on the tv"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(tvItem.getName(), new StringType("channel 4")));
+                .post(ItemEventFactory.createCommandEvent(tvItem.getName(), new StringType("channel 4"), any()));
         reset(eventPublisherMock);
     }
 
@@ -434,7 +434,7 @@ public class StandardInterpreterTest {
         when(itemRegistryMock.getAll()).thenReturn(items);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "watch channel 4 on the tv"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(tvItem.getName(), new StringType("channel 4")));
+                .post(ItemEventFactory.createCommandEvent(tvItem.getName(), new StringType("channel 4"), any()));
         reset(eventPublisherMock);
     }
 
@@ -448,7 +448,7 @@ public class StandardInterpreterTest {
         when(itemRegistryMock.getAll()).thenReturn(items);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "watch channel 4"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(virtualItem.getName(), new StringType("channel 4")));
+                .post(ItemEventFactory.createCommandEvent(virtualItem.getName(), new StringType("channel 4"), any()));
         reset(eventPublisherMock);
     }
 
@@ -478,7 +478,7 @@ public class StandardInterpreterTest {
         when(itemRegistryMock.getAll()).thenReturn(items);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "watch channel 4 on the tv"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(virtualItem.getName(), new StringType("KEY_4")));
+                .post(ItemEventFactory.createCommandEvent(virtualItem.getName(), new StringType("KEY_4"), any()));
         reset(eventPublisherMock);
     }
 
@@ -491,22 +491,22 @@ public class StandardInterpreterTest {
 
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "open blinds"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(blindsItem.getName(), UpDownType.UP));
+                .post(ItemEventFactory.createCommandEvent(blindsItem.getName(), UpDownType.UP, any()));
 
         reset(eventPublisherMock);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "open the blinds"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(blindsItem.getName(), UpDownType.UP));
+                .post(ItemEventFactory.createCommandEvent(blindsItem.getName(), UpDownType.UP, any()));
 
         reset(eventPublisherMock);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "close blinds"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(blindsItem.getName(), UpDownType.DOWN));
+                .post(ItemEventFactory.createCommandEvent(blindsItem.getName(), UpDownType.DOWN, any()));
 
         reset(eventPublisherMock);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "close the blinds"));
         verify(eventPublisherMock, times(1))
-                .post(ItemEventFactory.createCommandEvent(blindsItem.getName(), UpDownType.DOWN));
+                .post(ItemEventFactory.createCommandEvent(blindsItem.getName(), UpDownType.DOWN, any()));
     }
 
     @Test
@@ -545,7 +545,7 @@ public class StandardInterpreterTest {
         lenient().when(metadataRegistryMock.get(key)).thenReturn(new Metadata(key, "", configuration));
 
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn on light"));
-        verify(eventPublisherMock, times(1)).post(ItemEventFactory.createCommandEvent("light", OnOffType.ON));
+        verify(eventPublisherMock, times(1)).post(ItemEventFactory.createCommandEvent("light", OnOffType.ON, any()));
     }
 
     @Test
@@ -555,7 +555,7 @@ public class StandardInterpreterTest {
         lenient().when(itemRegistryMock.getAll()).thenReturn(List.of(lightItem));
 
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn on light"));
-        verify(eventPublisherMock, times(1)).post(ItemEventFactory.createCommandEvent("light", OnOffType.ON));
+        verify(eventPublisherMock, times(1)).post(ItemEventFactory.createCommandEvent("light", OnOffType.ON, any()));
 
         reset(eventPublisherMock);
         itemPermissionResolver.modified(
@@ -616,7 +616,7 @@ public class StandardInterpreterTest {
         lenient().when(metadataRegistryMock.get(itemKey)).thenReturn(new Metadata(itemKey, "", itemConfig));
 
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn on light"));
-        verify(eventPublisherMock, times(1)).post(ItemEventFactory.createCommandEvent("light", OnOffType.ON));
+        verify(eventPublisherMock, times(1)).post(ItemEventFactory.createCommandEvent("light", OnOffType.ON, any()));
     }
 
     @Test

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemCommandLLMToolTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemCommandLLMToolTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.voice.internal.text.interpreter.llm;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.events.EventPublisher;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemNotFoundException;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.voice.security.ItemPermission;
+import org.openhab.core.voice.security.ItemPermissionResolver;
+import org.openhab.core.voice.text.interpreter.llm.LLMToolException;
+
+/**
+ * Test class for {@link ItemCommandLLMTool}.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+public class ItemCommandLLMToolTest {
+    private static final String ITEM_NAME = "TestItem";
+
+    private final ItemRegistry itemRegistry = mock(ItemRegistry.class);
+    private final ItemPermissionResolver itemPermissionResolver = mock(ItemPermissionResolver.class);
+    private final EventPublisher eventPublisher = mock(EventPublisher.class);
+    private final Item item = mock(Item.class);
+
+    private @NonNullByDefault({}) ItemCommandLLMTool tool;
+
+    @BeforeEach
+    public void setUp() throws ItemNotFoundException {
+        when(itemRegistry.getItem(ITEM_NAME)).thenReturn(item);
+        when(item.getName()).thenReturn(ITEM_NAME);
+        when(item.getAcceptedCommandTypes()).thenReturn(List.of(OnOffType.class));
+        when(itemPermissionResolver.getPermission(item)).thenReturn(ItemPermission.READ_WRITE);
+
+        tool = new ItemCommandLLMTool(itemRegistry, itemPermissionResolver, eventPublisher);
+    }
+
+    @Test
+    public void getUIDReturnsCorrectId() {
+        assertEquals(ItemCommandLLMTool.ID, tool.getUID());
+    }
+
+    @Test
+    public void callSendsCommand() throws LLMToolException {
+        String result = tool.call(Map.of("itemName", ITEM_NAME, "command", "ON"), Locale.ENGLISH);
+        assertTrue(result.contains("Successfully sent command 'ON' to item 'TestItem'"));
+        verify(eventPublisher).post(any());
+    }
+
+    @Test
+    public void callThrowsLTEOnItemNotFound() throws ItemNotFoundException {
+        when(itemRegistry.getItem("UnknownItem")).thenThrow(new ItemNotFoundException("UnknownItem"));
+        LLMToolException exception = assertThrows(LLMToolException.class,
+                () -> tool.call(Map.of("itemName", "UnknownItem", "command", "ON"), Locale.ENGLISH));
+        String message = exception.getMessage();
+        assertNotNull(message);
+        assertTrue(message.contains("Item not found: UnknownItem"));
+        verify(eventPublisher, never()).post(any());
+    }
+
+    @Test
+    public void callThrowsLTEOnNotAccessible() {
+        when(itemPermissionResolver.getPermission(item)).thenReturn(ItemPermission.NO_ACCESS);
+        LLMToolException exception = assertThrows(LLMToolException.class,
+                () -> tool.call(Map.of("itemName", ITEM_NAME, "command", "ON"), Locale.ENGLISH));
+        String message = exception.getMessage();
+        assertNotNull(message);
+        assertTrue(message.contains("Item not found: TestItem"));
+        verify(eventPublisher, never()).post(any());
+    }
+
+    @Test
+    public void callThrowsLTEOnReadOnly() {
+        when(itemPermissionResolver.getPermission(item)).thenReturn(ItemPermission.READ_ONLY);
+        LLMToolException exception = assertThrows(LLMToolException.class,
+                () -> tool.call(Map.of("itemName", ITEM_NAME, "command", "ON"), Locale.ENGLISH));
+        String message = exception.getMessage();
+        assertNotNull(message);
+        assertTrue(message.contains("Item is read-only: TestItem"));
+        verify(eventPublisher, never()).post(any());
+    }
+
+    @Test
+    public void callThrowsLTEOnInvalidCommand() {
+        LLMToolException exception = assertThrows(LLMToolException.class,
+                () -> tool.call(Map.of("itemName", ITEM_NAME, "command", "INVALID"), Locale.ENGLISH));
+        String message = exception.getMessage();
+        assertNotNull(message);
+        assertTrue(message.contains("Failed to parse command 'INVALID' for item 'TestItem'"));
+        verify(eventPublisher, never()).post(any());
+    }
+
+    @Test
+    public void callThrowsLTEOnMissingParams() {
+        assertThrows(LLMToolException.class, () -> tool.call(Map.of(), Locale.ENGLISH));
+    }
+}

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMToolTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMToolTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.voice.internal.text.interpreter.llm;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemNotFoundException;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.voice.security.ItemPermissionResolver;
+import org.openhab.core.voice.text.interpreter.llm.LLMToolException;
+
+/**
+ * Test class for {@link ItemStateLLMTool}.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+public class ItemStateLLMToolTest {
+    private static final String ITEM_NAME = "TestItem";
+
+    private final ItemRegistry itemRegistry = mock(ItemRegistry.class);
+    private final ItemPermissionResolver itemPermissionResolver = mock(ItemPermissionResolver.class);
+    private final Item item = mock(Item.class);
+
+    private @NonNullByDefault({}) ItemStateLLMTool tool;
+
+    @BeforeEach
+    public void setUp() throws ItemNotFoundException {
+        when(itemRegistry.getItem(ITEM_NAME)).thenReturn(item);
+        when(item.getName()).thenReturn(ITEM_NAME);
+        when(item.getState()).thenReturn(OnOffType.ON);
+        when(itemPermissionResolver.isAccessible(item)).thenReturn(true);
+
+        tool = new ItemStateLLMTool(itemRegistry, itemPermissionResolver);
+    }
+
+    @Test
+    public void getUIDReturnsCorrectId() {
+        assertEquals(ItemStateLLMTool.ID, tool.getUID());
+    }
+
+    @Test
+    public void callReturnsState() throws LLMToolException {
+        String result = tool.call(Map.of("itemName", ITEM_NAME), Locale.ENGLISH);
+        assertEquals("ON", result);
+    }
+
+    @Test
+    public void callThrowsLTEOnItemNotFound() throws ItemNotFoundException {
+        when(itemRegistry.getItem("UnknownItem")).thenThrow(new ItemNotFoundException("UnknownItem"));
+        LLMToolException exception = assertThrows(LLMToolException.class,
+                () -> tool.call(Map.of("itemName", "UnknownItem"), Locale.ENGLISH));
+        String message = exception.getMessage();
+        assertNotNull(message);
+        assertTrue(message.contains("Item not found: UnknownItem"));
+    }
+
+    @Test
+    public void callThrowsLTEOnNotAccessible() {
+        when(itemPermissionResolver.isAccessible(item)).thenReturn(false);
+        LLMToolException exception = assertThrows(LLMToolException.class,
+                () -> tool.call(Map.of("itemName", ITEM_NAME), Locale.ENGLISH));
+        String message = exception.getMessage();
+        assertNotNull(message);
+        assertTrue(message.contains("Item not found: TestItem"));
+    }
+
+    @Test
+    public void callThrowsLTEOnMissingParams() {
+        assertThrows(LLMToolException.class, () -> tool.call(Map.of(), Locale.ENGLISH));
+    }
+}

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMToolTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMToolTest.java
@@ -25,6 +25,7 @@ import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.voice.security.ItemPermission;
 import org.openhab.core.voice.security.ItemPermissionResolver;
 import org.openhab.core.voice.text.interpreter.llm.LLMToolException;
 
@@ -76,7 +77,7 @@ public class ItemStateLLMToolTest {
 
     @Test
     public void callThrowsLTEOnNotAccessible() {
-        when(itemPermissionResolver.isAccessible(item)).thenReturn(false);
+        when(itemPermissionResolver.getPermission(item)).thenReturn(ItemPermission.NO_ACCESS);
         LLMToolException exception = assertThrows(LLMToolException.class,
                 () -> tool.call(Map.of("itemName", ITEM_NAME), Locale.ENGLISH));
         String message = exception.getMessage();

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMToolTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMToolTest.java
@@ -54,7 +54,7 @@ public class ItemStateLLMToolTest {
         when(itemRegistry.getItem(ITEM_NAME)).thenReturn(item);
         when(item.getName()).thenReturn(ITEM_NAME);
         when(item.getState()).thenReturn(OnOffType.ON);
-        when(itemPermissionResolver.isAccessible(item)).thenReturn(true);
+        when(itemPermissionResolver.getPermission(item)).thenReturn(ItemPermission.READ_ONLY);
         when(timeZoneProvider.getTimeZone()).thenReturn(ZoneId.systemDefault());
 
         tool = new ItemStateLLMTool(itemRegistry, itemPermissionResolver, timeZoneProvider);

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMToolTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMToolTest.java
@@ -15,16 +15,20 @@ package org.openhab.core.voice.internal.text.interpreter.llm;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.ZoneId;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.types.StateDescription;
 import org.openhab.core.voice.security.ItemPermission;
 import org.openhab.core.voice.security.ItemPermissionResolver;
 import org.openhab.core.voice.text.interpreter.llm.LLMToolException;
@@ -40,6 +44,7 @@ public class ItemStateLLMToolTest {
 
     private final ItemRegistry itemRegistry = mock(ItemRegistry.class);
     private final ItemPermissionResolver itemPermissionResolver = mock(ItemPermissionResolver.class);
+    private final TimeZoneProvider timeZoneProvider = mock(TimeZoneProvider.class);
     private final Item item = mock(Item.class);
 
     private @NonNullByDefault({}) ItemStateLLMTool tool;
@@ -50,8 +55,9 @@ public class ItemStateLLMToolTest {
         when(item.getName()).thenReturn(ITEM_NAME);
         when(item.getState()).thenReturn(OnOffType.ON);
         when(itemPermissionResolver.isAccessible(item)).thenReturn(true);
+        when(timeZoneProvider.getTimeZone()).thenReturn(ZoneId.systemDefault());
 
-        tool = new ItemStateLLMTool(itemRegistry, itemPermissionResolver);
+        tool = new ItemStateLLMTool(itemRegistry, itemPermissionResolver, timeZoneProvider);
     }
 
     @Test
@@ -60,9 +66,32 @@ public class ItemStateLLMToolTest {
     }
 
     @Test
-    public void callReturnsState() throws LLMToolException {
+    public void callReturnsStateWhenNoDisplayState() throws LLMToolException {
+        when(item.getStateDescription(Locale.ENGLISH)).thenReturn(null);
         String result = tool.call(Map.of("itemName", ITEM_NAME), Locale.ENGLISH);
         assertEquals("ON", result);
+    }
+
+    @Test
+    public void callReturnsStateWhenDisplayStateSameAsRaw() throws LLMToolException {
+        StateDescription stateDescription = mock(StateDescription.class);
+        when(stateDescription.getPattern()).thenReturn("%s");
+        when(stateDescription.getOptions()).thenReturn(List.of());
+        when(item.getStateDescription(Locale.ENGLISH)).thenReturn(stateDescription);
+
+        String result = tool.call(Map.of("itemName", ITEM_NAME), Locale.ENGLISH);
+        assertEquals("ON", result);
+    }
+
+    @Test
+    public void callReturnsDisplayAndRawStateWhenDisplayStateAvailableAndDifferent() throws LLMToolException {
+        StateDescription stateDescription = mock(StateDescription.class);
+        when(stateDescription.getPattern()).thenReturn("%s Test");
+        when(stateDescription.getOptions()).thenReturn(List.of());
+        when(item.getStateDescription(Locale.ENGLISH)).thenReturn(stateDescription);
+
+        String result = tool.call(Map.of("itemName", ITEM_NAME), Locale.ENGLISH);
+        assertEquals("ON Test (ON)", result);
     }
 
     @Test


### PR DESCRIPTION
Completes two of the tasks outlined in the plan in https://github.com/openhab/openhab-core/pull/5620.

This adds two new `LLMTool`s for getting the state of an Item and sending commands to an Item.
Both tools validate that the Item is accessible by `HumanLanguageInterpreter`s.

Also set the event source when sending Item commands in `AbstractRuleBasedInterpreter`.