### PR TITLE
[config] ConfigUtil: Add method to apply defaults from `ConfigDescription` to configuration `Map<String, Object>`

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
@@ -157,7 +157,7 @@ public class ConfigUtil {
         if (configDescription != null) {
             for (ConfigDescriptionParameter parameter : configDescription.getParameters()) {
                 String defaultValue = parameter.getDefault();
-                if (defaultValue != null && configuration.get(parameter.getName()) == nul) {
+                if (defaultValue != null && configuration.get(parameter.getName()) == null) {
                     Object value = ConfigUtil.getDefaultValueAsCorrectType(parameter);
                     if (value != null) {
                         configuration.put(parameter.getName(), value);

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
@@ -146,6 +146,28 @@ public class ConfigUtil {
     }
 
     /**
+     * Applies the default values from a give {@link ConfigDescription} to the given configuration {@link Map}.
+     * 
+     * @param configuration the configuration {@link Map} where the default values should be added (must not be null)
+     * @param configDescription the {@link ConfigDescription} where the default values are located (may be null, but
+     *            method won't have any effect then)
+     */
+    public static void applyDefaultConfiguration(Map<String, Object> configuration,
+            @Nullable ConfigDescription configDescription) {
+        if (configDescription != null) {
+            for (ConfigDescriptionParameter parameter : configDescription.getParameters()) {
+                String defaultValue = parameter.getDefault();
+                if (defaultValue != null && !configuration.containsKey(parameter.getName())) {
+                    Object value = ConfigUtil.getDefaultValueAsCorrectType(parameter);
+                    if (value != null) {
+                        configuration.put(parameter.getName(), value);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
      * Applies the default values from a give {@link ConfigDescription} to the given {@link Configuration}.
      *
      * @param configuration the {@link Configuration} where the default values should be added (must not be null)
@@ -154,17 +176,9 @@ public class ConfigUtil {
      */
     public static void applyDefaultConfiguration(Configuration configuration,
             @Nullable ConfigDescription configDescription) {
-        if (configDescription != null) {
-            for (ConfigDescriptionParameter parameter : configDescription.getParameters()) {
-                String defaultValue = parameter.getDefault();
-                if (defaultValue != null && configuration.get(parameter.getName()) == null) {
-                    Object value = ConfigUtil.getDefaultValueAsCorrectType(parameter);
-                    if (value != null) {
-                        configuration.put(parameter.getName(), value);
-                    }
-                }
-            }
-        }
+        Map<String, Object> properties = new HashMap<>(configuration.getProperties());
+        applyDefaultConfiguration(properties, configDescription);
+        configuration.setProperties(properties);
     }
 
     /**

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
@@ -176,7 +176,7 @@ public class ConfigUtil {
      */
     public static void applyDefaultConfiguration(Configuration configuration,
             @Nullable ConfigDescription configDescription) {
-        Map<String, Object> properties = new HashMap<>(configuration.getProperties());
+        Map<String, @Nullable Object> properties = new HashMap<>(configuration.getProperties());
         applyDefaultConfiguration(properties, configDescription);
         configuration.setProperties(properties);
     }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
@@ -157,7 +157,7 @@ public class ConfigUtil {
         if (configDescription != null) {
             for (ConfigDescriptionParameter parameter : configDescription.getParameters()) {
                 String defaultValue = parameter.getDefault();
-                if (defaultValue != null && !configuration.containsKey(parameter.getName())) {
+                if (defaultValue != null && configuration.get(parameter.getName()) == nul) {
                     Object value = ConfigUtil.getDefaultValueAsCorrectType(parameter);
                     if (value != null) {
                         configuration.put(parameter.getName(), value);

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
@@ -152,7 +152,7 @@ public class ConfigUtil {
      * @param configDescription the {@link ConfigDescription} where the default values are located (may be null, but
      *            method won't have any effect then)
      */
-    public static void applyDefaultConfiguration(Map<String, Object> configuration,
+    public static void applyDefaultConfiguration(Map<String, @Nullable Object> configuration,
             @Nullable ConfigDescription configDescription) {
         if (configDescription != null) {
             for (ConfigDescriptionParameter parameter : configDescription.getParameters()) {


### PR DESCRIPTION
This extracts a new override from the existing `ConfigUtil::applyDefaultConfiguration` method. The existing unit tests for the existing method pass, so this change should be fine.