### PR TITLE
ScriptTransformationService: Cleanup `ScriptEngine`s on corresponding `ScriptEngineFactory` removal

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -301,12 +301,17 @@ public class ScriptTransformationService
     }
 
     private void disposeScriptRecord(ScriptRecord scriptRecord) {
-        ScriptEngineContainer scriptEngineContainer = scriptRecord.scriptEngineContainer;
-        if (scriptEngineContainer != null) {
-            scriptEngineManager.removeEngine(scriptEngineContainer.getIdentifier());
-            scriptRecord.scriptEngineContainer = null;
+        scriptRecord.lock.lock();
+        try {
+            ScriptEngineContainer scriptEngineContainer = scriptRecord.scriptEngineContainer;
+            if (scriptEngineContainer != null) {
+                scriptEngineManager.removeEngine(scriptEngineContainer.getIdentifier());
+                scriptRecord.scriptEngineContainer = null;
+            }
+            scriptRecord.compiledScript = null;
+        } finally {
+            scriptRecord.lock.unlock();
         }
-        scriptRecord.compiledScript = null;
     }
 
     @Override

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -326,8 +326,8 @@ public class ScriptTransformationService
         }
 
         logger.debug(
-                "ScriptEngineFactory for script type '{}' has been removed, disposing script engines of type '{}'.",
-                scriptType, scriptType);
+                "ScriptEngineFactory for script type '{}' has been removed, disposing script engines of this type.",
+                scriptType);
         // removal of the ScriptEngineFactory for "our" scriptType causes all ScriptEngines to be closed:
         // cleanup all script engines so they can be properly recreated when needed and a ScriptEngineFactory for "our"
         // scriptType is available

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -325,6 +325,9 @@ public class ScriptTransformationService
             return;
         }
 
+        logger.debug(
+                "ScriptEngineFactory for script type '{}' has been removed, disposing script engines of type '{}'.",
+                scriptType, scriptType);
         // removal of the ScriptEngineFactory for "our" scriptType causes all ScriptEngines to be closed:
         // cleanup all script engines so they can be properly recreated when needed and a ScriptEngineFactory for "our"
         // scriptType is available

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -68,7 +68,8 @@ import org.slf4j.LoggerFactory;
 @Component(factory = "org.openhab.core.automation.module.script.transformation.factory", service = {
         TransformationService.class, ScriptTransformationService.class, ScriptDependencyTracker.Listener.class,
         ConfigOptionProvider.class, ConfigDescriptionProvider.class })
