### PR TITLE
Fix null annotations Configuration class

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/profile/ScriptProfileTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/profile/ScriptProfileTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -363,7 +364,7 @@ public class ScriptProfileTest extends JavaTest {
     }
 
     private static class ProfileContextBuilder {
-        private final Map<String, Object> configuration = new HashMap<>();
+        private final Map<String, @Nullable Object> configuration = new HashMap<>();
         private List<Class<? extends State>> acceptedDataTypes = List.of();
         private List<Class<? extends Command>> acceptedCommandTypes = List.of();
         private List<Class<? extends Command>> handlerAcceptedCommandTypes = List.of();

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/RuleDTOMapper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/RuleDTOMapper.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.automation.dto;
 
+import java.util.HashMap;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.automation.Rule;
 import org.openhab.core.automation.Rule.TemplateState;
@@ -38,7 +40,7 @@ public class RuleDTOMapper {
         RuleBuilder builder = RuleBuilder.create(ruleDto.uid).withActions(ActionDTOMapper.mapDto(ruleDto.actions))
                 .withConditions(ConditionDTOMapper.mapDto(ruleDto.conditions))
                 .withTriggers(TriggerDTOMapper.mapDto(ruleDto.triggers))
-                .withConfiguration(new Configuration(ruleDto.configuration))
+                .withConfiguration(new Configuration(new HashMap<>(ruleDto.configuration)))
                 .withConfigurationDescriptions(ConfigDescriptionDTOMapper.map(ruleDto.configDescriptions))
                 .withTemplateUID(ruleDto.templateUID).withVisibility(ruleDto.visibility).withTags(ruleDto.tags)
                 .withName(ruleDto.name).withDescription(ruleDto.description);
@@ -54,7 +56,12 @@ public class RuleDTOMapper {
         to.triggers = TriggerDTOMapper.map(from.getTriggers());
         to.conditions = ConditionDTOMapper.map(from.getConditions());
         to.actions = ActionDTOMapper.map(from.getActions());
-        to.configuration = from.getConfiguration().getProperties();
+        to.configuration = new HashMap<>();
+        from.getConfiguration().getProperties().forEach((k, v) -> {
+            if (v != null) {
+                to.configuration.put(k, v);
+            }
+        });
         to.configDescriptions = ConfigDescriptionDTOMapper.mapParameters(from.getConfigurationDescriptions());
         to.templateUID = from.getTemplateUID();
         to.templateState = from.getTemplateState().toString();

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleRegistryImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleRegistryImpl.java
@@ -33,6 +33,7 @@ import org.openhab.core.automation.Rule.TemplateState;
 import org.openhab.core.automation.RuleProvider;
 import org.openhab.core.automation.RuleRegistry;
 import org.openhab.core.automation.RuleStatus;
+import org.openhab.core.automation.RuleStatusDetail;
 import org.openhab.core.automation.RuleStatusInfo;
 import org.openhab.core.automation.Trigger;
 import org.openhab.core.automation.internal.template.RuleTemplateRegistry;
@@ -490,7 +491,7 @@ public class RuleRegistryImpl extends AbstractRegistry<Rule, String, RuleProvide
         Configuration configuration = rule.getConfiguration();
         ConfigurationNormalizer.normalizeConfiguration(configuration,
                 ConfigurationNormalizer.getConfigDescriptionMap(configDescriptions));
-        Map<String, Object> configurationProperties = configuration.getProperties();
+        Map<String, @Nullable Object> configurationProperties = configuration.getProperties();
         TemplateState templateState = rule.getTemplateState();
         if (templateState == TemplateState.INSTANTIATED || templateState == TemplateState.NO_TEMPLATE) {
             String uid = rule.getUID();
@@ -513,8 +514,8 @@ public class RuleRegistryImpl extends AbstractRegistry<Rule, String, RuleProvide
      * @throws IllegalArgumentException If a required configuration property is missing.
      */
     private void validateConfiguration(List<ConfigDescriptionParameter> configDescriptions,
-            Map<String, Object> configuration) throws IllegalArgumentException {
-        Map<String, Object> config = configuration == null ? new HashMap<>() : new HashMap<>(configuration);
+            Map<String, @Nullable Object> configuration) throws IllegalArgumentException {
+        Map<String, @Nullable Object> config = new HashMap<>(configuration);
         if (config.isEmpty()) {
             if (isOptionalConfig(configDescriptions)) {
                 return;

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/AbstractCompositeModuleHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/AbstractCompositeModuleHandler.java
@@ -82,7 +82,11 @@ public abstract class AbstractCompositeModuleHandler<M extends Module, MT extend
      */
     protected Map<String, Object> getCompositeContext(Map<String, ?> context) {
         Map<String, Object> result = new HashMap<>(context);
-        result.putAll(module.getConfiguration().getProperties());
+        module.getConfiguration().getProperties().forEach((k, v) -> {
+            if (v != null) {
+                result.putIfAbsent(k, v);
+            }
+        });
         return result;
     }
 

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ReferenceResolverUtilTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ReferenceResolverUtilTest.java
@@ -38,7 +38,7 @@ public class ReferenceResolverUtilTest {
     private static final String CONTEXT_PROPERTY4 = "contextProperty4";
 
     private static final Map<String, Object> CONTEXT = new HashMap<>();
-    private static final Map<String, Object> MODULE_CONFIGURATION = new HashMap<>();
+    private static final Map<String, @Nullable Object> MODULE_CONFIGURATION = new HashMap<>();
     private static final Map<String, @Nullable Object> EXPECTED_MODULE_CONFIGURATION = new HashMap<>();
     private static final Map<String, String> COMPOSITE_CHILD_MODULE_INPUTS_REFERENCES = new HashMap<>();
     private static final Map<String, @Nullable Object> EXPECTED_COMPOSITE_CHILD_MODULE_CONTEXT = new HashMap<>();

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/Configuration.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/Configuration.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
@@ -36,8 +37,9 @@ import org.eclipse.jdt.annotation.Nullable;
  * @author Michael Riess - fix concurrent modification exception when setting properties
  * @author Michael Riess - fix equals() implementation
  */
+@NonNullByDefault
 public class Configuration {
-    private final Map<String, Object> properties;
+    private final Map<String, @Nullable Object> properties;
 
     public Configuration() {
         this(Map.of(), true);
@@ -60,7 +62,7 @@ public class Configuration {
      *
      * @param properties the properties the configuration should be filled. If null, an empty configuration is created.
      */
-    public Configuration(@Nullable Map<String, Object> properties) {
+    public Configuration(@Nullable Map<String, @Nullable Object> properties) {
         this(properties == null ? Map.of() : properties, false);
     }
 
@@ -70,7 +72,7 @@ public class Configuration {
      * @param properties the properties to initialize (may be null)
      * @param alreadyNormalized flag if the properties are already normalized
      */
-    private Configuration(final Map<String, Object> properties, final boolean alreadyNormalized) {
+    private Configuration(final Map<String, @Nullable Object> properties, final boolean alreadyNormalized) {
         this.properties = synchronizedMap(alreadyNormalized ? new HashMap<>(properties) : normalizeTypes(properties));
     }
 
@@ -90,16 +92,16 @@ public class Configuration {
         return properties.containsKey(key);
     }
 
-    public Object get(String key) {
+    public @Nullable Object get(String key) {
         return properties.get(key);
     }
 
-    public Object put(String key, @Nullable Object value) {
+    public @Nullable Object put(String key, @Nullable Object value) {
         Object normalizedValue = value == null ? null : ConfigUtil.normalizeType(value, null);
         return properties.put(key, normalizedValue);
     }
 
-    public Object remove(String key) {
+    public @Nullable Object remove(String key) {
         return properties.remove(key);
     }
 
@@ -109,19 +111,19 @@ public class Configuration {
         }
     }
 
-    public Collection<Object> values() {
+    public Collection<@Nullable Object> values() {
         synchronized (properties) {
             return Collections.unmodifiableCollection(new ArrayList<>(properties.values()));
         }
     }
 
-    public Map<String, Object> getProperties() {
+    public Map<String, @Nullable Object> getProperties() {
         synchronized (properties) {
             return Collections.unmodifiableMap(new HashMap<>(properties));
         }
     }
 
-    public void setProperties(Map<String, Object> newProperties) {
+    public void setProperties(Map<String, @Nullable Object> newProperties) {
         synchronized (properties) {
             this.properties.clear();
             newProperties.entrySet().forEach(e -> put(e.getKey(), e.getValue()));
@@ -145,7 +147,7 @@ public class Configuration {
 
         synchronized (properties) {
             boolean first = true;
-            for (final Map.Entry<String, Object> prop : properties.entrySet()) {
+            for (final Map.Entry<String, @Nullable Object> prop : properties.entrySet()) {
                 if (first) {
                     first = false;
                 } else {

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorImpl.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorImpl.java
@@ -86,7 +86,7 @@ public final class ConfigDescriptionValidatorImpl implements ConfigDescriptionVa
      */
     @Override
     @SuppressWarnings({ "unchecked", "null" })
-    public void validate(Map<String, Object> configurationParameters, URI configDescriptionURI) {
+    public void validate(Map<String, @Nullable Object> configurationParameters, URI configDescriptionURI) {
         Objects.requireNonNull(configurationParameters, "Configuration parameters must not be null");
         Objects.requireNonNull(configDescriptionURI, "Config description URI must not be null");
 

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/validation/ConfigDescriptionValidator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/validation/ConfigDescriptionValidator.java
@@ -16,6 +16,7 @@ import java.net.URI;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.ConfigDescription;
 import org.openhab.core.config.core.Configuration;
 
@@ -41,5 +42,5 @@ public interface ConfigDescriptionValidator {
      *             description having the given URI
      * @throws NullPointerException if given config description URI or configuration parameters are null
      */
-    void validate(Map<String, Object> configurationParameters, URI configDescriptionURI);
+    void validate(Map<String, @Nullable Object> configurationParameters, URI configDescriptionURI);
 }

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigUtilTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigUtilTest.java
@@ -14,11 +14,8 @@ package org.openhab.core.config.core;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 import static org.openhab.core.config.core.ConfigDescriptionParameter.Type.*;
 
 import java.math.BigDecimal;
@@ -195,8 +192,8 @@ public class ConfigUtilTest {
         verifyValuesOfConfiguration(configuration.get("p2"), 3, List.of("first value", "second value", "third value"));
     }
 
-    private void verifyValuesOfConfiguration(Object subject, int expectedSize, List<?> expectedValues) {
-        assertThat(subject, is(notNullValue()));
+    private void verifyValuesOfConfiguration(@Nullable Object subject, int expectedSize, List<?> expectedValues) {
+        assertNotNull(subject);
         assertThat(subject, is(instanceOf(List.class)));
         assertThat(((List<?>) subject).size(), is(expectedSize));
         assertThat(((List<?>) subject), is(expectedValues));
@@ -246,6 +243,7 @@ public class ConfigUtilTest {
     @Test
     public void resolveVariablesResolvesList() {
         String hostname = mockEnv.get("HOSTNAME");
+        assertNotNull(hostname);
         List<Object> input = List.of("plain", "${ENV:HOSTNAME}", true, 42, 3.14159);
         List<Object> expected = List.of("plain", hostname, true, 42, 3.14159);
 

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurationTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurationTest.java
@@ -138,9 +138,9 @@ public class ConfigurationTest {
         configuration.put("anotherField", null);
 
         // ensure conversions are null-tolerant and don't throw exceptions
-        Map<String, Object> props = configuration.getProperties();
+        Map<String, @Nullable Object> props = configuration.getProperties();
         Set<String> keys = configuration.keySet();
-        List<Object> values = new ArrayList<>(configuration.values());
+        List<@Nullable Object> values = new ArrayList<>(configuration.values());
 
         // ensure copies, not views
         configuration.put("stringField", "someValue");
@@ -154,13 +154,13 @@ public class ConfigurationTest {
 
     @Test
     public void assertPropertiesCanBeRemoved() {
-        Map<String, Object> orgProperties = new HashMap<>();
+        Map<String, @Nullable Object> orgProperties = new HashMap<>();
         orgProperties.put("intField", 1);
         orgProperties.put("booleanField", false);
         orgProperties.put("stringField", "test");
         orgProperties.put("notExisitingProperty", true);
 
-        Map<String, Object> newProperties = new HashMap<>();
+        Map<String, @Nullable Object> newProperties = new HashMap<>();
         newProperties.put("booleanField", false);
         newProperties.put("stringField", "test");
         newProperties.put("notExisitingProperty", true);
@@ -186,7 +186,7 @@ public class ConfigurationTest {
 
     @Test
     public void assertNormalizationInSetProperties() {
-        Map<String, Object> properties = new HashMap<>();
+        Map<String, @Nullable Object> properties = new HashMap<>();
         properties.put("byteField", Byte.valueOf("1"));
         properties.put("shortField", Short.valueOf("1"));
         properties.put("intField", 1);

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/PersistentInboxTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/PersistentInboxTest.java
@@ -15,6 +15,7 @@ package org.openhab.core.config.discovery.internal;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.net.URI;
@@ -106,7 +107,7 @@ public class PersistentInboxTest {
 
     @Test
     public void testConfigUpdateNormalizationWithConfigDescription() throws URISyntaxException {
-        Map<String, Object> props = Map.of("foo", "1");
+        Map<String, @Nullable Object> props = Map.of("foo", "1");
         Configuration config = new Configuration(props);
         Thing thing = ThingBuilder.create(THING_TYPE_UID, THING_UID).withConfiguration(config).build();
         configureConfigDescriptionRegistryMock("foo", Type.TEXT);

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/fileformat/FileFormatItemDTOMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/fileformat/FileFormatItemDTOMapper.java
@@ -14,6 +14,7 @@ package org.openhab.core.io.rest.core.fileformat;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,9 +74,14 @@ public class FileFormatItemDTOMapper {
         List<FileFormatChannelLinkDTO> channelLinksDTO = new ArrayList<>();
         channelLinks.forEach(link -> {
             if (item.getName().equals(link.getItemName())) {
+                Map<String, Object> config = new HashMap<>();
+                link.getConfiguration().getProperties().forEach((k, v) -> {
+                    if (v != null) {
+                        config.put(k, v);
+                    }
+                });
                 channelLinksDTO.add(new FileFormatChannelLinkDTO(link.getLinkedUID().getAsString(),
-                        link.getConfiguration().getProperties().isEmpty() ? null
-                                : link.getConfiguration().getProperties()));
+                        link.getConfiguration().getProperties().isEmpty() ? null : config));
             }
         });
         if (!channelLinksDTO.isEmpty()) {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/fileformat/FileFormatResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/fileformat/FileFormatResource.java
@@ -901,8 +901,13 @@ public class FileFormatResource implements RESTResource {
             });
             itemChannelLinkRegistry.getLinks(itemName).forEach(link -> {
                 MetadataKey key = new MetadataKey("channel", itemName);
-                Metadata md = new Metadata(key, link.getLinkedUID().getAsString(),
-                        link.getConfiguration().getProperties());
+                Map<String, Object> config = new HashMap<>();
+                link.getConfiguration().getProperties().forEach((k, v) -> {
+                    if (v != null) {
+                        config.put(k, v);
+                    }
+                });
+                Metadata md = new Metadata(key, link.getLinkedUID().getAsString(), config);
                 metadata.add(md);
             });
         }
@@ -1012,7 +1017,7 @@ public class FileFormatResource implements RESTResource {
      * Create a thing from a discovery result without inserting it in the thing registry
      */
     private Thing simulateThing(DiscoveryResult result, ThingType thingType) {
-        Map<String, Object> configParams = new HashMap<>();
+        Map<String, @Nullable Object> configParams = new HashMap<>();
         List<ConfigDescriptionParameter> configDescriptionParameters = List.of();
         URI descURI = thingType.getConfigDescriptionURI();
         if (descURI != null) {
@@ -1340,7 +1345,7 @@ public class FileFormatResource implements RESTResource {
 
     private @Nullable Map<String, @Nullable Object> normalizeConfiguration(Map<String, @Nullable Object> properties,
             ChannelTypeUID channelTypeUID, ChannelUID channelUID) {
-        if (properties == null || properties.isEmpty()) {
+        if (properties.isEmpty()) {
             return properties;
         }
 
@@ -1357,12 +1362,10 @@ public class FileFormatResource implements RESTResource {
                 configDescriptions.add(typeConfigDesc);
             }
         }
-        if (getConfigDescriptionURI(channelUID) != null) {
-            ConfigDescription channelConfigDesc = configDescRegistry
-                    .getConfigDescription(getConfigDescriptionURI(channelUID));
-            if (channelConfigDesc != null) {
-                configDescriptions.add(channelConfigDesc);
-            }
+        ConfigDescription channelConfigDesc = configDescRegistry
+                .getConfigDescription(getConfigDescriptionURI(channelUID));
+        if (channelConfigDesc != null) {
+            configDescriptions.add(channelConfigDesc);
         }
 
         if (configDescriptions.isEmpty()) {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
@@ -531,10 +531,14 @@ public class ThingResource implements RESTResource {
         // only move on if Thing is known to be managed and handler is available, so it can get updated
         try {
             // note that we create a Configuration instance here in order to have normalized types
-            thingRegistry.updateConfiguration(thingUIDObject,
-                    new Configuration(
-                            normalizeConfiguration(configurationParameters, thing.getThingTypeUID(), thing.getUID()))
-                            .getProperties());
+            Map<String, Object> config = new HashMap<>();
+            new Configuration(normalizeConfiguration(configurationParameters, thing.getThingTypeUID(), thing.getUID()))
+                    .getProperties().forEach((k, v) -> {
+                        if (v != null) {
+                            config.put(k, v);
+                        }
+                    });
+            thingRegistry.updateConfiguration(thingUIDObject, config);
         } catch (ConfigValidationException ex) {
             logger.debug("Config description validation exception occurred for thingUID {} - Messages: {}", thingUID,
                     ex.getValidationMessages());
@@ -823,7 +827,7 @@ public class ThingResource implements RESTResource {
 
     private @Nullable Map<String, @Nullable Object> normalizeConfiguration(Map<String, @Nullable Object> properties,
             ChannelTypeUID channelTypeUID, ChannelUID channelUID) {
-        if (properties == null || properties.isEmpty()) {
+        if (properties.isEmpty()) {
             return properties;
         }
 
@@ -840,12 +844,10 @@ public class ThingResource implements RESTResource {
                 configDescriptions.add(typeConfigDesc);
             }
         }
-        if (getConfigDescriptionURI(channelUID) != null) {
-            ConfigDescription channelConfigDesc = configDescRegistry
-                    .getConfigDescription(getConfigDescriptionURI(channelUID));
-            if (channelConfigDesc != null) {
-                configDescriptions.add(channelConfigDesc);
-            }
+        ConfigDescription channelConfigDesc = configDescRegistry
+                .getConfigDescription(getConfigDescriptionURI(channelUID));
+        if (channelConfigDesc != null) {
+            configDescriptions.add(channelConfigDesc);
         }
 
         if (configDescriptions.isEmpty()) {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/link/EnrichedItemChannelLinkDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/link/EnrichedItemChannelLinkDTO.java
@@ -15,6 +15,7 @@ package org.openhab.core.io.rest.core.link;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.thing.link.dto.ItemChannelLinkDTO;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -31,7 +32,7 @@ public class EnrichedItemChannelLinkDTO extends ItemChannelLinkDTO {
 
     public Boolean editable;
 
-    public EnrichedItemChannelLinkDTO(String itemName, String channelUID, Map<String, Object> configuration,
+    public EnrichedItemChannelLinkDTO(String itemName, String channelUID, Map<String, @Nullable Object> configuration,
             boolean editable) {
         super(itemName, channelUID, configuration);
         this.editable = editable;

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/GenericItemProvider.java
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/GenericItemProvider.java
@@ -405,8 +405,13 @@ public class GenericItemProvider extends AbstractProvider<Item>
                             bindingType, item.getName(), e);
                 }
             } else {
-                genericMetaDataProvider.addMetadata(modelName, bindingType, item.getName(), config,
-                        configuration.getProperties());
+                Map<String, Object> properties = new HashMap<>();
+                configuration.getProperties().forEach((k, v) -> {
+                    if (v != null) {
+                        properties.put(k, v);
+                    }
+                });
+                genericMetaDataProvider.addMetadata(modelName, bindingType, item.getName(), config, properties);
             }
         }
     }

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/YamlItemProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/YamlItemProvider.java
@@ -245,7 +245,8 @@ public class YamlItemProvider extends AbstractProvider<Item> implements ItemProv
             }
             if (itemDTO.channels != null) {
                 itemDTO.channels.forEach((channelUID, config) -> {
-                    channelLinks.put(channelUID, new Configuration(config));
+                    Map<String, @Nullable Object> confMap = new HashMap<>(config);
+                    channelLinks.put(channelUID, new Configuration(confMap));
                 });
             }
         }

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/rules/AbstractYamlRuleProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/rules/AbstractYamlRuleProvider.java
@@ -14,6 +14,7 @@ package org.openhab.core.model.yaml.internal.rules;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -108,15 +109,15 @@ public abstract class AbstractYamlRuleProvider<@NonNull E> extends AbstractProvi
             try {
                 if (targetClazz.isAssignableFrom(Condition.class) && dto instanceof YamlConditionDTO cDto) {
                     modules.add((T) ModuleBuilder.createCondition().withId(dto.id).withTypeUID(dto.type)
-                            .withConfiguration(new Configuration(dto.config)).withInputs(cDto.inputs)
+                            .withConfiguration(new Configuration(new HashMap<>(dto.config))).withInputs(cDto.inputs)
                             .withLabel(dto.label).withDescription(dto.description).build());
                 } else if (targetClazz.isAssignableFrom(Action.class) && dto instanceof YamlActionDTO aDto) {
                     modules.add((T) ModuleBuilder.createAction().withId(dto.id).withTypeUID(dto.type)
-                            .withConfiguration(new Configuration(dto.config)).withInputs(aDto.inputs)
+                            .withConfiguration(new Configuration(new HashMap<>(dto.config))).withInputs(aDto.inputs)
                             .withLabel(dto.label).withDescription(dto.description).build());
                 } else if (targetClazz.isAssignableFrom(Trigger.class)) {
                     modules.add((T) ModuleBuilder.createTrigger().withId(dto.id).withTypeUID(dto.type)
-                            .withConfiguration(new Configuration(dto.config)).withLabel(dto.label)
+                            .withConfiguration(new Configuration(new HashMap<>(dto.config))).withLabel(dto.label)
                             .withDescription(dto.description).build());
                 } else {
                     throw new IllegalArgumentException("Invalid combination of target and dto classes: "

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/rules/YamlModuleDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/rules/YamlModuleDTO.java
@@ -43,7 +43,12 @@ public class YamlModuleDTO {
         this.label = module.getLabel();
         this.description = module.getDescription();
         this.type = ModuleTypeAliases.typeToAlias(module.getClass(), module.getTypeUID());
-        this.config = new LinkedHashMap<>(module.getConfiguration().getProperties());
+        this.config = new LinkedHashMap<>();
+        module.getConfiguration().getProperties().forEach((k, v) -> {
+            if (v != null) {
+                this.config.put(k, v);
+            }
+        });
         if (this.config.containsKey("script") && this.config.get("type") instanceof String type) {
             String typeAlias = MIMETypeAliases.mimeTypeToAlias(type);
             if (!type.equals(typeAlias)) {

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/rules/YamlRuleDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/rules/YamlRuleDTO.java
@@ -85,7 +85,12 @@ public class YamlRuleDTO implements ModularDTO<YamlRuleDTO, ObjectMapper, JsonNo
         this.tags = rule.getTags();
         this.description = rule.getDescription();
         this.visibility = rule.getVisibility();
-        this.config = rule.getConfiguration().getProperties();
+        this.config = new LinkedHashMap<>();
+        rule.getConfiguration().getProperties().forEach((key, value) -> {
+            if (value != null) {
+                this.config.put(key, value);
+            }
+        });
         List<@NonNull ConfigDescriptionParameter> configDescriptions = rule.getConfigurationDescriptions();
         if (!configDescriptions.isEmpty()) {
             Map<String, YamlConfigDescriptionParameterDTO> configDescriptionDtos = new LinkedHashMap<>(

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/rules/YamlRuleProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/rules/YamlRuleProvider.java
@@ -16,6 +16,7 @@ import static org.openhab.core.model.yaml.YamlModelUtils.isIsolatedModel;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -152,7 +153,7 @@ public class YamlRuleProvider extends AbstractYamlRuleProvider<Rule>
     private @Nullable Rule mapRule(YamlRuleDTO ruleDto) {
         RuleBuilder ruleBuilder = RuleBuilder.create(ruleDto.uid).withName(ruleDto.label)
                 .withDescription(ruleDto.description).withTags(ruleDto.tags).withVisibility(ruleDto.visibility)
-                .withTemplateUID(ruleDto.template).withConfiguration(new Configuration(ruleDto.config));
+                .withTemplateUID(ruleDto.template).withConfiguration(new Configuration(new HashMap<>(ruleDto.config)));
         if (ruleDto.templateState != null) {
             ruleBuilder.withTemplateState(ruleDto.templateState);
         }

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlChannelDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlChannelDTO.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.model.yaml.internal.things;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -48,7 +49,7 @@ public class YamlChannelDTO {
         boolean ok = true;
         if (config != null) {
             try {
-                new Configuration(config);
+                new Configuration(new HashMap<>(config));
             } catch (IllegalArgumentException e) {
                 errors.add("invalid data in \"config\" field: %s".formatted(e.getMessage()));
                 ok = false;

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlThingDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlThingDTO.java
@@ -13,6 +13,7 @@
 package org.openhab.core.model.yaml.internal.things;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -97,7 +98,7 @@ public class YamlThingDTO implements YamlElement, Cloneable {
         }
         if (config != null) {
             try {
-                new Configuration(config);
+                new Configuration(new HashMap<>(config));
             } catch (IllegalArgumentException e) {
                 addToList(errors,
                         "invalid thing \"%s\": invalid data in \"config\" field: %s".formatted(uid, e.getMessage()));

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlThingProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlThingProvider.java
@@ -381,7 +381,7 @@ public class YamlThingProvider extends AbstractProvider<Thing>
 
             ThingType thingType = thingTypeRegistry.getThingType(thingTypeUID, localeProvider.getLocale());
             ThingUID bridgeUID = thingDto.bridge != null ? new ThingUID(thingDto.bridge) : null;
-            Configuration configuration = new Configuration(thingDto.config);
+            Configuration configuration = new Configuration(new HashMap<>(thingDto.config));
 
             ThingBuilder thingBuilder = thingDto.isBridge() ? BridgeBuilder.create(thingTypeUID, thingUID)
                     : ThingBuilder.create(thingTypeUID, thingUID);
@@ -403,8 +403,8 @@ public class YamlThingProvider extends AbstractProvider<Thing>
                     .filter(thf -> isThingHandlerFactoryReady(thf) && thf.supportsThingType(thingTypeUID)).findFirst()
                     .orElse(null);
             if (handlerFactory != null) {
-                thingFromHandler = handlerFactory.createThing(thingTypeUID, new Configuration(thingDto.config),
-                        thingUID, bridgeUID);
+                thingFromHandler = handlerFactory.createThing(thingTypeUID,
+                        new Configuration(new HashMap<>(thingDto.config)), thingUID, bridgeUID);
                 if (thingFromHandler != null) {
                     mergeThing(thingFromHandler, thing, isolatedModel);
                     logger.debug("Successfully loaded thing \'{}\'", thingUID);
@@ -434,7 +434,7 @@ public class YamlThingProvider extends AbstractProvider<Thing>
                     : new ChannelTypeUID(thingUID.getBindingId(), channelDto.type);
             Channel channel = createChannel(applyDefaultConfig, thingUID, channelId, channelTypeUID,
                     channelDto.getKind(), channelDto.getItemType(), channelDto.label, channelDto.description, null,
-                    new Configuration(channelDto.config), true);
+                    new Configuration(new HashMap<>(channelDto.config)), true);
             channels.add(channel);
             addedChannelIds.add(channelId);
         });
@@ -606,7 +606,7 @@ public class YamlThingProvider extends AbstractProvider<Thing>
     }
 
     private Configuration processConfiguration(UID uid, Configuration configuration, Set<String> stringParameters) {
-        Map<String, Object> params = new HashMap<>();
+        Map<String, @Nullable Object> params = new HashMap<>();
 
         configuration.keySet().forEach(name -> {
             Object valueIn = configuration.get(name);

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicConfigurableThingHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicConfigurableThingHandler.java
@@ -15,6 +15,7 @@ package org.openhab.core.magic.binding.handler;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -43,7 +44,7 @@ public class MagicConfigurableThingHandler extends BaseThingHandler {
     }
 
     @Override
-    public void handleConfigurationUpdate(Map<String, Object> configurationParameters) {
+    public void handleConfigurationUpdate(Map<String, @Nullable Object> configurationParameters) {
         super.handleConfigurationUpdate(configurationParameters);
     }
 }

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceImpl.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceImpl.java
@@ -63,12 +63,12 @@ public class MagicServiceImpl implements MagicService {
     }
 
     @Activate
-    public void activate(Map<String, Object> properties) {
+    public void activate(Map<String, @Nullable Object> properties) {
         modified(properties);
     }
 
     @Modified
-    public void modified(Map<String, Object> properties) {
+    public void modified(Map<String, @Nullable Object> properties) {
         MagicServiceConfig config = new Configuration(properties).as(MagicServiceConfig.class);
         logger.debug("Magic Service has been modified: {}", config);
     }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
@@ -96,7 +96,7 @@ public abstract class BaseThingHandler implements ThingHandler {
     }
 
     @Override
-    public void handleConfigurationUpdate(Map<String, Object> configurationParameters) {
+    public void handleConfigurationUpdate(Map<String, @Nullable Object> configurationParameters) {
         if (!isModifyingCurrentConfig(configurationParameters)) {
             return;
         }
@@ -105,7 +105,7 @@ public abstract class BaseThingHandler implements ThingHandler {
 
         // can be overridden by subclasses
         Configuration configuration = editConfiguration();
-        for (Entry<String, Object> configurationParameter : configurationParameters.entrySet()) {
+        for (Entry<String, @Nullable Object> configurationParameter : configurationParameters.entrySet()) {
             configuration.put(configurationParameter.getKey(), configurationParameter.getValue());
         }
 
@@ -134,9 +134,9 @@ public abstract class BaseThingHandler implements ThingHandler {
      * @param configurationParameters the parameters to check against the current configuration
      * @return true if the parameters would result in a modified configuration, false otherwise
      */
-    protected boolean isModifyingCurrentConfig(Map<String, Object> configurationParameters) {
+    protected boolean isModifyingCurrentConfig(Map<String, @Nullable Object> configurationParameters) {
         Configuration currentConfig = getRawConfig();
-        for (Entry<String, Object> entry : configurationParameters.entrySet()) {
+        for (Entry<String, @Nullable Object> entry : configurationParameters.entrySet()) {
             if (!Objects.equals(currentConfig.get(entry.getKey()), entry.getValue())) {
                 return true;
             }
@@ -209,7 +209,7 @@ public abstract class BaseThingHandler implements ThingHandler {
      * @throws ConfigValidationException if one or more of the given configuration parameters do not match
      *             their declarations in the configuration description
      */
-    protected void validateConfigurationParameters(Map<String, Object> configurationParameters) {
+    protected void validateConfigurationParameters(Map<String, @Nullable Object> configurationParameters) {
         ThingHandlerCallback callback = this.callback;
         if (callback != null) {
             callback.validateConfigurationParameters(this.getThing(), configurationParameters);
@@ -552,7 +552,7 @@ public abstract class BaseThingHandler implements ThingHandler {
      * @return copy of the thing configuration (not null)
      */
     protected Configuration editConfiguration() {
-        Map<String, Object> properties = getRawConfig().getProperties();
+        Map<String, @Nullable Object> properties = getRawConfig().getProperties();
         return new Configuration(new HashMap<>(properties));
     }
 
@@ -565,7 +565,7 @@ public abstract class BaseThingHandler implements ThingHandler {
      * @param configuration configuration, that was updated and should be persisted
      */
     protected void updateConfiguration(Configuration configuration) {
-        Map<String, Object> old = getRawConfig().getProperties();
+        Map<String, @Nullable Object> old = getRawConfig().getProperties();
         Configuration oldResolved = getConfig();
         ThingHandlerCallback callback = this.callback;
         if (callback == null) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ConfigStatusBridgeHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ConfigStatusBridgeHandler.java
@@ -60,7 +60,7 @@ public abstract class ConfigStatusBridgeHandler extends BaseBridgeHandler implem
     }
 
     @Override
-    public void handleConfigurationUpdate(Map<String, Object> configurationParameters) {
+    public void handleConfigurationUpdate(Map<String, @Nullable Object> configurationParameters) {
         super.handleConfigurationUpdate(configurationParameters);
         if (configStatusCallback != null) {
             configStatusCallback.configUpdated(new ThingConfigStatusSource(getThing().getUID().getAsString()));

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ConfigStatusThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ConfigStatusThingHandler.java
@@ -61,7 +61,7 @@ public abstract class ConfigStatusThingHandler extends BaseThingHandler implemen
     }
 
     @Override
-    public void handleConfigurationUpdate(Map<String, Object> configurationParameters) {
+    public void handleConfigurationUpdate(Map<String, @Nullable Object> configurationParameters) {
         super.handleConfigurationUpdate(configurationParameters);
         if (configStatusCallback != null) {
             configStatusCallback.configUpdated(new ThingConfigStatusSource(getThing().getUID().getAsString()));

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerCallback.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerCallback.java
@@ -98,7 +98,7 @@ public interface ThingHandlerCallback {
      * @throws ConfigValidationException if one or more of the given configuration parameters do not match
      *             their declarations in the configuration description
      */
-    void validateConfigurationParameters(Thing thing, Map<String, Object> configurationParameters);
+    void validateConfigurationParameters(Thing thing, Map<String, @Nullable Object> configurationParameters);
 
     /**
      * Validates the given configuration parameters against the configuration description.
@@ -108,7 +108,7 @@ public interface ThingHandlerCallback {
      * @throws ConfigValidationException if one or more of the given configuration parameters do not match
      *             their declarations in the configuration description
      */
-    void validateConfigurationParameters(Channel channel, Map<String, Object> configurationParameters);
+    void validateConfigurationParameters(Channel channel, Map<String, @Nullable Object> configurationParameters);
 
     /**
      * Get the {@link ConfigDescription} for a {@link ChannelTypeUID}

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/ChannelBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/ChannelBuilder.java
@@ -15,7 +15,6 @@ package org.openhab.core.thing.binding.builder;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -142,16 +141,6 @@ public class ChannelBuilder {
      * @return channel builder
      */
     public ChannelBuilder withProperties(Map<String, String> properties) {
-        String propertiesWithNullKeyOrValue = properties.entrySet().stream()
-                .filter(e -> e.getKey() == null || e.getValue() == null).map(e -> String.valueOf(e.getKey())).sorted()
-                .collect(Collectors.joining(", "));
-        if (!propertiesWithNullKeyOrValue.isEmpty()) {
-            logger.error(
-                    "Unexpected properties ({}) with null key or value for channel {}; probably a bug in the related binding!",
-                    propertiesWithNullKeyOrValue, channelUID);
-            throw new IllegalArgumentException("Unexpected properties (%s) with null key or value for channel %s"
-                    .formatted(propertiesWithNullKeyOrValue, channelUID.getAsString()));
-        }
         this.properties = properties;
         return this;
     }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingDTOMapper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingDTOMapper.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.Thing;
@@ -79,8 +80,8 @@ public class ThingDTOMapper {
         return ThingHelper.merge(thing, thingDTO);
     }
 
-    private static Map<String, Object> toMap(Configuration configuration) {
-        Map<String, Object> configurationMap = new HashMap<>(configuration.keySet().size());
+    private static Map<String, @Nullable Object> toMap(Configuration configuration) {
+        Map<String, @Nullable Object> configurationMap = new HashMap<>(configuration.keySet().size());
         for (String key : configuration.keySet()) {
             configurationMap.put(key, configuration.get(key));
         }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingHandlerCallbackImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingHandlerCallbackImpl.java
@@ -157,7 +157,7 @@ class ThingHandlerCallbackImpl implements ThingHandlerCallback {
     }
 
     @Override
-    public void validateConfigurationParameters(Thing thing, Map<String, Object> configurationParameters) {
+    public void validateConfigurationParameters(Thing thing, Map<String, @Nullable Object> configurationParameters) {
         ThingType thingType = thingManager.thingTypeRegistry.getThingType(thing.getThingTypeUID());
         if (thingType != null) {
             URI configDescriptionURI = thingType.getConfigDescriptionURI();
@@ -168,7 +168,8 @@ class ThingHandlerCallbackImpl implements ThingHandlerCallback {
     }
 
     @Override
-    public void validateConfigurationParameters(Channel channel, Map<String, Object> configurationParameters) {
+    public void validateConfigurationParameters(Channel channel,
+            Map<String, @Nullable Object> configurationParameters) {
         ChannelType channelType = thingManager.channelTypeRegistry.getChannelType(channel.getChannelTypeUID());
         if (channelType != null) {
             URI configDescriptionURI = channelType.getConfigDescriptionURI();

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
@@ -210,7 +210,7 @@ public class ThingImpl implements Thing {
 
     @Override
     public @Nullable String setProperty(String name, @Nullable String value) {
-        if (name == null || name.isEmpty()) {
+        if (name.isEmpty()) {
             throw new IllegalArgumentException("Property name must not be null or empty");
         }
         synchronized (this) {
@@ -301,6 +301,9 @@ public class ThingImpl implements Thing {
 
     @Override
     public void setSemanticEquipmentTag(@Nullable SemanticTag semanticEquipmentTag) {
+        if (semanticEquipmentTag == null) {
+            return;
+        }
         setSemanticEquipmentTag(semanticEquipmentTag.getName());
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/console/ThingConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/console/ThingConsoleCommandExtension.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.io.console.Console;
 import org.openhab.core.io.console.extensions.AbstractConsoleCommandExtension;
@@ -252,7 +253,7 @@ public class ThingConsoleCommandExtension extends AbstractConsoleCommandExtensio
             console.println("No configuration parameters");
         } else {
             console.println("Configuration parameters:");
-            for (Map.Entry<String, Object> entry : thing.getConfiguration().getProperties().entrySet()) {
+            for (Map.Entry<String, @Nullable Object> entry : thing.getConfiguration().getProperties().entrySet()) {
                 console.println("\t" + entry.getKey() + " : " + entry.getValue());
             }
         }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareUpdateServiceImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareUpdateServiceImpl.java
@@ -145,12 +145,12 @@ public final class FirmwareUpdateServiceImpl implements FirmwareUpdateService, E
     };
 
     @Activate
-    protected void activate(Map<String, Object> config) {
+    protected void activate(Map<String, @Nullable Object> config) {
         modified(config);
     }
 
     @Modified
-    protected synchronized void modified(Map<String, Object> config) {
+    protected synchronized void modified(Map<String, @Nullable Object> config) {
         logger.debug("Modifying the configuration of the firmware update service.");
 
         if (!isValid(config)) {
@@ -159,12 +159,12 @@ public final class FirmwareUpdateServiceImpl implements FirmwareUpdateService, E
 
         cancelFirmwareUpdateStatusInfoJob();
 
-        firmwareStatusInfoJobPeriod = config.containsKey(PERIOD_CONFIG_KEY) ? (Integer) config.get(PERIOD_CONFIG_KEY)
-                : firmwareStatusInfoJobPeriod;
-        firmwareStatusInfoJobDelay = config.containsKey(DELAY_CONFIG_KEY) ? (Integer) config.get(DELAY_CONFIG_KEY)
-                : firmwareStatusInfoJobDelay;
-        firmwareStatusInfoJobTimeUnit = config.containsKey(TIME_UNIT_CONFIG_KEY)
-                ? TimeUnit.valueOf((String) config.get(TIME_UNIT_CONFIG_KEY))
+        Object jobPeriodObj = config.get(PERIOD_CONFIG_KEY);
+        firmwareStatusInfoJobPeriod = jobPeriodObj != null ? (Integer) jobPeriodObj : firmwareStatusInfoJobPeriod;
+        Object jobDelayObj = config.get(DELAY_CONFIG_KEY);
+        firmwareStatusInfoJobDelay = jobDelayObj != null ? (Integer) jobDelayObj : firmwareStatusInfoJobDelay;
+        Object timeUnitObj = config.get(TIME_UNIT_CONFIG_KEY);
+        firmwareStatusInfoJobTimeUnit = timeUnitObj != null ? TimeUnit.valueOf((String) timeUnitObj)
                 : firmwareStatusInfoJobTimeUnit;
 
         if (!firmwareUpdateHandlers.isEmpty()) {
@@ -414,7 +414,7 @@ public final class FirmwareUpdateServiceImpl implements FirmwareUpdateService, E
         }
     }
 
-    private boolean isValid(Map<String, Object> config) {
+    private boolean isValid(Map<String, @Nullable Object> config) {
         // the config description validator does not support option value validation at the moment; so we will validate
         // the time unit here
         Object timeUnit = config.get(TIME_UNIT_CONFIG_KEY);

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/dto/ItemChannelLinkDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/dto/ItemChannelLinkDTO.java
@@ -15,6 +15,7 @@ package org.openhab.core.thing.link.dto;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -28,7 +29,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class ItemChannelLinkDTO extends AbstractLinkDTO {
 
     public String channelUID;
-    public Map<String, Object> configuration;
+    public Map<String, @Nullable Object> configuration;
 
     /**
      * Default constructor for deserialization e.g. by Gson.
@@ -37,7 +38,7 @@ public class ItemChannelLinkDTO extends AbstractLinkDTO {
         this("", "", Map.of());
     }
 
-    public ItemChannelLinkDTO(String itemName, String channelUID, Map<String, Object> configuration) {
+    public ItemChannelLinkDTO(String itemName, String channelUID, Map<String, @Nullable Object> configuration) {
         super(itemName);
         this.channelUID = channelUID;
         this.configuration = configuration;

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TimestampOffsetProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TimestampOffsetProfileTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -130,7 +131,7 @@ public class TimestampOffsetProfileTest {
 
     private TimestampOffsetProfile createProfile(ProfileCallback callback, String offset) {
         ProfileContext context = mock(ProfileContext.class);
-        Map<String, Object> properties = new HashMap<>();
+        Map<String, @Nullable Object> properties = new HashMap<>();
         properties.put(TimestampOffsetProfile.OFFSET_PARAM, offset);
         when(context.getConfiguration()).thenReturn(new Configuration(properties));
         return new TimestampOffsetProfile(callback, context);

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/ToggleProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/ToggleProfileTest.java
@@ -151,7 +151,8 @@ public class ToggleProfileTest extends JavaTest {
     }
 
     private void initializeContextMock(@Nullable String triggerEvent) {
-        Map<String, Object> params = triggerEvent == null ? Map.of() : Map.of(ToggleProfile.EVENT_PARAM, triggerEvent);
+        Map<String, @Nullable Object> params = triggerEvent == null ? Map.of()
+                : Map.of(ToggleProfile.EVENT_PARAM, triggerEvent);
         when(contextMock.getConfiguration()).thenReturn(new Configuration(params));
     }
 

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationTest.java
@@ -15,8 +15,7 @@ package org.openhab.core.automation.integration.test;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -269,7 +268,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
     @Test
     public void assertThatARuleWithConnectionsIsExecuted() {
         logger.info("assert that a rule with connections is executed");
-        Map<String, Object> params = new HashMap<>();
+        Map<String, @Nullable Object> params = new HashMap<>();
         params.put("topic", "openhab/items/myMotionItem3/*");
         params.put("types", "ItemStateEvent");
         Configuration triggerConfig = new Configuration(params);
@@ -330,7 +329,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
     public void assertThatARuleWithNonExistingModuleTypeHandlerIsAddedToTheRuleRegistryInStateUNINITIALIZED() {
         logger.info(
                 "assert that a rule with non existing moduleTypeHandler is added to the ruleRegistry in state UNINITIALIZED");
-        Map<String, Object> params = new HashMap<>();
+        Map<String, @Nullable Object> params = new HashMap<>();
         params.put("eventSource", "myMotionItem");
         params.put("eventTopic", "openhab/*");
         params.put("eventTypes", "ItemStateEvent");
@@ -363,7 +362,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
 
     @Test
     public void assertThatARuleBasedOnACompositeModuleIsInitializedAndExecutedCorrectly() {
-        Map<String, Object> params = new HashMap<>();
+        Map<String, @Nullable Object> params = new HashMap<>();
         params.put("itemName", "myMotionItem3");
         Configuration triggerConfig = new Configuration(params);
 
@@ -420,7 +419,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
     @Test
     public void assertThatRuleNowMethodExecutesActionsOfTheRule() throws ItemNotFoundException {
         Configuration triggerConfig = new Configuration(Map.of("topic", "runNowEventTopic/*"));
-        Map<String, Object> params = new HashMap<>();
+        Map<String, @Nullable Object> params = new HashMap<>();
         params.put("itemName", "myLampItem3");
         params.put("command", "TOGGLE");
         Configuration actionConfig = new Configuration(params);
@@ -483,7 +482,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
     @Test
     public void assertThatRuleCanBeUpdated() throws ItemNotFoundException {
         Configuration triggerConfig = new Configuration(Map.of("topic", "runNowEventTopic/*"));
-        Map<String, Object> params = new HashMap<>();
+        Map<String, @Nullable Object> params = new HashMap<>();
         params.put("itemName", "myLampItem3");
         params.put("command", "ON");
         Configuration actionConfig = new Configuration(params);
@@ -554,7 +553,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
     @Test
     public void testChainOfCompositeModules() throws ItemNotFoundException {
         Configuration triggerConfig = new Configuration(Map.of("itemName", "myMotionItem4"));
-        Map<String, Object> params = new HashMap<>();
+        Map<String, @Nullable Object> params = new HashMap<>();
         params.put("itemName", "myLampItem4");
         params.put("command", "ON");
         Configuration actionConfig = new Configuration(params);
@@ -608,7 +607,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
     public void assertARuleAddedByApiIsExecutedAsExpected() {
         logger.info("assert a rule added by api is executed as expected");
         // Creation of RULE
-        Map<String, Object> params = new HashMap<>();
+        Map<String, @Nullable Object> params = new HashMap<>();
         params.put("topic", "openhab/items/myMotionItem2/*");
         params.put("types", "ItemStateEvent");
         Configuration triggerConfig = new Configuration(params);
@@ -676,7 +675,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
             assertThat(template.getTags().size(), is(not(0)));
         });
 
-        Map<String, Object> configs = new HashMap<>();
+        Map<String, @Nullable Object> configs = new HashMap<>();
         configs.put("onItem", "templ_MotionItem");
         configs.put("ifState", "ON");
         configs.put("updateItem", "templ_LampItem");
@@ -724,7 +723,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
             assertThat(template.getTags().size(), is(not(0)));
         });
 
-        Map<String, Object> configs = new HashMap<>();
+        Map<String, @Nullable Object> configs = new HashMap<>();
         configs.put("onItem", "xtempl_MotionItem");
         configs.put("ifState", ".*ON.*");
         configs.put("updateItem", "xtempl_LampItem");
@@ -867,7 +866,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
         logger.info("createSimpleRule");
         int rand = new Random().nextInt();
 
-        Map<String, Object> configs = new HashMap<>();
+        Map<String, @Nullable Object> configs = new HashMap<>();
         configs.put("topic", "openhab/items/myMotionItem2/*");
         configs.put("types", "ItemStateEvent");
         Configuration triggerConfig = new Configuration(configs);
@@ -892,7 +891,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
         int random = new Random().nextInt(100000);
         logger.info("assert a rule with generic condition works");
         // Creation of RULE
-        Map<String, Object> configs = new HashMap<>();
+        Map<String, @Nullable Object> configs = new HashMap<>();
         configs.put("topic", "openhab/items/myMotionItem5/*");
         configs.put("types", "ItemStateEvent");
         Configuration triggerConfig = new Configuration(configs);

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/RuleSimulationTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/RuleSimulationTest.java
@@ -15,8 +15,7 @@ package org.openhab.core.automation.integration.test;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -188,7 +187,7 @@ public class RuleSimulationTest extends JavaOSGiTest {
     private static Rule createRuleWithCronExpressionTrigger() {
         int rand = new Random().nextInt();
 
-        Map<String, Object> configs = new HashMap<>();
+        Map<String, @Nullable Object> configs = new HashMap<>();
         configs.put(GenericCronTriggerHandler.CFG_CRON_EXPRESSION, "0 30 10-11 ? * WED,FRI");
         final Configuration triggerConfig = new Configuration(configs);
         final String triggerUID = "CronTrigger_" + rand;
@@ -217,7 +216,7 @@ public class RuleSimulationTest extends JavaOSGiTest {
     private static Rule createRuleWithTimeOfDayTrigger() {
         int rand = new Random().nextInt();
 
-        Map<String, Object> configs = Map.of(TimeOfDayTriggerHandler.CFG_TIME, "16:00");
+        Map<String, @Nullable Object> configs = Map.of(TimeOfDayTriggerHandler.CFG_TIME, "16:00");
         final Configuration triggerConfig = new Configuration(configs);
         final String triggerUID = "TimeOfDayTrigger_" + rand;
         List<Trigger> triggers = List.of(ModuleBuilder.createTrigger().withId(triggerUID)
@@ -243,7 +242,7 @@ public class RuleSimulationTest extends JavaOSGiTest {
     private static Rule createRuleWithEphemerisCondition() {
         int rand = new Random().nextInt();
 
-        Map<String, Object> configs = Map.of(TimeOfDayTriggerHandler.CFG_TIME, "10:00");
+        Map<String, @Nullable Object> configs = Map.of(TimeOfDayTriggerHandler.CFG_TIME, "10:00");
         final Configuration triggerConfig = new Configuration(configs);
         final String triggerUID = "TimeOfDayTrigger_" + rand;
         List<Trigger> triggers = List.of(ModuleBuilder.createTrigger().withId(triggerUID)

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/BasicConditionHandlerTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/BasicConditionHandlerTest.java
@@ -15,8 +15,7 @@ package org.openhab.core.automation.module.timer.internal;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -146,7 +145,7 @@ public abstract class BasicConditionHandlerTest extends JavaOSGiTest {
 
         List<Condition> conditions = List.of(getPassingCondition());
 
-        Map<String, Object> cfgEntries = new HashMap<>();
+        Map<String, @Nullable Object> cfgEntries = new HashMap<>();
         cfgEntries.put("itemName", testItemName2);
         cfgEntries.put("command", "ON");
         Configuration actionConfig = new Configuration(cfgEntries);

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/IntervalConditionHandlerTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/IntervalConditionHandlerTest.java
@@ -25,6 +25,7 @@ import java.util.Random;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.automation.Action;
 import org.openhab.core.automation.Condition;
@@ -118,7 +119,7 @@ public class IntervalConditionHandlerTest extends BasicConditionHandlerTest {
 
         List<Condition> conditions = List.of(getPassingCondition());
 
-        Map<String, Object> cfgEntries = new HashMap<>();
+        Map<String, @Nullable Object> cfgEntries = new HashMap<>();
         cfgEntries.put("itemName", testItemName2);
         cfgEntries.put("command", "ON");
         Configuration actionConfig = new Configuration(cfgEntries);

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/RuntimeRuleTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/RuntimeRuleTest.java
@@ -15,8 +15,7 @@ package org.openhab.core.automation.module.timer.internal;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -28,6 +27,7 @@ import java.util.Random;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.automation.Action;
@@ -196,7 +196,7 @@ public class RuntimeRuleTest extends JavaOSGiTest {
         List<Trigger> triggers = List.of(ModuleBuilder.createTrigger().withId("MyTimerTrigger")
                 .withTypeUID(GenericCronTriggerHandler.MODULE_TYPE_ID).withConfiguration(triggerConfig).build());
 
-        Map<String, Object> cfgEntries = new HashMap<>();
+        Map<String, @Nullable Object> cfgEntries = new HashMap<>();
         cfgEntries.put("itemName", testItemName);
         cfgEntries.put("command", "ON");
         Configuration actionConfig = new Configuration(cfgEntries);

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/TimeOfDayConditionHandlerTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/TimeOfDayConditionHandlerTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.automation.Condition;
 import org.openhab.core.automation.internal.module.handler.DayOfWeekConditionHandler;
@@ -83,7 +84,7 @@ public class TimeOfDayConditionHandlerTest extends BasicConditionHandlerTest {
     }
 
     private Configuration getTimeConfiguration(String startTime, String endTime) {
-        Map<String, Object> timeMap = new HashMap<>();
+        Map<String, @Nullable Object> timeMap = new HashMap<>();
         timeMap.put("startTime", startTime);
         timeMap.put("endTime", endTime);
         return new Configuration(timeMap);

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ChangeThingTypeOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ChangeThingTypeOSGiTest.java
@@ -16,8 +16,7 @@ import static java.util.Map.entry;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -230,7 +229,7 @@ public class ChangeThingTypeOSGiTest extends JavaOSGiTest {
             updateStatus(ThingStatus.ONLINE);
             genericInits++;
             if (selfChanging) {
-                Map<String, Object> properties = Map.of("providedspecific", "there");
+                Map<String, @Nullable Object> properties = Map.of("providedspecific", "there");
                 changeThingType(THING_TYPE_SPECIFIC_UID, new Configuration(properties));
             }
         }
@@ -285,7 +284,7 @@ public class ChangeThingTypeOSGiTest extends JavaOSGiTest {
         }, 4000, 100);
 
         // Now do the actual migration
-        Map<String, Object> properties = new HashMap<>(1);
+        Map<String, @Nullable Object> properties = new HashMap<>(1);
         properties.put("providedspecific", "there");
         ((BaseThingHandler) thing.getHandler()).changeThingType(THING_TYPE_SPECIFIC_UID, new Configuration(properties));
 
@@ -329,7 +328,7 @@ public class ChangeThingTypeOSGiTest extends JavaOSGiTest {
         // println "[ChangeThingTypeOSGiTest] ======== assert loading specialized thing type works directly"
 
         StorageService storage = getService(StorageService.class);
-        Map<String, Object> properties = Map.of("providedspecific", "there");
+        Map<String, @Nullable Object> properties = Map.of("providedspecific", "there");
         Thing persistedThing = ThingFactory.createThing(thingTypeSpecific,
                 new ThingUID("testBinding", "persistedThing"), new Configuration(properties), null, null);
         persistedThing.setProperty("universal", "survives");

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -15,8 +15,8 @@ package org.openhab.core.thing.internal;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import java.net.URI;
@@ -1016,8 +1016,8 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         assertThat(storage.containsKey(THING_UID.getAsString()), is(true));
     }
 
-    private void assertThingStatus(Map<String, Object> propsThing, Map<String, Object> propsChannel, ThingStatus status,
-            ThingStatusDetail statusDetail) {
+    private void assertThingStatus(Map<String, @Nullable Object> propsThing, Map<String, @Nullable Object> propsChannel,
+            ThingStatus status, ThingStatusDetail statusDetail) {
         Configuration configThing = new Configuration(propsThing);
         Configuration configChannel = new Configuration(propsChannel);
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareUpdateServiceTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareUpdateServiceTest.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -975,7 +976,8 @@ public class FirmwareUpdateServiceTest extends JavaOSGiTest {
     }
 
     private void updateConfig(int period, int delay, TimeUnit timeUnit) throws IOException {
-        Map<String, Object> properties = Map.ofEntries(entry(FirmwareUpdateServiceImpl.PERIOD_CONFIG_KEY, period),
+        Map<String, @Nullable Object> properties = Map.ofEntries(
+                entry(FirmwareUpdateServiceImpl.PERIOD_CONFIG_KEY, period),
                 entry(FirmwareUpdateServiceImpl.DELAY_CONFIG_KEY, delay),
                 entry(FirmwareUpdateServiceImpl.TIME_UNIT_CONFIG_KEY, timeUnit.name()));
         firmwareUpdateService.modified(properties);

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactoryOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactoryOSGiTest.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,7 +54,7 @@ import org.openhab.core.thing.type.ChannelType;
 @NonNullByDefault
 public class SystemProfileFactoryOSGiTest extends JavaOSGiTest {
 
-    private final Map<String, Object> properties = Map.of(SystemOffsetProfile.OFFSET_PARAM, BigDecimal.ZERO,
+    private final Map<String, @Nullable Object> properties = Map.of(SystemOffsetProfile.OFFSET_PARAM, BigDecimal.ZERO,
             SystemHysteresisStateProfile.LOWER_PARAM, BigDecimal.TEN, SystemRangeStateProfile.UPPER_PARAM,
             BigDecimal.valueOf(40));
 


### PR DESCRIPTION
Identified in review of https://github.com/openhab/openhab-core/pull/5638#event-26517887796

The `Configuration` class has incomplete null annotations, leading to wrong conclusions.

This may have an impact on addons compilation, TBC