### PR TITLE
[automation] Enable asynchronous execution of rules and lock engine lock when loading scripts

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/delegates/SimpleTriggerHandlerCallbackDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/delegates/SimpleTriggerHandlerCallbackDelegate.java
@@ -13,6 +13,7 @@
 package org.openhab.core.automation.module.script.rulesupport.internal.delegates;
 
 import java.util.Map;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -81,5 +82,16 @@ public class SimpleTriggerHandlerCallbackDelegate implements SimpleTriggerHandle
     @Override
     public void runNow(String uid, boolean considerConditions, @Nullable Map<String, @Nullable Object> context) {
         callback.runNow(uid, considerConditions, context);
+    }
+
+    @Override
+    public Future<Map<String, @Nullable Object>> runAsync(String ruleUID) {
+        return callback.runAsync(ruleUID);
+    }
+
+    @Override
+    public Future<Map<String, @Nullable Object>> runAsync(String ruleUID, boolean considerConditions,
+            @Nullable Map<String, @Nullable Object> context) {
+        return callback.runAsync(ruleUID, considerConditions, context);
     }
 }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/LockableScriptEngine.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/LockableScriptEngine.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script;
+
+import java.util.concurrent.locks.Lock;
+
+import javax.script.ScriptEngine;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * This interface is used to indicate that a {@link ScriptEngine} is lockable, i.e. that it doesn't support
+ * concurrency and should run scripts inside a lock.
+ *
+ * @author Ravi Nadahar - Initial contribution
+ */
+@NonNullByDefault
+public interface LockableScriptEngine extends ScriptEngine {
+
+    /**
+     * @return The {@link Lock} instance that should be used to guard script execution.
+     */
+    Lock getLock();
+
+    /**
+     * Get the lock acquisition timeout for use with {@link Lock#tryLock(long, java.util.concurrent.TimeUnit)}. The
+     * lock should always be acquired with a timeout to avoid deadlocks.
+     *
+     * @return The timeout period to wait when trying to acquire the {@link Lock} in milliseconds before considering the
+     *         acquisition a failure.
+     *
+     * @implNote A default implementation with a 5 seconds timeout exists.
+     */
+    default long getLockAcquisitionTimeoutMs() {
+        return 5000L;
+    }
+}

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
 
 import javax.script.Invocable;
 import javax.script.ScriptContext;
@@ -55,6 +56,7 @@ import org.slf4j.LoggerFactory;
 @Component(service = ScriptEngineManager.class)
 public class ScriptEngineManagerImpl implements ScriptEngineManager {
 
+    private static final long LOCK_ACQUISITION_TIMEOUT_S = 60L;
     private final ScheduledExecutorService scheduler = ThreadPoolManager
             .getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON);
 
@@ -159,32 +161,61 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
         ScriptEngineContainer container = loadedScriptEngineInstances.get(engineIdentifier);
         if (container == null) {
             logger.error("Could not load script, as no ScriptEngine has been created");
-        } else {
-            ScriptEngine engine = container.getScriptEngine();
-            try {
-                engine.eval(scriptData);
-                if (engine instanceof Invocable inv) {
-                    try {
-                        inv.invokeFunction("scriptLoaded", engineIdentifier);
-                    } catch (NoSuchMethodException e) {
-                        logger.trace("scriptLoaded() is not defined in the script: {}", engineIdentifier);
-                    }
-                } else {
-                    logger.trace("ScriptEngine does not support Invocable interface");
-                }
-                return true;
-            } catch (Exception ex) {
-                logger.error("Error during evaluation of script '{}': {}", engineIdentifier, ex.getMessage());
-                // Only call logger if debug level is actually enabled, because OPS4J Pax Logging holds (at least for
-                // some time) a reference to the exception and its cause, which may hold a reference to the script
-                // engine.
-                // This prevents garbage collection (at least for some time) to remove the script engine from heap.
-                if (logger.isDebugEnabled()) {
-                    logger.debug("", ex);
-                }
-            }
+            return false;
         }
