### PR TITLE
[voice] Add missing toString implementations to Conversation events

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/conversation/events/ConversationCreatedEvent.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/conversation/events/ConversationCreatedEvent.java
@@ -36,4 +36,9 @@ public class ConversationCreatedEvent extends ConversationEvent {
     public String getType() {
         return TYPE;
     }
+
+    @Override
+    public String toString() {
+        return "Conversation '" + getConversationId() + "' has been created.";
+    }
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/conversation/events/ConversationMessageAddedEvent.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/conversation/events/ConversationMessageAddedEvent.java
@@ -48,8 +48,8 @@ public class ConversationMessageAddedEvent extends ConversationEvent {
 
     @Override
     public String toString() {
-        return "Message '" + messageId + "' of role '" + role + "' with text '" + text
-                + "' has been added to conversation '" + getConversationId() + "'.";
+        return "Message '" + messageId + "' of role '" + role + "' has been added to conversation '"
+                + getConversationId() + "'.";
     }
 
     public int getMessageId() {

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/conversation/events/ConversationMessageAddedEvent.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/conversation/events/ConversationMessageAddedEvent.java
@@ -46,6 +46,12 @@ public class ConversationMessageAddedEvent extends ConversationEvent {
         return TYPE;
     }
 
+    @Override
+    public String toString() {
+        return "Message '" + messageId + "' of role '" + role + "' with text '" + text
+                + "' has been added to conversation '" + getConversationId() + "'.";
+    }
+
     public int getMessageId() {
         return messageId;
     }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/conversation/events/ConversationMessagesRemovedEvent.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/conversation/events/ConversationMessagesRemovedEvent.java
@@ -39,6 +39,12 @@ public class ConversationMessagesRemovedEvent extends ConversationEvent {
         return TYPE;
     }
 
+    @Override
+    public String toString() {
+        return "Messages since message ID " + removedSinceMessagesId + " have been removed from conversation '"
+                + getConversationId() + "'.";
+    }
+
     public int getRemovedSinceMessagesId() {
         return removedSinceMessagesId;
     }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/conversation/events/ConversationRemovedEvent.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/conversation/events/ConversationRemovedEvent.java
@@ -36,4 +36,9 @@ public class ConversationRemovedEvent extends ConversationEvent {
     public String getType() {
         return TYPE;
     }
+
+    @Override
+    public String toString() {
+        return "Conversation '" + getConversationId() + "' has been removed.";
+    }
 }

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/conversation/events/ConversationEventFactoryTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/conversation/events/ConversationEventFactoryTest.java
@@ -96,8 +96,7 @@ public class ConversationEventFactoryTest {
         assertEquals(msgId, event.getMessageId());
         assertEquals(role, event.getRole());
         assertEquals(text, event.getText());
-        assertEquals("Message '1' of role 'USER' with text 'Hello' has been added to conversation 'conv-1'.",
-                event.toString());
+        assertEquals("Message '1' of role 'USER' has been added to conversation 'conv-1'.", event.toString());
     }
 
     @Test

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/conversation/events/ConversationEventFactoryTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/conversation/events/ConversationEventFactoryTest.java
@@ -37,6 +37,7 @@ public class ConversationEventFactoryTest {
         assertEquals(ConversationCreatedEvent.TYPE, event.getType());
         assertEquals("openhab/conversations/conv-1/added", event.getTopic());
         assertEquals(id, event.getConversationId());
+        assertEquals("Conversation 'conv-1' has been created.", event.toString());
     }
 
     @Test
@@ -62,6 +63,7 @@ public class ConversationEventFactoryTest {
         assertEquals(ConversationRemovedEvent.TYPE, event.getType());
         assertEquals("openhab/conversations/conv-1/removed", event.getTopic());
         assertEquals(id, event.getConversationId());
+        assertEquals("Conversation 'conv-1' has been removed.", event.toString());
     }
 
     @Test
@@ -94,6 +96,8 @@ public class ConversationEventFactoryTest {
         assertEquals(msgId, event.getMessageId());
         assertEquals(role, event.getRole());
         assertEquals(text, event.getText());
+        assertEquals("Message '1' of role 'USER' with text 'Hello' has been added to conversation 'conv-1'.",
+                event.toString());
     }
 
     @Test
@@ -129,6 +133,7 @@ public class ConversationEventFactoryTest {
         assertEquals("openhab/conversations/conv-1/messagesremoved", event.getTopic());
         assertEquals(convId, event.getConversationId());
         assertEquals(removedSinceMessagesId, event.getRemovedSinceMessagesId());
+        assertEquals("Messages since message ID 1 have been removed from conversation 'conv-1'.", event.toString());
     }
 
     @Test


### PR DESCRIPTION
As openHAB logs all events, we need a proper toString implementation, or we end up with this:

```
10:05:03.257 [INFO ] [b.event.ConversationMessageAddedEvent] - org.openhab.core.voice.text.conversation.events.ConversationMessageAddedEvent@dfee3f4c
```