### PR TITLE
Fix missing regex replace escaping in DslRuleConverter

### DIFF
--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/converter/DslRuleConverter.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/converter/DslRuleConverter.java
@@ -329,7 +329,7 @@ public class DslRuleConverter implements RuleSerializer, RuleParser {
                         if (!scriptContent.endsWith("\n")) {
                             scriptContent += '\n';
                         }
-                        generated = m.replaceFirst(scriptContent);
+                        generated = m.replaceFirst(Matcher.quoteReplacement(scriptContent));
                     }
                 }
                 m = PLACEHOLDER_PATTERN.matcher(generated);


### PR DESCRIPTION
Thanks a lot to @lolodomo for finding this one so quickly. I had forgotten to escape the regex replacement string in `DslRuleConverter`, which leads to errors if certain characters (`$` and `\`) are used. This fixes the problem.

Fixes #5652.