-        return false;
+        ScriptEngine engine = container.getScriptEngine();
+        if (engine instanceof Lock lock) {
+            boolean locked;
+            try {
+                locked = lock.tryLock(LOCK_ACQUISITION_TIMEOUT_S, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.error("Interrupted while waiting to acquire the lock while loading script for engine '{}'",
+                        engineIdentifier);
+                logger.trace("", e);
+                return false;
+            }
+            if (locked) {
+                try {
+                    return runScript(engineIdentifier, engine, scriptData);
+                } finally {
+                    lock.unlock();
+                }
+            } else {
+                logger.error(
+                        "Failed to acquire the lock while loading script for engine '{}' within {} seconds. Aborting loading of script.",
+                        engineIdentifier, LOCK_ACQUISITION_TIMEOUT_S);
+                return false;
+            }
+        } else {
+            return runScript(engineIdentifier, engine, scriptData);
+        }
+    }
+
+    private boolean runScript(String engineIdentifier, ScriptEngine engine, InputStreamReader scriptData) {
+        try {
+            engine.eval(scriptData);
+            if (engine instanceof Invocable inv) {
+                try {
+                    inv.invokeFunction("scriptLoaded", engineIdentifier);
+                } catch (NoSuchMethodException e) {
+                    logger.trace("scriptLoaded() is not defined in the script: {}", engineIdentifier);
+                }
+            } else {
+                logger.trace("ScriptEngine does not support Invocable interface");
+            }
+            return true;
+        } catch (Exception ex) {
+            logger.error("Error during evaluation of script '{}': {}", engineIdentifier, ex.getMessage());
+            // Only call logger if debug level is actually enabled, because OPS4J Pax Logging holds (at least for
+            // some time) a reference to the exception and its cause, which may hold a reference to the script
+            // engine.
+            // This prevents garbage collection (at least for some time) to remove the script engine from heap.
+            if (logger.isDebugEnabled()) {
+                logger.debug("", ex);
+            }
+            return false;
+        }
     }
 
     @Override

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -32,6 +32,7 @@ import javax.script.SimpleScriptContext;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.module.script.LockableScriptEngine;
 import org.openhab.core.automation.module.script.ScriptDependencyTracker;
 import org.openhab.core.automation.module.script.ScriptEngineContainer;
 import org.openhab.core.automation.module.script.ScriptEngineFactory;
@@ -56,7 +57,6 @@ import org.slf4j.LoggerFactory;
 @Component(service = ScriptEngineManager.class)
 public class ScriptEngineManagerImpl implements ScriptEngineManager {
 
-    private static final long LOCK_ACQUISITION_TIMEOUT_S = 60L;
     private final ScheduledExecutorService scheduler = ThreadPoolManager
             .getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON);
 
@@ -164,10 +164,12 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
             return false;
         }
         ScriptEngine engine = container.getScriptEngine();
