### PR TITLE
Delay refresh of DSL scripts until start level 20 is reached

### DIFF
--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
@@ -146,6 +146,7 @@ public class DSLRuleProvider
     @Deactivate
     protected void deactivate() {
         modelRepository.removeModelRepositoryChangeListener(this);
+        readyService.unregisterTracker(this);
         rulesMap.clear();
         contexts.clear();
         xExpressions.clear();
@@ -726,10 +727,16 @@ public class DSLRuleProvider
 
     @Override
     public void onReadyMarkerRemoved(ReadyMarker readyMarker) {
-        if ((ScriptItemRefresher.SCRIPTS_REFRESH_MARKER_TYPE.equals(readyMarker.getType())
-                && ScriptItemRefresher.SCRIPTS_REFRESH.equals(readyMarker.getIdentifier()))
-                || (RulesRefresher.RULES_REFRESH_MARKER_TYPE.equals(readyMarker.getType())
-                        && RulesRefresher.RULES_REFRESH.equals(readyMarker.getIdentifier()))) {
+        boolean readyBefore = scriptsReady && rulesReady;
+        if (ScriptItemRefresher.SCRIPTS_REFRESH_MARKER_TYPE.equals(readyMarker.getType())
+                && ScriptItemRefresher.SCRIPTS_REFRESH.equals(readyMarker.getIdentifier())) {
+            scriptsReady = false;
+        } else if (RulesRefresher.RULES_REFRESH_MARKER_TYPE.equals(readyMarker.getType())
+                && RulesRefresher.RULES_REFRESH.equals(readyMarker.getIdentifier())) {
+            rulesReady = false;
+        }
+        boolean readyAfter = scriptsReady && rulesReady;
+        if (readyBefore && !readyAfter) {
             readyService.unmarkReady(marker);
         }
     }

--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
@@ -92,10 +92,10 @@ import org.openhab.core.model.rule.rules.TimerTrigger;
 import org.openhab.core.model.rule.rules.UpdateEventTrigger;
 import org.openhab.core.model.rule.rules.WeekdayCondition;
 import org.openhab.core.model.rule.rules.impl.RuleImpl;
+import org.openhab.core.model.script.jvmmodel.ScriptItemRefresher;
 import org.openhab.core.model.script.runtime.DSLScriptContextProvider;
 import org.openhab.core.model.script.script.Script;
 import org.openhab.core.service.ReadyMarker;
-import org.openhab.core.service.ReadyMarkerFilter;
 import org.openhab.core.service.ReadyService;
 import org.openhab.core.service.ReadyService.ReadyTracker;
 import org.osgi.service.component.annotations.Activate;
@@ -112,6 +112,7 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - Initial contribution
  * @author Laurent Garnier - Add support for conditions
  * @author Laurent Garnier - Add optional rule UID + registry notification refactoring
+ * @author Laurent Garnier - wait for marker scripts=refresh in addition to marker rules=refresh
  */
 @NonNullByDefault
 @Component(immediate = true, service = { DSLRuleProvider.class, RuleProvider.class, DSLScriptContextProvider.class })
@@ -131,16 +132,15 @@ public class DSLRuleProvider
     private final ModelRepository modelRepository;
     private final ReadyService readyService;
 
+    private boolean scriptsReady;
+    private boolean rulesReady;
+
     @Activate
     public DSLRuleProvider(@Reference ModelRepository modelRepository, @Reference ReadyService readyService) {
         this.modelRepository = modelRepository;
         this.readyService = readyService;
-    }
 
-    @Activate
-    protected void activate() {
-        readyService.registerTracker(this, new ReadyMarkerFilter().withType(RulesRefresher.RULES_REFRESH_MARKER_TYPE)
-                .withIdentifier(RulesRefresher.RULES_REFRESH));
+        readyService.registerTracker(this);
     }
 
     @Deactivate
@@ -652,6 +652,19 @@ public class DSLRuleProvider
 
     @Override
     public void onReadyMarkerAdded(ReadyMarker readyMarker) {
+        if (ScriptItemRefresher.SCRIPTS_REFRESH_MARKER_TYPE.equals(readyMarker.getType())
+                && ScriptItemRefresher.SCRIPTS_REFRESH.equals(readyMarker.getIdentifier())) {
+            scriptsReady = true;
+        } else if (RulesRefresher.RULES_REFRESH_MARKER_TYPE.equals(readyMarker.getType())
+                && RulesRefresher.RULES_REFRESH.equals(readyMarker.getIdentifier())) {
+            rulesReady = true;
+        } else {
+            return;
+        }
+        if (!scriptsReady || !rulesReady) {
+            return;
+        }
+
         for (String modelFileName : modelRepository.getAllModelNamesOfType("script")) {
             logger.debug("onReadyMarkerAdded handle script {}", modelFileName);
             EObject model = modelRepository.getModel(modelFileName);
@@ -713,7 +726,12 @@ public class DSLRuleProvider
 
     @Override
     public void onReadyMarkerRemoved(ReadyMarker readyMarker) {
-        readyService.unmarkReady(marker);
+        if ((ScriptItemRefresher.SCRIPTS_REFRESH_MARKER_TYPE.equals(readyMarker.getType())
+                && ScriptItemRefresher.SCRIPTS_REFRESH.equals(readyMarker.getIdentifier()))
+                || (RulesRefresher.RULES_REFRESH_MARKER_TYPE.equals(readyMarker.getType())
+                        && RulesRefresher.RULES_REFRESH.equals(readyMarker.getIdentifier()))) {
+            readyService.unmarkReady(marker);
+        }
     }
 
     private record RulePair(Rule oldRule, Rule newRule) {

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesRefresher.java
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesRefresher.java
@@ -61,18 +61,20 @@ public class RulesRefresher implements ReadyTracker {
     public static final String RULES_REFRESH_MARKER_TYPE = "rules";
     public static final String RULES_REFRESH = "refresh";
 
-    private final Logger logger = LoggerFactory.getLogger(RulesRefresher.class);
+    private final ReadyMarker MARKER = new ReadyMarker(RULES_REFRESH_MARKER_TYPE, RULES_REFRESH);
 
-    private @Nullable ScheduledFuture<?> job;
-    private final ScheduledExecutorService scheduler = Executors
-            .newSingleThreadScheduledExecutor(new NamedThreadFactory("rulesRefresher"));
-    private boolean started;
-    private final ReadyMarker marker = new ReadyMarker("rules", RULES_REFRESH);
+    private final Logger logger = LoggerFactory.getLogger(RulesRefresher.class);
 
     private final ModelRepository modelRepository;
     private final ItemRegistry itemRegistry;
     private final ThingRegistry thingRegistry;
     private final ReadyService readyService;
+
+    private final ScheduledExecutorService scheduler = Executors
+            .newSingleThreadScheduledExecutor(new NamedThreadFactory("rulesRefresher"));
+
+    private @Nullable ScheduledFuture<?> job;
+    private boolean started;
 
     private final ItemRegistryChangeListener itemRegistryChangeListener = new ItemRegistryChangeListener() {
         @Override
@@ -123,16 +125,17 @@ public class RulesRefresher implements ReadyTracker {
         this.itemRegistry = itemRegistry;
         this.thingRegistry = thingRegistry;
         this.readyService = readyService;
-    }
 
-    @Activate
-    protected void activate() {
         readyService.registerTracker(this, new ReadyMarkerFilter().withType(StartLevelService.STARTLEVEL_MARKER_TYPE)
                 .withIdentifier(Integer.toString(StartLevelService.STARTLEVEL_MODEL)));
     }
 
     @Deactivate
     protected void deactivate() {
+        ScheduledFuture<?> localJob = job;
+        if (localJob != null && !localJob.isDone()) {
+            localJob.cancel(false);
+        }
         readyService.unregisterTracker(this);
     }
 
@@ -179,7 +182,7 @@ public class RulesRefresher implements ReadyTracker {
             }
             if (!started) {
                 started = true;
-                readyService.markReady(marker);
+                readyService.markReady(MARKER);
             }
         }, delay, TimeUnit.SECONDS);
     }

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesRefresher.java
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesRefresher.java
@@ -134,8 +134,10 @@ public class RulesRefresher implements ReadyTracker {
     protected void deactivate() {
         ScheduledFuture<?> localJob = job;
         if (localJob != null && !localJob.isDone()) {
-            localJob.cancel(false);
+            localJob.cancel(true);
         }
+        job = null;
+        started = false;
         readyService.unregisterTracker(this);
     }
 

--- a/bundles/org.openhab.core.model.script/bnd.bnd
+++ b/bundles/org.openhab.core.model.script/bnd.bnd
@@ -22,6 +22,7 @@ Import-Package: \
  org.openhab.core.automation,\
  org.openhab.core.automation.module.script.action,\
  org.openhab.core.automation.module.script.rulesupport.shared,\
+ org.openhab.core.common,\
  org.openhab.core.common.registry,\
  org.openhab.core.config.core,\
  org.openhab.core.ephemeris,\
@@ -41,6 +42,7 @@ Import-Package: \
  org.openhab.core.persistence.extensions,\
  org.openhab.core.scheduler,\
  org.openhab.core.semantics,\
+ org.openhab.core.service,\
  org.openhab.core.thing,\
  org.openhab.core.thing.binding,\
  org.openhab.core.thing.events,\

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptItemRefresher.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptItemRefresher.java
@@ -84,8 +84,10 @@ public class ScriptItemRefresher implements ItemRegistryChangeListener, ReadyTra
     protected void deactivate() {
         ScheduledFuture<?> localJob = job;
         if (localJob != null && !localJob.isDone()) {
-            localJob.cancel(false);
+            localJob.cancel(true);
         }
+        job = null;
+        started = false;
         readyService.unregisterTracker(this);
     }
 

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptItemRefresher.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptItemRefresher.java
@@ -18,12 +18,21 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.common.NamedThreadFactory;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.items.ItemRegistryChangeListener;
 import org.openhab.core.model.core.ModelRepository;
 import org.openhab.core.model.script.engine.action.ActionService;
+import org.openhab.core.service.ReadyMarker;
+import org.openhab.core.service.ReadyMarkerFilter;
+import org.openhab.core.service.ReadyService;
+import org.openhab.core.service.ReadyService.ReadyTracker;
+import org.openhab.core.service.StartLevelService;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
@@ -35,64 +44,76 @@ import org.slf4j.LoggerFactory;
  *
  * @author Oliver Libutzki - Initial contribution
  * @author Kai Kreuzer - added delayed execution
+ * @author Laurent Garnier - delayed execution until start level 20 is reached
  */
 @Component(service = {})
-public class ScriptItemRefresher implements ItemRegistryChangeListener {
+public class ScriptItemRefresher implements ItemRegistryChangeListener, ReadyTracker {
+
+    // delay in seconds before script resources are refreshed after items or services have changed
+    private static final long REFRESH_DELAY = 30;
+
+    public static final String SCRIPTS_REFRESH_MARKER_TYPE = "scripts";
+    public static final String SCRIPTS_REFRESH = "refresh";
+
+    private final ReadyMarker MARKER = new ReadyMarker(SCRIPTS_REFRESH_MARKER_TYPE, SCRIPTS_REFRESH);
 
     private final Logger logger = LoggerFactory.getLogger(ScriptItemRefresher.class);
 
-    // delay before rule resources are refreshed after items or services have changed
-    private static final long REFRESH_DELAY = 2000;
+    private final ModelRepository modelRepository;
+    private final ItemRegistry itemRegistry;
+    private final ReadyService readyService;
 
-    ModelRepository modelRepository;
-    private ItemRegistry itemRegistry;
-    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
-    private ScheduledFuture<?> job;
+    private final ScheduledExecutorService scheduler = Executors
+            .newSingleThreadScheduledExecutor(new NamedThreadFactory("scriptsRefresher"));
 
-    @Reference
-    public void setModelRepository(ModelRepository modelRepository) {
+    private @Nullable ScheduledFuture<?> job;
+    private boolean started;
+
+    @Activate
+    public ScriptItemRefresher(@Reference ModelRepository modelRepository, @Reference ItemRegistry itemRegistry,
+            @Reference ReadyService readyService) {
         this.modelRepository = modelRepository;
-    }
-
-    public void unsetModelRepository(ModelRepository modelRepository) {
-        if (job != null && !job.isDone()) {
-            job.cancel(false);
-        }
-        this.modelRepository = null;
-    }
-
-    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
-    public void setItemRegistry(ItemRegistry itemRegistry) {
         this.itemRegistry = itemRegistry;
-        this.itemRegistry.addRegistryChangeListener(this);
+        this.readyService = readyService;
+
+        readyService.registerTracker(this, new ReadyMarkerFilter().withType(StartLevelService.STARTLEVEL_MARKER_TYPE)
+                .withIdentifier(Integer.toString(StartLevelService.STARTLEVEL_MODEL)));
     }
 
-    public void unsetItemRegistry(ItemRegistry itemRegistry) {
-        this.itemRegistry.removeRegistryChangeListener(this);
-        this.itemRegistry = null;
+    @Deactivate
+    protected void deactivate() {
+        ScheduledFuture<?> localJob = job;
+        if (localJob != null && !localJob.isDone()) {
+            localJob.cancel(false);
+        }
+        readyService.unregisterTracker(this);
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
     protected void addActionService(ActionService actionService) {
-        logger.debug("Script action added => scripts are going to be refreshed");
-        scheduleScriptRefresh();
+        if (started) {
+            logger.debug("Script action added => scripts are going to be refreshed");
+            scheduleScriptRefresh(REFRESH_DELAY);
+        }
     }
 
     protected void removeActionService(ActionService actionService) {
-        logger.debug("Script action removed => scripts are going to be refreshed");
-        scheduleScriptRefresh();
+        if (started) {
+            logger.debug("Script action removed => scripts are going to be refreshed");
+            scheduleScriptRefresh(REFRESH_DELAY);
+        }
     }
 
     @Override
     public void added(Item element) {
         logger.debug("Item \"{}\" added => scripts are going to be refreshed", element.getName());
-        scheduleScriptRefresh();
+        scheduleScriptRefresh(REFRESH_DELAY);
     }
 
     @Override
     public void removed(Item element) {
         logger.debug("Item \"{}\" removed => scripts are going to be refreshed", element.getName());
-        scheduleScriptRefresh();
+        scheduleScriptRefresh(REFRESH_DELAY);
     }
 
     @Override
@@ -102,24 +123,35 @@ public class ScriptItemRefresher implements ItemRegistryChangeListener {
     @Override
     public void allItemsChanged(Collection<String> oldItemNames) {
         logger.debug("All items changed => scripts are going to be refreshed");
-        scheduleScriptRefresh();
+        scheduleScriptRefresh(REFRESH_DELAY);
     }
 
-    private synchronized void scheduleScriptRefresh() {
-        if (job != null && !job.isDone()) {
-            job.cancel(false);
+    private synchronized void scheduleScriptRefresh(long delay) {
+        ScheduledFuture<?> localJob = job;
+        if (localJob != null && !localJob.isDone()) {
+            localJob.cancel(false);
         }
-        job = scheduler.schedule(runnable, REFRESH_DELAY, TimeUnit.MILLISECONDS);
-    }
-
-    Runnable runnable = new Runnable() {
-        @Override
-        public void run() {
+        job = scheduler.schedule(() -> {
             try {
                 modelRepository.reloadAllModelsOfType("script");
             } catch (Exception e) {
                 logger.debug("Exception occurred during execution: {}", e.getMessage(), e);
             }
-        }
-    };
+            if (!started) {
+                started = true;
+                readyService.markReady(MARKER);
+            }
+        }, delay, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void onReadyMarkerAdded(ReadyMarker readyMarker) {
+        scheduleScriptRefresh(0);
+        itemRegistry.addRegistryChangeListener(this);
+    }
+
+    @Override
+    public void onReadyMarkerRemoved(ReadyMarker readyMarker) {
+        itemRegistry.removeRegistryChangeListener(this);
+    }
 }

--- a/itests/org.openhab.core.model.rule.tests/src/main/java/org/openhab/core/model/rule/runtime/DSLRuleProviderTest.java
+++ b/itests/org.openhab.core.model.rule.tests/src/main/java/org/openhab/core/model/rule/runtime/DSLRuleProviderTest.java
@@ -54,6 +54,7 @@ import org.openhab.core.events.EventPublisher;
 import org.openhab.core.model.core.ModelRepository;
 import org.openhab.core.model.rule.jvmmodel.RulesRefresher;
 import org.openhab.core.model.rule.runtime.internal.DSLRuleProvider;
+import org.openhab.core.model.script.jvmmodel.ScriptItemRefresher;
 import org.openhab.core.model.script.runtime.internal.engine.DSLScriptEngine;
 import org.openhab.core.service.ReadyMarker;
 import org.openhab.core.service.ReadyService;
@@ -90,7 +91,9 @@ public class DSLRuleProviderTest extends JavaOSGiTest {
 
         readyService = getService(ReadyService.class);
         assertThat(readyService, is(notNullValue()));
-        readyService.markReady(new ReadyMarker("rules", RulesRefresher.RULES_REFRESH));
+        readyService.markReady(
+                new ReadyMarker(ScriptItemRefresher.SCRIPTS_REFRESH_MARKER_TYPE, ScriptItemRefresher.SCRIPTS_REFRESH));
+        readyService.markReady(new ReadyMarker(RulesRefresher.RULES_REFRESH_MARKER_TYPE, RulesRefresher.RULES_REFRESH));
     }
 
     @AfterEach


### PR DESCRIPTION
Align the behaviour for DSL scripts with the behaviour for DSL rules.

This can avoid usekess DSL script refreshes at OH startup due to script refresher starting too early.

The DSL rule provider is now waiting for both markers rules=refresh and scripts=refresh to provide scripts and rules to the rule registry.
