### PR TITLE
DSL Rule Converter: Always quote strings in triggers for target DSL

### DIFF
--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/converter/DslRuleConverter.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/converter/DslRuleConverter.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -97,9 +96,6 @@ import org.openhab.core.model.rule.rules.ValidState;
 import org.openhab.core.model.rule.rules.ValidTrigger;
 import org.openhab.core.model.rule.rules.WeekdayCondition;
 import org.openhab.core.model.rule.runtime.internal.DSLRuleProvider;
-import org.openhab.core.model.script.scoping.StateAndCommandProvider;
-import org.openhab.core.types.Command;
-import org.openhab.core.types.State;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -124,8 +120,6 @@ public class DslRuleConverter implements RuleSerializer, RuleParser {
     private static final Pattern NUMERIC_PATTERN = Pattern.compile("-?\\d+(\\.\\d+)?");
     private static final Pattern TIME_PATTERN = Pattern.compile("^([012]?\\d):([0-5]\\d)$");
     private static final Pattern INDEX_PATTERN = Pattern.compile("-(?<idx>\\d+)$");
-    private final Set<String> enumStates;
-    private final Set<String> enumCommands;
 
     private final Logger logger = LoggerFactory.getLogger(DslRuleConverter.class);
 
@@ -143,18 +137,6 @@ public class DslRuleConverter implements RuleSerializer, RuleParser {
     public DslRuleConverter(@Reference ModelRepository modelRepository, @Reference DSLRuleProvider ruleProvider) {
         this.modelRepository = modelRepository;
         this.ruleProvider = ruleProvider;
-
-        Set<String> enums = new LinkedHashSet<>();
-        for (State state : StateAndCommandProvider.getAllStates()) {
-            enums.add(state.toString());
-        }
-        this.enumStates = Set.copyOf(enums);
-
-        enums = new LinkedHashSet<>();
-        for (Command command : StateAndCommandProvider.getAllCommands()) {
-            enums.add(command.toString());
-        }
-        this.enumCommands = Set.copyOf(enums);
     }
 
     @Override
@@ -817,8 +799,6 @@ public class DslRuleConverter implements RuleSerializer, RuleParser {
         ValidState result;
         if (NUMERIC_PATTERN.matcher(stateValue).matches()) {
             result = RulesFactory.eINSTANCE.createValidStateNumber();
-        } else if (enumStates.contains(stateValue)) {
-            result = RulesFactory.eINSTANCE.createValidStateId();
         } else {
             result = RulesFactory.eINSTANCE.createValidStateString();
         }
@@ -830,8 +810,6 @@ public class DslRuleConverter implements RuleSerializer, RuleParser {
         ValidCommand result;
         if (NUMERIC_PATTERN.matcher(commandValue).matches()) {
             result = RulesFactory.eINSTANCE.createValidCommandNumber();
-        } else if (enumCommands.contains(commandValue)) {
-            result = RulesFactory.eINSTANCE.createValidCommandId();
         } else {
             result = RulesFactory.eINSTANCE.createValidCommandString();
         }


### PR DESCRIPTION
For a string item `s` when writing triggers
```
when
  Item s changed to OM or
  Item s changed to ON
then
```
`OM` and `ON` are just `StringType` values, they are not enum constants, and when writing DSL rules it only makes sense to quote both `OM` and `ON`, or not to quote both of them.  In practice it makes no difference, if `OM` and `ON` above are quoted (`to "OM" or … to "ON"`) or not.
    
In the triggers in DSL Rules, the states and commands do not have to be quoted, if they are not keywords and  match
```
terminal ID:'? ('a'..'z'|'A'..'Z'|'$'|'_') ('a'..'z'|'A'..'Z'|'$'|'_'|'0'..'9')*;
```
Otherwise states and commands must be quoted, for the sake of satisfying the DSL lexer/parser.  At runtime there is no difference between quoted or not quoted states/commands.  By coincidence states and commands, which are enum constants implementing [org.openhab.core.types.Type](https://www.openhab.org/javadoc/latest/org/openhab/core/types/type), match the criterion, so they can be quoted, but can be also not quoted.
    
As a matter of fact the lexer/parser allows alternatives, as in `changed to ^if` ⇔ `changed to "if"`, or `changed to fuf` ⇔ `changed to ^fuf` ⇔ `changed to "fuf"`.
    
This changeset simplifies the code by always quoting states and commands, when YAML or `.rules` input is converted to `DSL Rule`.

The correct way to decice, whether to quote or not to quote, would be to invoke the lexer, and let it check if the input is ID, reserved keyword, ValidID, something else.
    
As DslRuleConverter is an immediate OSGi component, this change avoids the unconditional static initializations in StateAndCommandProvider, when openHAB starts, also reducing the memory requirements at run-time.