-public class ScriptTransformationService implements TransformationService, ScriptDependencyTracker.Listener,
+public class ScriptTransformationService
+        implements TransformationService, ScriptDependencyTracker.Listener, ScriptEngineManager.FactoryChangeListener,
         ConfigOptionProvider, ConfigDescriptionProvider, RegistryChangeListener<Transformation> {
     public static final String SCRIPT_TYPE_PROPERTY_NAME = "openhab.transform.script.scriptType";
     public static final String OPENHAB_TRANSFORMATION_SCRIPT = "openhab-transformation-script-";
@@ -106,10 +107,12 @@ public class ScriptTransformationService implements TransformationService, Scrip
         this.scriptType = scriptType;
         this.profileConfigUri = URI.create(PROFILE_CONFIG_URI_PREFIX + scriptType.toUpperCase());
         transformationRegistry.addRegistryChangeListener(this);
+        scriptEngineManager.addFactoryChangeListener(this);
     }
 
     @Deactivate
     public void deactivate() {
+        scriptEngineManager.removeFactoryChangeListener(this);
         transformationRegistry.removeRegistryChangeListener(this);
 
         // cleanup script engines
@@ -219,18 +222,6 @@ public class ScriptTransformationService implements TransformationService, Scrip
                 }
             } catch (ScriptException e) {
                 throw new TransformationException("Failed to execute script.", e);
-            } catch (IllegalStateException e) {
-                // ISE thrown by JS Scripting if script engine already closed
-                if ("The Context is already closed.".equals(e.getMessage())) {
-                    logger.warn(
-                            "Script engine context {} is already closed, this should not happen. Recreating script engine.",
-                            scriptUid);
-                    scriptCache.remove(scriptUid);
-                    return transform(function, source);
-                } else {
-                    // rethrow
-                    throw e;
-                }
             }
         } finally {
             scriptRecord.lock.unlock();
@@ -313,8 +304,26 @@ public class ScriptTransformationService implements TransformationService, Scrip
         ScriptEngineContainer scriptEngineContainer = scriptRecord.scriptEngineContainer;
         if (scriptEngineContainer != null) {
             scriptEngineManager.removeEngine(scriptEngineContainer.getIdentifier());
+            scriptRecord.scriptEngineContainer = null;
         }
         scriptRecord.compiledScript = null;
+    }
+
+    @Override
+    public void factoryAdded(String scriptType) {
+        // we don't need to process this, as the scriptCache is lazy-initialized
+    }
+
+    @Override
+    public void factoryRemoved(String scriptType) {
+        if (!this.scriptType.equals(scriptType)) {
+            return;
+        }
+
+        // removal of the ScriptEngineFactory for "our" scriptType causes all ScriptEngines to be closed:
+        // cleanup all script engines so they can be properly recreated when needed and a ScriptEngineFactory for "our"
+        // scriptType is available
+        scriptCache.values().forEach(this::disposeScriptRecord);
     }
 
     private static class ScriptRecord {

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -16,10 +16,10 @@ import static org.openhab.core.automation.module.script.ScriptEngineFactory.*;
 
 import java.io.InputStreamReader;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
@@ -64,7 +64,7 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
     private final Map<String, ScriptEngineContainer> loadedScriptEngineInstances = new HashMap<>();
     private final Map<String, ScriptEngineFactory> factories = new HashMap<>();
     private final ScriptExtensionManager scriptExtensionManager;
-    private final Set<FactoryChangeListener> listeners = new HashSet<>();
+    private final Set<FactoryChangeListener> listeners = new CopyOnWriteArraySet<>();
 
     @Activate
     public ScriptEngineManagerImpl(final @Reference ScriptExtensionManager scriptExtensionManager) {

--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/ScriptTransformationServiceTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/ScriptTransformationServiceTest.java
@@ -204,18 +204,25 @@ public class ScriptTransformationServiceTest extends JavaTest {
     }
 
     @Test
-    public void recoversFromClosedScriptContext() throws ScriptException, TransformationException {
-        when(scriptEngine.eval(SCRIPT)).thenThrow(new IllegalStateException("The Context is already closed."))
-                .thenReturn(SCRIPT_OUTPUT);
-        setupInterceptedLogger(ScriptTransformationService.class, LogLevel.WARN);
+    public void factoryRemovedOfDifferentScriptTypeDoesNotDisposeEngine() throws TransformationException {
+        service.transform(SCRIPT_UID, "input");
 
-        String returnValue = Objects.requireNonNull(service.transform(SCRIPT_UID, "input"));
+        service.factoryRemoved("differentLanguage");
+        verify(scriptEngineManager, never()).removeEngine(any());
+    }
 
-        assertThat(returnValue, is(SCRIPT_OUTPUT));
+    @Test
+    public void factoryRemovedOfSameScriptTypeDisposesEngine() throws TransformationException {
+        when(scriptEngineContainer.getIdentifier()).thenReturn("engineId");
+        service.transform(SCRIPT_UID, "input");
 
-        stopInterceptedLogger(ScriptTransformationService.class);
-        assertLogMessage(ScriptTransformationService.class, LogLevel.WARN, "Script engine context " + SCRIPT_UID
-                + " is already closed, this should not happen. Recreating script engine.");
+        // Engine should be disposed
+        service.factoryRemoved(SCRIPT_LANGUAGE);
+        verify(scriptEngineManager).removeEngine("engineId");
+
+        // Subsequent transform should recreate the engine
+        service.transform(SCRIPT_UID, "input");
+        verify(scriptEngineManager, times(2)).createScriptEngine(eq(SCRIPT_LANGUAGE), any());
     }
 
     @Test


### PR DESCRIPTION
Make `ScriptTransformationService` listen for the addition and removal of `ScriptEngineFactory` and clean up `ScriptEngine`s if their factory has been removed. This fixes an issue where script transformations attempt to execute in a closed ScriptEngine.

Allows to revert the "workaround" from #4437.