-        if (engine instanceof Lock lock) {
+        if (engine instanceof LockableScriptEngine lockable) {
+            Lock lock = lockable.getLock();
+            long timeout = lockable.getLockAcquisitionTimeoutMs();
             boolean locked;
             try {
-                locked = lock.tryLock(LOCK_ACQUISITION_TIMEOUT_S, TimeUnit.SECONDS);
+                locked = lock.tryLock(timeout, TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.error("Interrupted while waiting to acquire the lock while loading script for engine '{}'",
@@ -182,9 +184,15 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
                     lock.unlock();
                 }
             } else {
-                logger.error(
-                        "Failed to acquire the lock while loading script for engine '{}' within {} seconds. Aborting loading of script.",
-                        engineIdentifier, LOCK_ACQUISITION_TIMEOUT_S);
+                if (timeout < 2000L) {
+                    logger.error(
+                            "Failed to acquire the lock while loading script for engine '{}' within {} milliseconds. Aborting loading of script.",
+                            engineIdentifier, timeout);
+                } else {
+                    logger.error(
+                            "Failed to acquire the lock while loading script for engine '{}' within {} seconds. Aborting loading of script.",
+                            engineIdentifier, TimeUnit.MILLISECONDS.toSeconds(timeout));
+                }
                 return false;
             }
         } else {

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptActionHandler.java
@@ -25,6 +25,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.Action;
 import org.openhab.core.automation.handler.ActionHandler;
+import org.openhab.core.automation.module.script.LockableScriptEngine;
 import org.openhab.core.automation.module.script.ScriptEngineManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,15 +86,29 @@ public class ScriptActionHandler extends AbstractScriptModuleHandler<Action> imp
         }
 
         ScriptEngine scriptEngine = getScriptEngine();
+        Lock lock = null;
+        long timeout = 0L;
+        if (scriptEngine instanceof LockableScriptEngine lockable) {
+            lock = lockable.getLock();
+            timeout = lockable.getLockAcquisitionTimeoutMs();
+        }
         if (scriptEngine != null) {
             try {
-                if (scriptEngine instanceof Lock lock && !lock.tryLock(1, TimeUnit.MINUTES)) {
-                    logger.error(
-                            "Failed to acquire lock within one minute for script module '{}' of rule with UID '{}'",
-                            module.getId(), ruleUID);
+                if (lock != null && !lock.tryLock(timeout, TimeUnit.MILLISECONDS)) {
+                    if (timeout < 2000L) {
+                        logger.error(
+                                "Failed to acquire lock within {} milliseconds for script module '{}' of rule with UID '{}'",
+                                timeout, module.getId(), ruleUID);
+
+                    } else {
+                        logger.error(
+                                "Failed to acquire lock within {} seconds for script module '{}' of rule with UID '{}'",
+                                TimeUnit.MILLISECONDS.toSeconds(timeout), module.getId(), ruleUID);
+                    }
                     return resultMap;
                 }
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
             }
             try {
@@ -101,9 +116,8 @@ public class ScriptActionHandler extends AbstractScriptModuleHandler<Action> imp
                 Object result = eval(scriptEngine);
                 resultMap.put("result", result);
                 resetExecutionContext(scriptEngine, context);
-            } finally { // Make sure that Lock is unlocked regardless of an exception being thrown or not to avoid
-                        // deadlocks
-                if (scriptEngine instanceof Lock lock) {
+            } finally {
+                if (lock != null) {
                     lock.unlock();
                 }
             }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptConditionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptConditionHandler.java
@@ -22,6 +22,7 @@ import javax.script.ScriptException;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.automation.Condition;
 import org.openhab.core.automation.handler.ConditionHandler;
+import org.openhab.core.automation.module.script.LockableScriptEngine;
 import org.openhab.core.automation.module.script.ScriptEngineManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,16 +65,29 @@ public class ScriptConditionHandler extends AbstractScriptModuleHandler<Conditio
         }
 
         ScriptEngine scriptEngine = getScriptEngine();
+        Lock lock = null;
+        long timeout = 0L;
+        if (scriptEngine instanceof LockableScriptEngine lockable) {
+            lock = lockable.getLock();
+            timeout = lockable.getLockAcquisitionTimeoutMs();
+        }
 
         if (scriptEngine != null) {
             try {
-                if (scriptEngine instanceof Lock lock && !lock.tryLock(1, TimeUnit.MINUTES)) {
-                    logger.error(
-                            "Failed to acquire lock within one minute for script module '{}' of rule with UID '{}'",
-                            module.getId(), ruleUID);
+                if (lock != null && !lock.tryLock(timeout, TimeUnit.MILLISECONDS)) {
+                    if (timeout < 2000L) {
+                        logger.error(
+                                "Failed to acquire lock within {} milliseconds for script module '{}' of rule with UID '{}'",
+                                timeout, module.getId(), ruleUID);
+                    } else {
+                        logger.error(
+                                "Failed to acquire lock within {} seconds for script module '{}' of rule with UID '{}'",
+                                TimeUnit.MILLISECONDS.toSeconds(timeout), module.getId(), ruleUID);
+                    }
                     return result;
                 }
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
             }
             try {
@@ -86,9 +100,8 @@ public class ScriptConditionHandler extends AbstractScriptModuleHandler<Conditio
                             returnVal);
                 }
                 resetExecutionContext(scriptEngine, context);
-            } finally { // Make sure that Lock is unlocked regardless of an exception being thrown or not to avoid
-                        // deadlocks
-                if (scriptEngine instanceof Lock lock) {
+            } finally {
+                if (lock != null) {
                     lock.unlock();
                 }
             }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/ModuleHandlerCallback.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/ModuleHandlerCallback.java
@@ -13,6 +13,7 @@
 package org.openhab.core.automation;
 
 import java.util.Map;
+import java.util.concurrent.Future;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -92,4 +93,45 @@ public interface ModuleHandlerCallback {
      * @param context the context that is passed to the conditions and the actions of the rule.
      */
     void runNow(String uid, boolean considerConditions, @Nullable Map<String, @Nullable Object> context);
+
+    /**
+     * The method skips triggers and conditions and executes the actions of the rule asynchronously.
+     * This should always be possible unless an action has a mandatory input that is linked to a trigger.
+     * In that case the action is skipped and the rule engine continues execution of remaining actions.
+     * <p>
+     * <b>Note:</b> Unlike {@link #runNow(String)}, this method will return immediately. To wait for the execution to be
+     * completed, call {@link Future#get()} on the returned {@link Future}.
+     *
+     * @param ruleUID uid of the rule whose actions should be executed.
+     * @return A {@link Future} containing the copy of the rule context after completion, including possible return
+     *         values.
+     * @throws UnsupportedOperationException If asynchronous execution isn't supported by the {@link RuleManager}
+     *             implementation.
+     *
+     * @implNote The default implementation simply calls {@link #runAsync(String, boolean, Map)}.
+     */
+    default Future<Map<String, @Nullable Object>> runAsync(String ruleUID) {
+        return runAsync(ruleUID, false, null);
+    }
+
+    /**
+     * Same as {@link #runAsync(String)} with the additional option to enable/disable evaluation of
+     * conditions defined in the target rule. The context can be set here, too, but might also be {@code null}.
+     * <p>
+     * <b>Note:</b> Unlike {@link #runNow(String, boolean, Map)}, this method will return immediately. To wait for the
+     * execution to be completed, call {@link Future#get()} on the returned {@link Future}.
+     *
+     * @param ruleUID uid of the rule whose actions should be executed.
+     * @param considerConditions if {@code true} the conditions of the rule will be checked.
+     * @param context the context that is passed to the conditions and the actions of the rule.
+     * @return a copy of the rule context, including possible return values
+     * @throws UnsupportedOperationException If asynchronous execution isn't supported by the {@link RuleManager}
+     *             implementation.
+     *
+     * @implNote The default implementation throws an {@link UnsupportedOperationException}.
+     */
+    default Future<Map<String, @Nullable Object>> runAsync(String ruleUID, boolean considerConditions,
+            @Nullable Map<String, @Nullable Object> context) {
+        throw new UnsupportedOperationException("runAsync() isn't implemented by " + getClass().getName());
+    }
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleManager.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleManager.java
@@ -14,6 +14,7 @@ package org.openhab.core.automation;
 
 import java.time.ZonedDateTime;
 import java.util.Map;
+import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -99,6 +100,47 @@ public interface RuleManager {
      */
     Map<String, @Nullable Object> runNow(String uid, boolean considerConditions,
             @Nullable Map<String, @Nullable Object> context);
+
+    /**
+     * The method skips triggers and conditions and executes the actions of the rule asynchronously.
+     * This should always be possible unless an action has a mandatory input that is linked to a trigger.
+     * In that case the action is skipped and the rule engine continues execution of remaining actions.
+     * <p>
+     * <b>Note:</b> Unlike {@link #runNow(String)}, this method will return immediately. To wait for the execution to be
+     * completed, call {@link Future#get()} on the returned {@link Future}.
+     *
+     * @param ruleUID uid of the rule whose actions should be executed.
+     * @return A {@link Future} containing the copy of the rule context after completion, including possible return
+     *         values.
+     * @throws UnsupportedOperationException If asynchronous execution isn't supported by the {@link RuleManager}
+     *             implementation.
+     *
+     * @implNote The default implementation simply calls {@link #runAsync(String, boolean, Map)}.
+     */
+    default Future<Map<String, @Nullable Object>> runAsync(String ruleUID) {
+        return runAsync(ruleUID, false, null);
+    }
+
+    /**
+     * Same as {@link #runAsync(String)} with the additional option to enable/disable evaluation of
+     * conditions defined in the target rule. The context can be set here, too, but might also be {@code null}.
+     * <p>
+     * <b>Note:</b> Unlike {@link #runNow(String, boolean, Map)}, this method will return immediately. To wait for the
+     * execution to be completed, call {@link Future#get()} on the returned {@link Future}.
+     *
+     * @param ruleUID uid of the rule whose actions should be executed.
+     * @param considerConditions if {@code true} the conditions of the rule will be checked.
+     * @param context the context that is passed to the conditions and the actions of the rule.
+     * @return a copy of the rule context, including possible return values
+     * @throws UnsupportedOperationException If asynchronous execution isn't supported by the {@link RuleManager}
+     *             implementation.
+     *
+     * @implNote The default implementation throws an {@link UnsupportedOperationException}.
+     */
+    default Future<Map<String, @Nullable Object>> runAsync(String ruleUID, boolean considerConditions,
+            @Nullable Map<String, @Nullable Object> context) {
+        throw new UnsupportedOperationException("runAsync() isn't implemented by " + getClass().getName());
+    }
 
     /**
      * Simulates the execution of all rules with tag 'Schedule' for the given time interval.

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -264,6 +264,17 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
         public void runNow(String uid, boolean considerConditions, @Nullable Map<String, @Nullable Object> context) {
             RuleEngineImpl.this.runNow(uid, considerConditions, context);
         }
+
+        @Override
+        public Future<Map<String, @Nullable Object>> runAsync(String ruleUID) {
+            return RuleEngineImpl.this.runAsync(ruleUID);
+        }
+
+        @Override
+        public Future<Map<String, @Nullable Object>> runAsync(String ruleUID, boolean considerConditions,
+                @Nullable Map<String, @Nullable Object> context) {
+            return RuleEngineImpl.this.runAsync(ruleUID, considerConditions, context);
+        }
     };
 
     /**

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutionException;
@@ -923,8 +925,8 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
         if (started && slTriggers.stream()
                 .anyMatch(t -> ((BigDecimal) t.getConfiguration().get(SystemTriggerHandler.CFG_STARTLEVEL))
                         .intValue() <= startLevel)) {
-            runNow(rule.getUID(), true, Map.of(SystemTriggerHandler.OUT_STARTLEVEL, StartLevelService.STARTLEVEL_RULES,
-                    "event", SystemEventFactory.createStartlevelEvent(startLevel)));
+            runAsync(rule.getUID(), true, Map.of(SystemTriggerHandler.OUT_STARTLEVEL,
+                    StartLevelService.STARTLEVEL_RULES, "event", SystemEventFactory.createStartlevelEvent(startLevel)));
         }
 
         return true;
@@ -1122,9 +1124,9 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
                 boolean isSatisfied = calculateConditions(rule);
                 if (isSatisfied) {
                     executeActions(rule, true);
-                    logger.debug("The rule '{}' is executed.", ruleUID);
+                    logger.debug("The rule '{}' was executed.", ruleUID);
                 } else {
-                    logger.debug("The rule '{}' is NOT executed, since it has unsatisfied conditions.", ruleUID);
+                    logger.debug("The rule '{}' was NOT executed, since it has unsatisfied conditions.", ruleUID);
                 }
             }
         } catch (Throwable t) {
@@ -1164,39 +1166,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
 
         Future<Map<String, @Nullable Object>> future;
         try {
-            future = thCallback.getScheduler().submit(() -> {
-                Map<String, @Nullable Object> returnContext = new HashMap<>();
-                synchronized (this) {
-                    final RuleStatus ruleStatus = getRuleStatus(ruleUID);
-                    if (ruleStatus != null && ruleStatus != RuleStatus.IDLE) {
-                        logger.error("Failed to execute rule '{}' with status '{}'", ruleUID, ruleStatus.name());
-                        return Map.of();
-                    }
-                    // change state to RUNNING
-                    setStatus(ruleUID, new RuleStatusInfo(RuleStatus.RUNNING));
-                }
-                try {
-                    clearContext(ruleUID);
-                    if (context != null && !context.isEmpty()) {
-                        getContext(ruleUID, null).putAll(context);
-                    }
-                    if (!considerConditions || calculateConditions(rule)) {
-                        executeActions(rule, false);
-                    }
-                    logger.debug("The rule '{}' is executed.", ruleUID);
-                    returnContext.putAll(getContext(ruleUID, null));
-                } catch (Throwable t) {
-                    logger.error("Failed to execute rule '{}': ", ruleUID, t);
-                } finally {
-                    // change state to IDLE only if the rule has not been DISABLED.
-                    synchronized (this) {
-                        if (getRuleStatus(ruleUID) == RuleStatus.RUNNING) {
-                            setStatus(ruleUID, new RuleStatusInfo(RuleStatus.IDLE));
-                        }
-                    }
-                }
-                return returnContext;
-            });
+            future = thCallback.getScheduler().submit(new RunRuleCallable(rule, considerConditions, context));
         } catch (RejectedExecutionException e) {
             logger.warn("Failed to execute rule '{}' because the rule executor rejected execution: {}", ruleUID,
                     e.getMessage());
@@ -1217,6 +1187,46 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
     @Override
     public Map<String, @Nullable Object> runNow(String ruleUID) {
         return runNow(ruleUID, false, null);
+    }
+
+    @Override
+    public Future<Map<String, @Nullable Object>> runAsync(String ruleUID) {
+        return runAsync(ruleUID, false, null);
+    }
+
+    @Override
+    public Future<Map<String, @Nullable Object>> runAsync(String ruleUID, boolean considerConditions,
+            @Nullable Map<String, @Nullable Object> context) {
+        final WrappedRule rule = getManagedRule(ruleUID);
+        if (rule == null) {
+            logger.warn("Failed to execute rule '{}': Invalid rule UID", ruleUID);
+            return CompletableFuture.failedFuture(new IllegalArgumentException("Invalid rule UID: " + ruleUID));
+        }
+
+        TriggerHandlerCallbackImpl thCallback;
+        synchronized (this) {
+            thCallback = thCallbacks.get(ruleUID);
+        }
+        if (thCallback == null) {
+            RuleStatus ruleStatus;
+            synchronized (this) {
+                ruleStatus = getRuleStatus(ruleUID);
+            }
+            logger.error("Failed to execute rule '{}' with status '{}': could not acquire rule thread", ruleUID,
+                    ruleStatus == null ? "UNKNOWN" : ruleStatus.name());
+            return CompletableFuture.failedFuture(new IllegalStateException(
+                    "Could not acquire rule thread for rule '" + ruleUID + "' for rule execution"));
+        }
+
+        Future<Map<String, @Nullable Object>> future;
+        try {
+            future = thCallback.getScheduler().submit(new RunRuleCallable(rule, considerConditions, context));
+        } catch (RejectedExecutionException e) {
+            logger.warn("Failed to execute rule '{}' because the rule executor rejected execution: {}", ruleUID,
+                    e.getMessage());
+            return CompletableFuture.failedFuture(e);
+        }
+        return future;
     }
 
     /**
@@ -1680,11 +1690,26 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
 
     private void executeRulesWithStartLevel() {
         getScheduledExecutor().submit(() -> {
-            ruleRegistry.stream() //
+            List<Future<Map<String, @Nullable Object>>> futures = ruleRegistry.stream() //
                     .filter(this::mustTrigger) //
-                    .forEach(r -> runNow(r.getUID(), true,
+                    .map(r -> runAsync(r.getUID(), true,
                             Map.of(SystemTriggerHandler.OUT_STARTLEVEL, StartLevelService.STARTLEVEL_RULES, "event",
-                                    SystemEventFactory.createStartlevelEvent(StartLevelService.STARTLEVEL_RULES))));
+                                    SystemEventFactory.createStartlevelEvent(StartLevelService.STARTLEVEL_RULES))))
+                    .toList();
+
+            // Wait for the rule executions to complete before announcing to be "started"
+            for (Future<Map<String, @Nullable Object>> future : futures) {
+                try {
+                    future.get();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    logger.warn("Interrupted while executing rules with startlevels");
+                    return;
+                } catch (ExecutionException e) {
+                    logger.warn("Failed to execute rule at startlevel: {}", e.getMessage());
+                    logger.trace("", e);
+                }
+            }
             started = true;
             readyService.markReady(MARKER);
             logger.info("Rule engine started.");
@@ -1754,5 +1779,56 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
     @Override
     public Stream<RuleExecution> simulateRuleExecutions(ZonedDateTime from, ZonedDateTime until) {
         return new RuleExecutionSimulator(this.ruleRegistry, this).simulateRuleExecutions(from, until);
+    }
+
+    private class RunRuleCallable implements Callable<Map<String, @Nullable Object>> {
+
+        private final WrappedRule rule;
+        private final boolean considerConditions;
+        private final @Nullable Map<String, @Nullable Object> context;
+
+        public RunRuleCallable(WrappedRule rule, boolean considerConditions,
+                @Nullable Map<String, @Nullable Object> context) {
+            this.rule = rule;
+            this.considerConditions = considerConditions;
+            this.context = context;
+        }
+
+        @Override
+        public Map<String, @Nullable Object> call() throws Exception {
+            String ruleUID = rule.getUID();
+            Map<String, @Nullable Object> returnContext = new HashMap<>();
+            synchronized (RuleEngineImpl.this) {
+                final RuleStatus ruleStatus = getRuleStatus(ruleUID);
+                if (ruleStatus != null && ruleStatus != RuleStatus.IDLE) {
+                    logger.error("Failed to execute rule '{}' with status '{}'", ruleUID, ruleStatus.name());
+                    return Map.of();
+                }
+                // change state to RUNNING
+                setStatus(ruleUID, new RuleStatusInfo(RuleStatus.RUNNING));
+            }
+            try {
+                clearContext(ruleUID);
+                Map<String, @Nullable Object> context = this.context;
+                if (context != null && !context.isEmpty()) {
+                    getContext(ruleUID, null).putAll(context);
+                }
+                if (!considerConditions || calculateConditions(rule)) {
+                    executeActions(rule, false);
+                }
+                logger.debug("The rule '{}' was executed.", ruleUID);
+                returnContext.putAll(getContext(ruleUID, null));
+            } catch (Throwable t) {
+                logger.error("Failed to execute rule '{}': ", ruleUID, t);
+            } finally {
+                // change state to IDLE only if the rule has not been DISABLED.
+                synchronized (RuleEngineImpl.this) {
+                    if (getRuleStatus(ruleUID) == RuleStatus.RUNNING) {
+                        setStatus(ruleUID, new RuleStatusInfo(RuleStatus.IDLE));
+                    }
+                }
+            }
+            return returnContext;
+        }
     }
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/TriggerHandlerCallbackImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/TriggerHandlerCallbackImpl.java
@@ -124,6 +124,17 @@ public class TriggerHandlerCallbackImpl implements TriggerHandlerCallback {
     }
 
     @Override
+    public Future<Map<String, @Nullable Object>> runAsync(String ruleUID) {
+        return re.runAsync(ruleUID);
+    }
+
+    @Override
+    public Future<Map<String, @Nullable Object>> runAsync(String ruleUID, boolean considerConditions,
+            @Nullable Map<String, @Nullable Object> context) {
+        return re.runAsync(ruleUID, considerConditions, context);
+    }
+
+    @Override
     public ScheduledExecutorService getScheduler() {
         return executor;
     }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/CompositeTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/CompositeTriggerHandler.java
@@ -17,6 +17,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -173,5 +174,16 @@ public class CompositeTriggerHandler
     @Override
     public void runNow(String uid, boolean considerConditions, @Nullable Map<String, @Nullable Object> context) {
         callback.runNow(uid, considerConditions, context);
+    }
+
+    @Override
+    public Future<Map<String, @Nullable Object>> runAsync(String ruleUID) {
+        return callback.runAsync(ruleUID);
+    }
+
+    @Override
+    public Future<Map<String, @Nullable Object>> runAsync(String ruleUID, boolean considerConditions,
+            @Nullable Map<String, @Nullable Object> context) {
+        return callback.runAsync(ruleUID, considerConditions, context);
     }
 }

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationTest.java
@@ -102,8 +102,8 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
     private @Nullable ThingRegistry thingRegistry;
     private @Nullable ItemRegistry itemRegistry;
     private @NonNullByDefault({}) StartLevelService startLevelService;
-    private @Nullable RuleRegistry ruleRegistry;
-    private @Nullable RuleManager ruleEngine;
+    private @NonNullByDefault({}) RuleRegistry ruleRegistry;
+    private @NonNullByDefault({}) RuleManager ruleEngine;
     private @Nullable ManagedRuleProvider managedRuleProvider;
     private @Nullable ModuleTypeRegistry moduleTypeRegistry;
     private @Nullable TemplateRegistry<RuleTemplate> templateRegistry;
@@ -426,7 +426,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
     }
 
     @Test
-    public void assertThatRuleNowMethodExecutesActionsOfTheRule() throws ItemNotFoundException {
+    public void assertThatRunNowMethodExecutesActionsOfTheRule() throws ItemNotFoundException {
         Configuration triggerConfig = new Configuration(Map.of("topic", "runNowEventTopic/*"));
         Map<String, Object> params = new HashMap<>();
         params.put("itemName", "myLampItem3");
@@ -478,6 +478,69 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
         registerService(itemEventHandler);
 
         ruleEngine.runNow(rule.getUID());
+        waitForAssert(() -> {
+            assertThat(itemEvent, is(notNullValue()));
+        }, 3000, 100);
+        waitForAssert(() -> {
+            assertThat(((ItemCommandEvent) itemEvent).getItemCommand(), is(OnOffType.ON));
+        }, 3000, 100);
+
+        ruleRegistry.remove(rule.getUID());
+    }
+
+    @Test
+    public void assertThatRunAsyncMethodExecutesActionsOfTheRule() throws ItemNotFoundException {
+        Configuration triggerConfig = new Configuration(Map.of("topic", "runNowEventTopic/*"));
+        Map<String, Object> params = new HashMap<>();
+        params.put("itemName", "myLampItem3");
+        params.put("command", "TOGGLE");
+        Configuration actionConfig = new Configuration(params);
+        params = new HashMap<>();
+        params.put("itemName", "myLampItem3");
+        params.put("command", "ON");
+        Configuration actionConfig2 = new Configuration(params);
+        params = new HashMap<>();
+        params.put("itemName", "myLampItem3");
+        params.put("command", "OFFF");
+        Configuration actionConfig3 = new Configuration(params);
+        List<Trigger> triggers = List.of(ModuleBuilder.createTrigger().withId("GenericEventTriggerId")
+                .withTypeUID("core.GenericEventTrigger").withConfiguration(triggerConfig).build());
+        List<Action> actions = List.of(
+                ModuleBuilder.createAction().withId("ItemPostCommandActionId").withTypeUID("core.ItemCommandAction")
+                        .withConfiguration(actionConfig).build(),
+                ModuleBuilder.createAction().withId("ItemPostCommandActionId2").withTypeUID("core.ItemCommandAction")
+                        .withConfiguration(actionConfig2).build(),
+                ModuleBuilder.createAction().withId("ItemPostCommandActionId3").withTypeUID("core.ItemCommandAction")
+                        .withConfiguration(actionConfig3).build());
+
+        Rule rule = RuleBuilder.create("runNowRule" + new Random().nextInt()).withTriggers(triggers)
+                .withActions(actions).build();
+        logger.info("Rule created: {}", rule.getUID());
+
+        ruleRegistry.add(rule);
+
+        // TEST RULE
+        waitForAssert(() -> {
+            assertThat(ruleEngine.getStatusInfo(rule.getUID()).getStatus(), is(RuleStatus.IDLE));
+        }, 3000, 100);
+
+        EventSubscriber itemEventHandler = new EventSubscriber() {
+            @Override
+            public Set<String> getSubscribedEventTypes() {
+                return Set.of(ItemCommandEvent.TYPE);
+            }
+
+            @Override
+            public void receive(Event e) {
+                logger.info("Event: {}", e.getTopic());
+                if (e.getTopic().contains("myLampItem3")) {
+                    itemEvent = e;
+                }
+            }
+        };
+        registerService(itemEventHandler);
+
+        ruleEngine.runAsync(rule.getUID());
         waitForAssert(() -> {
             assertThat(itemEvent, is(notNullValue()));
         }, 3000, 100);


### PR DESCRIPTION
This has been in the back of my mind for a little while. The situation is that when `runNow()` is called, the calling thread is forced to wait for the rule execution to finish before returning, even if it doesn't need the execution result. This causes unnecessary waiting and potential deadlocks.

This PR offers `runAsync()` in addition to `runNow()`, where the caller can choose which behavior is desirable. `runAsync()` returns a `Future`, so that it's still possible to wait for and retrieve the result, but it's entirely optional. It's also possible to cancel the rule execution if it hasn't yet started.

I did this somewhat in a rush now, because I saw that this would also solve what #5634 does without the need to schedule yet another set of "tasks" that will just have to wait while the rule thread executes the rule. I'm thus submitting it as a draft, it's not "polished" and there might be aspects I have overlooked.

I'd like the approach to be discussed before investing further work in the idea.
