### PR TITLE
[automation] AbstractScriptModuleHandler: Handle ScriptEngineFactory lifecycle

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -45,7 +45,8 @@ import org.slf4j.LoggerFactory;
  * @param <T> the type of module the concrete handler can handle
  */
 @NonNullByDefault
-public abstract class AbstractScriptModuleHandler<T extends Module> extends BaseModuleHandler<T> {
+public abstract class AbstractScriptModuleHandler<T extends Module> extends BaseModuleHandler<T>
+        implements ScriptEngineManager.FactoryChangeListener {
 
     private final Logger logger = LoggerFactory.getLogger(AbstractScriptModuleHandler.class);
 
@@ -79,6 +80,8 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
 
         this.type = getValidConfigParameter(CONFIG_SCRIPT_TYPE, module.getConfiguration(), module.getId(), false);
         this.script = getValidConfigParameter(CONFIG_SCRIPT, module.getConfiguration(), module.getId(), true);
+
+        scriptEngineManager.addFactoryChangeListener(this);
     }
 
     private static String getValidConfigParameter(String parameter, Configuration config, String moduleId,
@@ -117,6 +120,7 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
 
     @Override
     public void dispose() {
+        scriptEngineManager.removeFactoryChangeListener(this);
         scriptEngineManager.removeEngine(engineIdentifier);
     }
 
@@ -263,5 +267,22 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
                     logger.isDebugEnabled() ? e : null);
         }
         return null;
+    }
+
+    @Override
+    public void factoryAdded(String scriptType) {
+        try {
+            compileScript();
+        } catch (ScriptException e) {
+            logger.error("Script compilation of rule with UID '{}' failed: {}", ruleUID, e.getMessage());
+        }
+    }
+
+    @Override
+    public void factoryRemoved(String scriptType) {
+        if (!type.equals(scriptType)) {
+            return;
+        }
+        resetScriptEngine();
     }
 }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -271,7 +271,13 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
 
     @Override
     public void factoryAdded(String scriptType) {
+        if (!type.equals(scriptType)) {
+            return;
+        }
         try {
+            logger.debug(
+                    "ScriptEngineFactory for script type '{}' has been added, pre-compiling script of rule with UID '{}'.",
+                    type, ruleUID);
             compileScript();
         } catch (ScriptException e) {
             logger.error("Script compilation of rule with UID '{}' failed: {}", ruleUID, e.getMessage());
@@ -283,6 +289,9 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
         if (!type.equals(scriptType)) {
             return;
         }
+        logger.debug(
+                "ScriptEngineFactory for script type '{}' has been added, resetting ScriptEngine of rule with UID '{}'.",
+                type, ruleUID);
         resetScriptEngine();
     }
 }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -271,17 +271,7 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
 
     @Override
     public void factoryAdded(String scriptType) {
-        if (!type.equals(scriptType)) {
-            return;
-        }
-        try {
-            logger.debug(
-                    "ScriptEngineFactory for script type '{}' has been added, pre-compiling script of rule with UID '{}'.",
-                    type, ruleUID);
-            compileScript();
-        } catch (ScriptException e) {
-            logger.error("Script compilation of rule with UID '{}' failed: {}", ruleUID, e.getMessage());
-        }
+        // we don't need to process this, but could attempt to compile the script here
     }
 
     @Override


### PR DESCRIPTION
Handle the ScriptEngineFactory lifecycle properly:

- ~on addition: Attempt pre-compilation. In case pre-compilation failed until now because no ScriptEngineFactory for the language was available, this ensures pre-compilation happens once a ScriptEngineFactory for its language is available.~
- on removal: If the removed ScriptEngineFactory created the ScriptEngine of this instance, reset the script engine.

This fixes an issue where a reload of the JS Scripting add-on and its org.graalvm.polyglot.Engine causes the engine to close and execution to fail.