### PR TITLE
[voice] Provide the semantic model + non-semantic items as context to LLM HLIs

### DIFF
--- a/bundles/org.openhab.core.voice/pom.xml
+++ b/bundles/org.openhab.core.voice/pom.xml
@@ -22,6 +22,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.semantics</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
       <artifactId>org.openhab.core.config.core</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
@@ -375,7 +375,8 @@ public class DialogProcessor implements KSListener, STTListener {
                 if (error == null) {
                     List<LLMTool> tools = dialogContext.llmTools();
                     InterpreterContext interpreterContext = new InterpreterContext(conversation, tools,
-                            dialogContext.locationItem(), dialogContext.systemPrompt());
+                            dialogContext.locationItem(),
+                            eventListener.enrichSystemPrompt(dialogContext.systemPrompt()));
                     for (HumanLanguageInterpreter interpreter : dialogContext.hlis()) {
                         try {
                             answer = interpreter.interpret(dialogContext.locale(), interpreterContext);
@@ -530,5 +531,13 @@ public class DialogProcessor implements KSListener, STTListener {
          * @param context used by the dialog processor
          */
         void onDialogStopped(DialogContext context);
+
+        /**
+         * Enriches the system prompt with additional context, e.g., available items.
+         *
+         * @param baseSystemPrompt the base system prompt
+         * @return the system prompt with the additional context
+         */
+        String enrichSystemPrompt(@Nullable String baseSystemPrompt);
     }
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -55,6 +55,8 @@ import org.openhab.core.config.core.ParameterOption;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.i18n.LocaleProvider;
 import org.openhab.core.i18n.TranslationProvider;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.storage.Storage;
 import org.openhab.core.storage.StorageService;
@@ -73,6 +75,7 @@ import org.openhab.core.voice.TTSException;
 import org.openhab.core.voice.TTSService;
 import org.openhab.core.voice.Voice;
 import org.openhab.core.voice.VoiceManager;
+import org.openhab.core.voice.security.ItemPermissionResolver;
 import org.openhab.core.voice.text.HumanLanguageInterpreter;
 import org.openhab.core.voice.text.InterpretationArguments;
 import org.openhab.core.voice.text.InterpretationException;
@@ -81,6 +84,7 @@ import org.openhab.core.voice.text.conversation.Conversation;
 import org.openhab.core.voice.text.conversation.ConversationException;
 import org.openhab.core.voice.text.conversation.ConversationManager;
 import org.openhab.core.voice.text.conversation.ConversationRole;
+import org.openhab.core.voice.text.interpreter.llm.LLMItemSerializer;
 import org.openhab.core.voice.text.interpreter.llm.LLMTool;
 import org.openhab.core.voice.text.interpreter.llm.LLMToolRegistry;
 import org.osgi.framework.Bundle;
@@ -125,6 +129,8 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
     private final Map<String, HumanLanguageInterpreter> humanLanguageInterpreters = new HashMap<>();
     private final LLMToolRegistry llmToolRegistry;
     private final ConversationManager conversationManager;
+    private final ItemRegistry itemRegistry;
+    private final ItemPermissionResolver itemPermissionResolver;
 
     private final WeakHashMap<String, DialogContext> activeDialogGroups = new WeakHashMap<>();
 
@@ -147,7 +153,9 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
             final @Reference EventPublisher eventPublisher, final @Reference TranslationProvider i18nProvider,
             final @Reference StorageService storageService, final @Reference LLMToolRegistry llmToolRegistry,
             final @Reference ConversationManager conversationManager,
-            final @Reference ConfigDescriptionRegistry configDescriptionRegistry) {
+            final @Reference ConfigDescriptionRegistry configDescriptionRegistry,
+            final @Reference ItemRegistry itemRegistry,
+            final @Reference ItemPermissionResolver itemPermissionResolver) {
         this.localeProvider = localeProvider;
         this.audioManager = audioManager;
         this.eventPublisher = eventPublisher;
@@ -156,6 +164,8 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
                 this.getClass().getClassLoader());
         this.conversationManager = conversationManager;
         this.llmToolRegistry = llmToolRegistry;
+        this.itemRegistry = itemRegistry;
+        this.itemPermissionResolver = itemPermissionResolver;
         this.configuration = new VoiceManagerConfiguration(configDescriptionRegistry);
     }
 
@@ -403,7 +413,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
                 locationItem = null;
             }
             InterpreterContext context = new InterpreterContext(conversation, tools, locationItem,
-                    configuration.getSystemPrompt());
+                    enrichSystemPrompt(configuration.getSystemPrompt()));
             InterpretationException exception = null;
             for (var interpreter : interpreters) {
                 try {
@@ -1130,5 +1140,18 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
             // try to rebuild in case it was manually stopped
             scheduleDialogRegistrations();
         }
+    }
+
+    @Override
+    public String enrichSystemPrompt(@Nullable String baseSystemPrompt) {
+        String base = baseSystemPrompt != null ? baseSystemPrompt : "";
+        List<Item> accessibleItems = itemRegistry.getItems().stream().filter(itemPermissionResolver::isAccessible)
+                .toList();
+        String serializedItems = LLMItemSerializer.serialize(accessibleItems);
+        if (serializedItems.isEmpty()) {
+            return base;
+        }
+        String itemsSection = "Available items:\n" + serializedItems;
+        return base.isEmpty() ? itemsSection : base + "\n\n" + itemsSection;
     }
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.voice.text.interpreter.llm;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.items.Item;
+import org.openhab.core.semantics.Equipment;
+import org.openhab.core.semantics.Location;
+import org.openhab.core.semantics.Point;
+import org.openhab.core.semantics.Property;
+import org.openhab.core.semantics.SemanticTags;
+import org.openhab.core.semantics.Tag;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+
+/**
+ * {@link LLMItemSerializer} is a utility class to serialize a collection of items (both semantic and non-semantic) into
+ * a structured,
+ * hierarchical string representation for passing into the context of a Large Language Model (LLM) based
+ * {@link org.openhab.core.voice.text.HumanLanguageInterpreter}.
+ * The output format is YAML, as this is hierarchical and token-efficient, as well as easy to generate using Jackson.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+public class LLMItemSerializer {
+
+    private static final Comparator<Item> itemComparator = Comparator.comparing(Item::getName);
+    private static final ObjectMapper mapper;
+
+    static {
+        YAMLFactory yamlFactory = new YAMLFactory().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+                .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES);
+        mapper = new ObjectMapper(yamlFactory);
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private record LocationNode(String name, @Nullable String label, String type, @Nullable String semanticType,
+            List<LocationNode> locationItems, List<EquipmentNode> equipmentItems, List<PointNode> pointItems) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private record EquipmentNode(String name, @Nullable String label, String type, @Nullable String semanticType,
+            List<EquipmentNode> equipmentItems, List<PointNode> pointItems) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private record PointNode(String name, @Nullable String label, String type, @Nullable String semanticType,
+            List<String> properties) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private record NonSemanticItemNode(String name, @Nullable String label, String type) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private record RootNode(List<LocationNode> locationItems, List<EquipmentNode> equipmentItems,
+            List<PointNode> pointItems, List<NonSemanticItemNode> items) {
+    }
+
+    /**
+     * Serializes a collection of items.
+     *
+     * @param items the items to serialize
+     * @return the serialized representation (YAML) of the items
+     */
+    public static String serialize(Collection<Item> items) {
+        if (items.isEmpty()) {
+            return "";
+        }
+
+        Map<String, Item> itemMap = new HashMap<>();
+        for (Item item : items) {
+            if (item != null) {
+                itemMap.put(item.getName(), item);
+            }
+        }
+
+        Map<String, List<Item>> parentToChildren = new HashMap<>();
+        Set<String> childNames = new HashSet<>();
+
+        for (Item child : items) {
+            if (child == null) {
+                continue;
+            }
+
+            boolean isLocation = SemanticTags.getLocation(child) != null;
+            boolean isEquipment = SemanticTags.getEquipment(child) != null;
+            boolean isPoint = SemanticTags.getPoint(child) != null || SemanticTags.getProperty(child) != null;
+
+            if (!isLocation && !isEquipment && !isPoint) {
+                continue;
+            }
+
+            String parentName = null;
+            if (isLocation) {
+                for (String groupName : child.getGroupNames()) {
+                    Item parent = itemMap.get(groupName);
+                    if (parent != null && SemanticTags.getLocation(parent) != null) {
+                        parentName = groupName;
+                        break;
+                    }
+                }
+            } else if (isEquipment) {
+                String fallbackParent = null;
+                for (String groupName : child.getGroupNames()) {
+                    Item parent = itemMap.get(groupName);
+                    if (parent != null) {
+                        if (SemanticTags.getEquipment(parent) != null) {
+                            parentName = groupName;
+                            break;
+                        } else if (SemanticTags.getLocation(parent) != null && fallbackParent == null) {
+                            fallbackParent = groupName;
+                        }
+                    }
+                }
+                if (parentName == null) {
+                    parentName = fallbackParent;
+                }
+            } else {
+                String fallbackParent = null;
+                for (String groupName : child.getGroupNames()) {
+                    Item parent = itemMap.get(groupName);
+                    if (parent != null) {
+                        if (SemanticTags.getEquipment(parent) != null) {
+                            parentName = groupName;
+                            break;
+                        } else if (SemanticTags.getLocation(parent) != null && fallbackParent == null) {
+                            fallbackParent = groupName;
+                        }
+                    }
+                }
+                if (parentName == null) {
+                    parentName = fallbackParent;
+                }
+            }
+
+            if (parentName != null) {
+                parentToChildren.computeIfAbsent(parentName, k -> new ArrayList<>()).add(child);
+                childNames.add(child.getName());
+            }
+        }
+
+        List<Item> rootLocations = new ArrayList<>();
+        List<Item> rootEquipments = new ArrayList<>();
+        List<Item> rootPoints = new ArrayList<>();
+        List<Item> nonSemanticItems = new ArrayList<>();
+
+        for (Item item : items) {
+            if (item == null) {
+                continue;
+            }
+
+            boolean isLocation = SemanticTags.getLocation(item) != null;
+            boolean isEquipment = SemanticTags.getEquipment(item) != null;
+            boolean isPoint = SemanticTags.getPoint(item) != null || SemanticTags.getProperty(item) != null;
+
+            if (isLocation) {
+                if (!childNames.contains(item.getName())) {
+                    rootLocations.add(item);
+                }
+            } else if (isEquipment) {
+                if (!childNames.contains(item.getName())) {
+                    rootEquipments.add(item);
+                }
+            } else if (isPoint) {
+                if (!childNames.contains(item.getName())) {
+                    rootPoints.add(item);
+                }
+            } else {
+                nonSemanticItems.add(item);
+            }
+        }
+
+        rootLocations.sort(itemComparator);
+        rootEquipments.sort(itemComparator);
+        rootPoints.sort(itemComparator);
+        nonSemanticItems.sort(itemComparator);
+
+        List<LocationNode> rootLocNodes = new ArrayList<>();
+        List<EquipmentNode> rootEqNodes = new ArrayList<>();
+        List<PointNode> rootPtNodes = new ArrayList<>();
+        List<NonSemanticItemNode> nonSemanticNodes = new ArrayList<>();
+
+        for (Item loc : rootLocations) {
+            rootLocNodes.add(buildLocationNode(loc, parentToChildren));
+        }
+        for (Item eq : rootEquipments) {
+            rootEqNodes.add(buildEquipmentNode(eq, parentToChildren));
+        }
+        for (Item pt : rootPoints) {
+            rootPtNodes.add(buildPointNode(pt));
+        }
+        for (Item item : nonSemanticItems) {
+            nonSemanticNodes.add(new NonSemanticItemNode(item.getName(), getOrNullLabel(item), item.getType()));
+        }
+
+        RootNode root = new RootNode(rootLocNodes, rootEqNodes, rootPtNodes, nonSemanticNodes);
+
+        try {
+            return mapper.writeValueAsString(root);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize items to YAML", e);
+        }
+    }
+
+    private static LocationNode buildLocationNode(Item loc, Map<String, List<Item>> parentToChildren) {
+        List<Item> children = parentToChildren.getOrDefault(loc.getName(), List.of());
+        List<LocationNode> subLocations = new ArrayList<>();
+        List<EquipmentNode> equipments = new ArrayList<>();
+        List<PointNode> points = new ArrayList<>();
+
+        for (Item child : children) {
+            if (SemanticTags.getLocation(child) != null) {
+                subLocations.add(buildLocationNode(child, parentToChildren));
+            } else if (SemanticTags.getEquipment(child) != null) {
+                equipments.add(buildEquipmentNode(child, parentToChildren));
+            } else if (SemanticTags.getPoint(child) != null || SemanticTags.getProperty(child) != null) {
+                points.add(buildPointNode(child));
+            }
+        }
+
+        subLocations.sort(Comparator.comparing(LocationNode::name));
+        equipments.sort(Comparator.comparing(EquipmentNode::name));
+        points.sort(Comparator.comparing(PointNode::name));
+
+        Class<? extends Location> locType = SemanticTags.getLocation(loc);
+        String semType = locType != null ? locType.getSimpleName() : null;
+
+        return new LocationNode(loc.getName(), getOrNullLabel(loc), loc.getType(), semType, subLocations, equipments,
+                points);
+    }
+
+    private static EquipmentNode buildEquipmentNode(Item eq, Map<String, List<Item>> parentToChildren) {
+        List<Item> children = parentToChildren.getOrDefault(eq.getName(), List.of());
+        List<EquipmentNode> subEquipments = new ArrayList<>();
+        List<PointNode> points = new ArrayList<>();
+
+        for (Item child : children) {
+            if (SemanticTags.getEquipment(child) != null) {
+                subEquipments.add(buildEquipmentNode(child, parentToChildren));
+            } else if (SemanticTags.getPoint(child) != null || SemanticTags.getProperty(child) != null) {
+                points.add(buildPointNode(child));
+            }
+        }
+
+        subEquipments.sort(Comparator.comparing(EquipmentNode::name));
+        points.sort(Comparator.comparing(PointNode::name));
+
+        Class<? extends Equipment> eqType = SemanticTags.getEquipment(eq);
+        String semType = eqType != null ? eqType.getSimpleName() : null;
+
+        return new EquipmentNode(eq.getName(), getOrNullLabel(eq), eq.getType(), semType, subEquipments, points);
+    }
+
+    private static PointNode buildPointNode(Item pt) {
+        Class<? extends Point> ptType = SemanticTags.getPoint(pt);
+        String semType = ptType != null ? ptType.getSimpleName() : null;
+
+        List<String> properties = new ArrayList<>();
+        for (String tagId : pt.getTags()) {
+            Class<? extends Tag> type = SemanticTags.getById(tagId);
+            if (type != null && Property.class.isAssignableFrom(type)) {
+                properties.add(type.getSimpleName());
+            }
+        }
+        if (!properties.isEmpty()) {
+            Collections.sort(properties);
+        }
+
+        return new PointNode(pt.getName(), getOrNullLabel(pt), pt.getType(), semType, properties);
+    }
+
+    private static @Nullable String getOrNullLabel(Item item) {
+        String label = item.getLabel();
+        return (label == null || label.isBlank()) ? null : label;
+    }
+}

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
@@ -50,7 +50,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 @NonNullByDefault
 public class LLMItemSerializer {
 
-    private static final Comparator<Item> itemComparator = Comparator.comparing(Item::getName);
+    private static final Comparator<Item> ITEM_COMPARATOR = Comparator.comparing(Item::getName);
     private static final ObjectMapper mapper;
 
     static {
@@ -96,19 +96,13 @@ public class LLMItemSerializer {
 
         Map<String, Item> itemMap = new HashMap<>();
         for (Item item : items) {
-            if (item != null) {
-                itemMap.put(item.getName(), item);
-            }
+            itemMap.put(item.getName(), item);
         }
 
         Map<String, List<Item>> parentToChildren = new HashMap<>();
         Set<String> childNames = new HashSet<>();
 
         for (Item child : items) {
-            if (child == null) {
-                continue;
-            }
-
             boolean isLocation = SemanticTags.getLocation(child) != null;
             boolean isEquipment = SemanticTags.getEquipment(child) != null;
             boolean isPoint = SemanticTags.getPoint(child) != null || SemanticTags.getProperty(child) != null;
@@ -118,19 +112,16 @@ public class LLMItemSerializer {
             }
 
             String parentName = null;
-            if (isLocation) {
-                for (String groupName : child.getGroupNames()) {
-                    Item parent = itemMap.get(groupName);
-                    if (parent != null && SemanticTags.getLocation(parent) != null) {
-                        parentName = groupName;
-                        break;
-                    }
-                }
-            } else if (isEquipment) {
-                String fallbackParent = null;
-                for (String groupName : child.getGroupNames()) {
-                    Item parent = itemMap.get(groupName);
-                    if (parent != null) {
+            String fallbackParent = null;
+            for (String groupName : child.getGroupNames()) {
+                Item parent = itemMap.get(groupName);
+                if (parent != null) {
+                    if (isLocation) {
+                        if (SemanticTags.getLocation(parent) != null) {
+                            parentName = groupName;
+                            break;
+                        }
+                    } else {
                         if (SemanticTags.getEquipment(parent) != null) {
                             parentName = groupName;
                             break;
@@ -139,25 +130,9 @@ public class LLMItemSerializer {
                         }
                     }
                 }
-                if (parentName == null) {
-                    parentName = fallbackParent;
-                }
-            } else {
-                String fallbackParent = null;
-                for (String groupName : child.getGroupNames()) {
-                    Item parent = itemMap.get(groupName);
-                    if (parent != null) {
-                        if (SemanticTags.getEquipment(parent) != null) {
-                            parentName = groupName;
-                            break;
-                        } else if (SemanticTags.getLocation(parent) != null && fallbackParent == null) {
-                            fallbackParent = groupName;
-                        }
-                    }
-                }
-                if (parentName == null) {
-                    parentName = fallbackParent;
-                }
+            }
+            if (parentName == null) {
+                parentName = fallbackParent;
             }
 
             if (parentName != null) {
@@ -172,10 +147,6 @@ public class LLMItemSerializer {
         List<Item> nonSemanticItems = new ArrayList<>();
 
         for (Item item : items) {
-            if (item == null) {
-                continue;
-            }
-
             boolean isLocation = SemanticTags.getLocation(item) != null;
             boolean isEquipment = SemanticTags.getEquipment(item) != null;
             boolean isPoint = SemanticTags.getPoint(item) != null || SemanticTags.getProperty(item) != null;
@@ -197,10 +168,10 @@ public class LLMItemSerializer {
             }
         }
 
-        rootLocations.sort(itemComparator);
-        rootEquipments.sort(itemComparator);
-        rootPoints.sort(itemComparator);
-        nonSemanticItems.sort(itemComparator);
+        rootLocations.sort(ITEM_COMPARATOR);
+        rootEquipments.sort(ITEM_COMPARATOR);
+        rootPoints.sort(ITEM_COMPARATOR);
+        nonSemanticItems.sort(ITEM_COMPARATOR);
 
         List<LocationNode> rootLocNodes = new ArrayList<>();
         List<EquipmentNode> rootEqNodes = new ArrayList<>();

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -99,8 +98,14 @@ public class LLMItemSerializerTest {
         Item item1 = mockItem("ItemB", "Label B", "Switch", Set.of(), List.of());
         Item item2 = mockItem("ItemA", null, "Dimmer", Set.of(), List.of());
 
-        String expected = "items:\n" + "- name: ItemA\n" + "  type: Dimmer\n" + "- name: ItemB\n" + "  label: Label B\n"
-                + "  type: Switch\n";
+        String expected = """
+                items:
+                - name: ItemA
+                  type: Dimmer
+                - name: ItemB
+                  label: Label B
+                  type: Switch
+                """;
 
         assertEquals(expected, LLMItemSerializer.serialize(List.of(item1, item2)));
     }
@@ -129,20 +134,42 @@ public class LLMItemSerializerTest {
         // Non-semantic Item
         Item systemMode = mockItem("System_Mode", "System Mode", "String", Set.of(), List.of());
 
-        List<Item> items = new ArrayList<>(List.of(tvPower, livingRoom, systemMode, lrLight, tv, gf));
-        // Shuffle the list to ensure the serializer sorts correctly
-        Collections.shuffle(items);
+        // Intentionally provide an unsorted order to ensure the serializer sorts deterministically
+        List<Item> items = List.of(tvPower, livingRoom, systemMode, lrLight, tv, gf);
 
-        String expected = "locationItems:\n" + "- name: GF\n" + "  label: Ground Floor\n" + "  type: Group\n"
-                + "  semanticType: MockFloor\n" + "  locationItems:\n" + "  - name: LivingRoom\n"
-                + "    label: Living Room\n" + "    type: Group\n" + "    semanticType: MockLivingRoom\n"
-                + "    equipmentItems:\n" + "    - name: TV\n" + "      label: Living Room TV\n" + "      type: Group\n"
-                + "      semanticType: MockTV\n" + "      pointItems:\n" + "      - name: TV_Power\n"
-                + "        label: TV Power\n" + "        type: Switch\n" + "        semanticType: MockPower\n"
-                + "        properties:\n" + "        - MockPowerProperty\n" + "    pointItems:\n"
-                + "    - name: LivingRoom_Light\n" + "      label: Living Room Light\n" + "      type: Dimmer\n"
-                + "      semanticType: MockLight\n" + "items:\n" + "- name: System_Mode\n" + "  label: System Mode\n"
-                + "  type: String\n";
+        String expected = """
+                locationItems:
+                - name: GF
+                  label: Ground Floor
+                  type: Group
+                  semanticType: MockFloor
+                  locationItems:
+                  - name: LivingRoom
+                    label: Living Room
+                    type: Group
+                    semanticType: MockLivingRoom
+                    equipmentItems:
+                    - name: TV
+                      label: Living Room TV
+                      type: Group
+                      semanticType: MockTV
+                      pointItems:
+                      - name: TV_Power
+                        label: TV Power
+                        type: Switch
+                        semanticType: MockPower
+                        properties:
+                        - MockPowerProperty
+                    pointItems:
+                    - name: LivingRoom_Light
+                      label: Living Room Light
+                      type: Dimmer
+                      semanticType: MockLight
+                items:
+                - name: System_Mode
+                  label: System Mode
+                  type: String
+                """;
 
         assertEquals(expected, LLMItemSerializer.serialize(items));
     }
@@ -152,8 +179,15 @@ public class LLMItemSerializerTest {
         Item item1 = mockItem("item:with:colon", "label # with hash", "Switch", Set.of(), List.of());
         Item item2 = mockItem("yes", "true", "String", Set.of(), List.of());
 
-        String expected = "items:\n" + "- name: item:with:colon\n" + "  label: \"label # with hash\"\n"
-                + "  type: Switch\n" + "- name: \"yes\"\n" + "  label: \"true\"\n" + "  type: String\n";
+        String expected = """
+                items:
+                - name: item:with:colon
+                  label: "label # with hash"
+                  type: Switch
+                - name: "yes"
+                  label: "true"
+                  type: String
+                """;
 
         assertEquals(expected, LLMItemSerializer.serialize(List.of(item1, item2)));
     }

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.voice.text.interpreter.llm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.items.Item;
+import org.openhab.core.semantics.Equipment;
+import org.openhab.core.semantics.Location;
+import org.openhab.core.semantics.Point;
+import org.openhab.core.semantics.Property;
+import org.openhab.core.semantics.SemanticTags;
+
+/**
+ * Test class for {@link LLMItemSerializer}.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+public class LLMItemSerializerTest {
+    // Mock semantic sub-interfaces for registering with SemanticTags
+    private interface MockFloor extends Location {
+    }
+
+    private interface MockLivingRoom extends Location {
+    }
+
+    private interface MockTV extends Equipment {
+    }
+
+    private interface MockLight extends Point {
+    }
+
+    private interface MockPower extends Point {
+    }
+
+    private interface MockPowerProperty extends Property {
+    }
+
+    @BeforeAll
+    public static void setUpTags() {
+        SemanticTags.addTagSet("Location_Floor", MockFloor.class);
+        SemanticTags.addTagSet("Location_Room_LivingRoom", MockLivingRoom.class);
+        SemanticTags.addTagSet("Equipment_Entertainment_TV", MockTV.class);
+        SemanticTags.addTagSet("Point_Control_Light", MockLight.class);
+        SemanticTags.addTagSet("Point_Control_Power", MockPower.class);
+        SemanticTags.addTagSet("Property_Power", MockPowerProperty.class);
+    }
+
+    @AfterAll
+    public static void tearDownTags() {
+        SemanticTags.removeTagSet("Location_Floor", MockFloor.class);
+        SemanticTags.removeTagSet("Location_Room_LivingRoom", MockLivingRoom.class);
+        SemanticTags.removeTagSet("Equipment_Entertainment_TV", MockTV.class);
+        SemanticTags.removeTagSet("Point_Control_Light", MockLight.class);
+        SemanticTags.removeTagSet("Point_Control_Power", MockPower.class);
+        SemanticTags.removeTagSet("Property_Power", MockPowerProperty.class);
+    }
+
+    private Item mockItem(String name, @Nullable String label, String type, Set<String> tags, List<String> groupNames) {
+        Item item = mock(Item.class);
+        when(item.getName()).thenReturn(name);
+        when(item.getLabel()).thenReturn(label);
+        when(item.getType()).thenReturn(type);
+        when(item.getTags()).thenReturn(tags);
+        when(item.getGroupNames()).thenReturn(groupNames);
+        return item;
+    }
+
+    @Test
+    public void testSerializeNullOrEmpty() {
+        assertEquals("", LLMItemSerializer.serialize(Collections.emptyList()));
+    }
+
+    @Test
+    public void testSerializeNonSemanticItemsOnly() {
+        Item item1 = mockItem("ItemB", "Label B", "Switch", Set.of(), List.of());
+        Item item2 = mockItem("ItemA", null, "Dimmer", Set.of(), List.of());
+
+        String expected = "items:\n" + "- name: ItemA\n" + "  type: Dimmer\n" + "- name: ItemB\n" + "  label: Label B\n"
+                + "  type: Switch\n";
+
+        assertEquals(expected, LLMItemSerializer.serialize(List.of(item1, item2)));
+    }
+
+    @Test
+    public void testSerializeHierarchicalModel() {
+        // GF Floor
+        Item gf = mockItem("GF", "Ground Floor", "Group", Set.of("Location_Floor"), List.of());
+
+        // LivingRoom Room inside GF
+        Item livingRoom = mockItem("LivingRoom", "Living Room", "Group", Set.of("Location_Room_LivingRoom"),
+                List.of("GF"));
+
+        // TV Equipment inside LivingRoom
+        Item tv = mockItem("TV", "Living Room TV", "Group", Set.of("Equipment_Entertainment_TV"),
+                List.of("LivingRoom"));
+
+        // TV Power Control inside TV
+        Item tvPower = mockItem("TV_Power", "TV Power", "Switch", Set.of("Point_Control_Power", "Property_Power"),
+                List.of("TV"));
+
+        // Living Room Light control inside LivingRoom directly
+        Item lrLight = mockItem("LivingRoom_Light", "Living Room Light", "Dimmer", Set.of("Point_Control_Light"),
+                List.of("LivingRoom"));
+
+        // Non-semantic Item
+        Item systemMode = mockItem("System_Mode", "System Mode", "String", Set.of(), List.of());
+
+        List<Item> items = new ArrayList<>(List.of(tvPower, livingRoom, systemMode, lrLight, tv, gf));
+        // Shuffle the list to ensure the serializer sorts correctly
+        Collections.shuffle(items);
+
+        String expected = "locationItems:\n" + "- name: GF\n" + "  label: Ground Floor\n" + "  type: Group\n"
+                + "  semanticType: MockFloor\n" + "  locationItems:\n" + "  - name: LivingRoom\n"
+                + "    label: Living Room\n" + "    type: Group\n" + "    semanticType: MockLivingRoom\n"
+                + "    equipmentItems:\n" + "    - name: TV\n" + "      label: Living Room TV\n" + "      type: Group\n"
+                + "      semanticType: MockTV\n" + "      pointItems:\n" + "      - name: TV_Power\n"
+                + "        label: TV Power\n" + "        type: Switch\n" + "        semanticType: MockPower\n"
+                + "        properties:\n" + "        - MockPowerProperty\n" + "    pointItems:\n"
+                + "    - name: LivingRoom_Light\n" + "      label: Living Room Light\n" + "      type: Dimmer\n"
+                + "      semanticType: MockLight\n" + "items:\n" + "- name: System_Mode\n" + "  label: System Mode\n"
+                + "  type: String\n";
+
+        assertEquals(expected, LLMItemSerializer.serialize(items));
+    }
+
+    @Test
+    public void testSerializeEscapingAndReservedWords() {
+        Item item1 = mockItem("item:with:colon", "label # with hash", "Switch", Set.of(), List.of());
+        Item item2 = mockItem("yes", "true", "String", Set.of(), List.of());
+
+        String expected = "items:\n" + "- name: item:with:colon\n" + "  label: \"label # with hash\"\n"
+                + "  type: Switch\n" + "- name: \"yes\"\n" + "  label: \"true\"\n" + "  type: String\n";
+
+        assertEquals(expected, LLMItemSerializer.serialize(List.of(item1, item2)));
+    }
+}

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
@@ -60,22 +60,22 @@ public class LLMItemSerializerTest {
 
     @BeforeAll
     public static void setUpTags() {
-        SemanticTags.addTagSet("Location_Floor", MockFloor.class);
-        SemanticTags.addTagSet("Location_Room_LivingRoom", MockLivingRoom.class);
-        SemanticTags.addTagSet("Equipment_Entertainment_TV", MockTV.class);
-        SemanticTags.addTagSet("Point_Control_Light", MockLight.class);
-        SemanticTags.addTagSet("Point_Control_Power", MockPower.class);
-        SemanticTags.addTagSet("Property_Power", MockPowerProperty.class);
+        SemanticTags.addTagSet("Mock_Location_Floor", MockFloor.class);
+        SemanticTags.addTagSet("Mock_Location_Room_LivingRoom", MockLivingRoom.class);
+        SemanticTags.addTagSet("Mock_Equipment_Entertainment_TV", MockTV.class);
+        SemanticTags.addTagSet("Mock_Point_Control_Light", MockLight.class);
+        SemanticTags.addTagSet("Mock_Point_Control_Power", MockPower.class);
+        SemanticTags.addTagSet("Mock_Property_Power", MockPowerProperty.class);
     }
 
     @AfterAll
     public static void tearDownTags() {
-        SemanticTags.removeTagSet("Location_Floor", MockFloor.class);
-        SemanticTags.removeTagSet("Location_Room_LivingRoom", MockLivingRoom.class);
-        SemanticTags.removeTagSet("Equipment_Entertainment_TV", MockTV.class);
-        SemanticTags.removeTagSet("Point_Control_Light", MockLight.class);
-        SemanticTags.removeTagSet("Point_Control_Power", MockPower.class);
-        SemanticTags.removeTagSet("Property_Power", MockPowerProperty.class);
+        SemanticTags.removeTagSet("Mock_Location_Floor", MockFloor.class);
+        SemanticTags.removeTagSet("Mock_Location_Room_LivingRoom", MockLivingRoom.class);
+        SemanticTags.removeTagSet("Mock_Equipment_Entertainment_TV", MockTV.class);
+        SemanticTags.removeTagSet("Mock_Point_Control_Light", MockLight.class);
+        SemanticTags.removeTagSet("Mock_Point_Control_Power", MockPower.class);
+        SemanticTags.removeTagSet("Mock_Property_Power", MockPowerProperty.class);
     }
 
     private Item mockItem(String name, @Nullable String label, String type, Set<String> tags, List<String> groupNames) {
@@ -113,22 +113,22 @@ public class LLMItemSerializerTest {
     @Test
     public void testSerializeHierarchicalModel() {
         // GF Floor
-        Item gf = mockItem("GF", "Ground Floor", "Group", Set.of("Location_Floor"), List.of());
+        Item gf = mockItem("GF", "Ground Floor", "Group", Set.of("Mock_Location_Floor"), List.of());
 
         // LivingRoom Room inside GF
-        Item livingRoom = mockItem("LivingRoom", "Living Room", "Group", Set.of("Location_Room_LivingRoom"),
+        Item livingRoom = mockItem("LivingRoom", "Living Room", "Group", Set.of("Mock_Location_Room_LivingRoom"),
                 List.of("GF"));
 
         // TV Equipment inside LivingRoom
-        Item tv = mockItem("TV", "Living Room TV", "Group", Set.of("Equipment_Entertainment_TV"),
+        Item tv = mockItem("TV", "Living Room TV", "Group", Set.of("Mock_Equipment_Entertainment_TV"),
                 List.of("LivingRoom"));
 
         // TV Power Control inside TV
-        Item tvPower = mockItem("TV_Power", "TV Power", "Switch", Set.of("Point_Control_Power", "Property_Power"),
-                List.of("TV"));
+        Item tvPower = mockItem("TV_Power", "TV Power", "Switch",
+                Set.of("Mock_Point_Control_Power", "Mock_Property_Power"), List.of("TV"));
 
         // Living Room Light control inside LivingRoom directly
-        Item lrLight = mockItem("LivingRoom_Light", "Living Room Light", "Dimmer", Set.of("Point_Control_Light"),
+        Item lrLight = mockItem("LivingRoom_Light", "Living Room Light", "Dimmer", Set.of("Mock_Point_Control_Light"),
                 List.of("LivingRoom"));
 
         // Non-semantic Item

--- a/itests/org.openhab.core.voice.tests/itest.bndrun
+++ b/itests/org.openhab.core.voice.tests/itest.bndrun
@@ -81,4 +81,9 @@ Fragment-Host: org.openhab.core.voice
 	org.openhab.core.voice.tests;version='[5.2.0,5.2.1)',\
 	biz.aQute.tester.junit-platform;version='[7.3.0,7.3.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.3.3,2.3.4)',\
-	org.openhab.core.semantics;version='[5.2.0,5.2.1)'
+	org.openhab.core.semantics;version='[5.2.0,5.2.1)',\
+	com.fasterxml.jackson.core.jackson-annotations;version='[2.21.0,2.21.1)',\
+	com.fasterxml.jackson.core.jackson-core;version='[2.21.4,2.21.5)',\
+	com.fasterxml.jackson.core.jackson-databind;version='[2.21.4,2.21.5)',\
+	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.21.4,2.21.5)',\
+	org.yaml.snakeyaml;version='[2.5.0,2.5.1)'

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceManagerImplTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceManagerImplTest.java
@@ -715,7 +715,6 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
         org.openhab.core.library.items.SwitchItem testItem = new org.openhab.core.library.items.SwitchItem(
                 "TestSwitch");
         testItem.setLabel("Test Switch Label");
-        itemRegistry.add(testItem);
 
         // Setup a custom HumanLanguageInterpreter to capture InterpreterContext
         final String[] capturedPrompt = new String[1];
@@ -758,9 +757,9 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
             }
         };
 
-        registerService(customHli);
-
         try {
+            itemRegistry.add(testItem);
+            registerService(customHli);
             // Configure VoiceManager configuration to use this HLI and have a base system prompt
             Dictionary<String, Object> config = new Hashtable<>();
             config.put("defaultHLI", "customHli");
@@ -769,18 +768,19 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
             Configuration configuration = configAdmin.getConfiguration(VoiceConfigurationConstants.CONFIGURATION_PID);
             configuration.update(config);
 
-            // Wait some time to be sure that the configuration will be updated
-            Thread.sleep(2000);
-
-            // Call interpret
-            voiceManager.interpret("hello", new InterpretationArguments("customHli", "", "", "", null));
-
-            // Verify captured prompt contains base prompt and serialized items
-            assertNotNull(capturedPrompt[0]);
-            assertTrue(capturedPrompt[0].contains("You are an assistant."));
-            assertTrue(capturedPrompt[0].contains("Available items:"));
-            assertTrue(capturedPrompt[0].contains("TestSwitch"));
-            assertTrue(capturedPrompt[0].contains("Test Switch Label"));
+            // Wait until the configuration update is effective
+            waitForAssert(() -> {
+                try {
+                    voiceManager.interpret("hello", new InterpretationArguments("customHli", "", "", "", null));
+                } catch (InterpretationException e) {
+                    throw new AssertionError(e);
+                }
+                assertNotNull(capturedPrompt[0]);
+                assertTrue(capturedPrompt[0].contains("You are an assistant."));
+                assertTrue(capturedPrompt[0].contains("Available items:"));
+                assertTrue(capturedPrompt[0].contains("TestSwitch"));
+                assertTrue(capturedPrompt[0].contains("Test Switch Label"));
+            });
         } finally {
             // Clean up item and service
             itemRegistry.remove("TestSwitch");

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceManagerImplTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceManagerImplTest.java
@@ -30,6 +30,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.audio.AudioManager;
@@ -37,11 +38,13 @@ import org.openhab.core.audio.AudioSource;
 import org.openhab.core.config.core.ParameterOption;
 import org.openhab.core.i18n.LocaleProvider;
 import org.openhab.core.i18n.TranslationProvider;
+import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.voice.DialogContext;
 import org.openhab.core.voice.DialogRegistration;
 import org.openhab.core.voice.Voice;
 import org.openhab.core.voice.VoiceManager;
+import org.openhab.core.voice.text.HumanLanguageInterpreter;
 import org.openhab.core.voice.text.InterpretationArguments;
 import org.openhab.core.voice.text.InterpretationException;
 import org.openhab.core.voice.text.conversation.ConversationRole;
@@ -701,5 +704,86 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
         voiceManager.unregisterDialog(dialogRegistration);
         // Assert dialog has been stopped
         assertTrue(ksService.isAborted());
+    }
+
+    @Test
+    public void testSystemPromptEnrichment() throws Exception {
+        ItemRegistry itemRegistry = getService(ItemRegistry.class);
+        assertNotNull(itemRegistry);
+
+        // Add a test item
+        org.openhab.core.library.items.SwitchItem testItem = new org.openhab.core.library.items.SwitchItem(
+                "TestSwitch");
+        testItem.setLabel("Test Switch Label");
+        itemRegistry.add(testItem);
+
+        // Setup a custom HumanLanguageInterpreter to capture InterpreterContext
+        final String[] capturedPrompt = new String[1];
+        HumanLanguageInterpreter customHli = new HumanLanguageInterpreter() {
+            @Override
+            public String getId() {
+                return "customHli";
+            }
+
+            @Override
+            public String getLabel(@Nullable Locale locale) {
+                return "Custom HLI";
+            }
+
+            @Override
+            public String interpret(Locale locale, String text) throws InterpretationException {
+                return "Interpreted";
+            }
+
+            @Override
+            public String interpret(Locale locale, org.openhab.core.voice.text.InterpreterContext interpreterContext)
+                    throws InterpretationException {
+                capturedPrompt[0] = interpreterContext.systemPrompt();
+                return "Interpreted Context";
+            }
+
+            @Override
+            public @Nullable String getGrammar(Locale locale, String format) {
+                return null;
+            }
+
+            @Override
+            public Set<Locale> getSupportedLocales() {
+                return Set.of(Locale.ENGLISH);
+            }
+
+            @Override
+            public Set<String> getSupportedGrammarFormats() {
+                return Set.of();
+            }
+        };
+
+        registerService(customHli);
+
+        try {
+            // Configure VoiceManager configuration to use this HLI and have a base system prompt
+            Dictionary<String, Object> config = new Hashtable<>();
+            config.put("defaultHLI", "customHli");
+            config.put("systemPrompt", "You are an assistant.");
+            ConfigurationAdmin configAdmin = super.getService(ConfigurationAdmin.class);
+            Configuration configuration = configAdmin.getConfiguration(VoiceConfigurationConstants.CONFIGURATION_PID);
+            configuration.update(config);
+
+            // Wait some time to be sure that the configuration will be updated
+            Thread.sleep(2000);
+
+            // Call interpret
+            voiceManager.interpret("hello", new InterpretationArguments("customHli", "", "", "", null));
+
+            // Verify captured prompt contains base prompt and serialized items
+            assertNotNull(capturedPrompt[0]);
+            assertTrue(capturedPrompt[0].contains("You are an assistant."));
+            assertTrue(capturedPrompt[0].contains("Available items:"));
+            assertTrue(capturedPrompt[0].contains("TestSwitch"));
+            assertTrue(capturedPrompt[0].contains("Test Switch Label"));
+        } finally {
+            // Clean up item and service
+            itemRegistry.remove("TestSwitch");
+        }
     }
 }


### PR DESCRIPTION
Addresses the final remaining task from #5620.

- Implements a serialiser that serialises a collection of Items to YAML representation.
- Semantic Items are serialized to a hierarchical YAML representation of the semantic model.
- Non-semantic Items are appended as a flat list.