### PR TITLE
[voice] LLMItemSerializer: Add commandOptions if defined

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.WeakHashMap;
 import java.util.stream.Stream;
@@ -376,7 +377,7 @@ public class DialogProcessor implements KSListener, STTListener {
                     List<LLMTool> tools = dialogContext.llmTools();
                     InterpreterContext interpreterContext = new InterpreterContext(conversation, tools,
                             dialogContext.locationItem(),
-                            eventListener.enrichSystemPrompt(dialogContext.systemPrompt()));
+                            eventListener.enrichSystemPrompt(dialogContext.systemPrompt(), dialogContext.locale()));
                     for (HumanLanguageInterpreter interpreter : dialogContext.hlis()) {
                         try {
                             answer = interpreter.interpret(dialogContext.locale(), interpreterContext);
@@ -536,8 +537,9 @@ public class DialogProcessor implements KSListener, STTListener {
          * Enriches the system prompt with additional context, e.g., available items.
          *
          * @param baseSystemPrompt the base system prompt
+         * @param locale the locale to use for command options localization
          * @return the system prompt with the additional context
          */
-        String enrichSystemPrompt(@Nullable String baseSystemPrompt);
+        String enrichSystemPrompt(@Nullable String baseSystemPrompt, @Nullable Locale locale);
     }
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -412,7 +412,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
                 locationItem = null;
             }
             InterpreterContext context = new InterpreterContext(conversation, tools, locationItem,
-                    enrichSystemPrompt(configuration.getSystemPrompt()));
+                    enrichSystemPrompt(configuration.getSystemPrompt(), locale));
             InterpretationException exception = null;
             for (var interpreter : interpreters) {
                 try {
@@ -1142,11 +1142,11 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
     }
 
     @Override
-    public String enrichSystemPrompt(@Nullable String baseSystemPrompt) {
+    public String enrichSystemPrompt(@Nullable String baseSystemPrompt, @Nullable Locale locale) {
         String base = baseSystemPrompt != null ? baseSystemPrompt : "";
         List<Item> accessibleItems = itemRegistry.getItems().stream().filter(itemPermissionResolver::isAccessible)
                 .toList();
-        String serializedItems = LLMItemSerializer.serialize(accessibleItems);
+        String serializedItems = LLMItemSerializer.serialize(accessibleItems, locale);
         if (serializedItems.isEmpty()) {
             return base;
         }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
@@ -19,6 +19,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -31,6 +32,8 @@ import org.openhab.core.semantics.Point;
 import org.openhab.core.semantics.Property;
 import org.openhab.core.semantics.SemanticTags;
 import org.openhab.core.semantics.Tag;
+import org.openhab.core.types.CommandDescription;
+import org.openhab.core.types.CommandOption;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -65,17 +68,22 @@ public class LLMItemSerializer {
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private record CommandOptionNode(String command, @Nullable String label) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record EquipmentNode(String name, @Nullable String label, String type, @Nullable String semanticType,
-            List<EquipmentNode> equipmentItems, List<PointNode> pointItems) {
+            List<CommandOptionNode> commandOptions, List<EquipmentNode> equipmentItems, List<PointNode> pointItems) {
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record PointNode(String name, @Nullable String label, String type, @Nullable String semanticType,
-            List<String> properties) {
+            List<String> properties, List<CommandOptionNode> commandOptions) {
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private record NonSemanticItemNode(String name, @Nullable String label, String type) {
+    private record NonSemanticItemNode(String name, @Nullable String label, String type,
+            List<CommandOptionNode> commandOptions) {
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -84,12 +92,13 @@ public class LLMItemSerializer {
     }
 
     /**
-     * Serializes a collection of items.
+     * Serializes a collection of items, localizing command options with the given locale if available.
      *
      * @param items the items to serialize
+     * @param locale the locale to use for command options localization
      * @return the serialized representation (YAML) of the items
      */
-    public static String serialize(Collection<Item> items) {
+    public static String serialize(Collection<Item> items, @Nullable Locale locale) {
         if (items.isEmpty()) {
             return "";
         }
@@ -179,16 +188,17 @@ public class LLMItemSerializer {
         List<NonSemanticItemNode> nonSemanticNodes = new ArrayList<>();
 
         for (Item loc : rootLocations) {
-            rootLocNodes.add(buildLocationNode(loc, parentToChildren));
+            rootLocNodes.add(buildLocationNode(loc, parentToChildren, locale));
         }
         for (Item eq : rootEquipments) {
-            rootEqNodes.add(buildEquipmentNode(eq, parentToChildren));
+            rootEqNodes.add(buildEquipmentNode(eq, parentToChildren, locale));
         }
         for (Item pt : rootPoints) {
-            rootPtNodes.add(buildPointNode(pt));
+            rootPtNodes.add(buildPointNode(pt, locale));
         }
         for (Item item : nonSemanticItems) {
-            nonSemanticNodes.add(new NonSemanticItemNode(item.getName(), getOrNullLabel(item), item.getType()));
+            nonSemanticNodes.add(new NonSemanticItemNode(item.getName(), getOrNullLabel(item), item.getType(),
+                    getCommandOptions(item, locale)));
         }
 
         RootNode root = new RootNode(rootLocNodes, rootEqNodes, rootPtNodes, nonSemanticNodes);
@@ -200,7 +210,8 @@ public class LLMItemSerializer {
         }
     }
 
-    private static LocationNode buildLocationNode(Item loc, Map<String, List<Item>> parentToChildren) {
+    private static LocationNode buildLocationNode(Item loc, Map<String, List<Item>> parentToChildren,
+            @Nullable Locale locale) {
         List<Item> children = parentToChildren.getOrDefault(loc.getName(), List.of());
         List<LocationNode> subLocations = new ArrayList<>();
         List<EquipmentNode> equipments = new ArrayList<>();
@@ -208,11 +219,11 @@ public class LLMItemSerializer {
 
         for (Item child : children) {
             if (SemanticTags.getLocation(child) != null) {
-                subLocations.add(buildLocationNode(child, parentToChildren));
+                subLocations.add(buildLocationNode(child, parentToChildren, locale));
             } else if (SemanticTags.getEquipment(child) != null) {
-                equipments.add(buildEquipmentNode(child, parentToChildren));
+                equipments.add(buildEquipmentNode(child, parentToChildren, locale));
             } else if (SemanticTags.getPoint(child) != null || SemanticTags.getProperty(child) != null) {
-                points.add(buildPointNode(child));
+                points.add(buildPointNode(child, locale));
             }
         }
 
@@ -227,16 +238,17 @@ public class LLMItemSerializer {
                 points);
     }
 
-    private static EquipmentNode buildEquipmentNode(Item eq, Map<String, List<Item>> parentToChildren) {
+    private static EquipmentNode buildEquipmentNode(Item eq, Map<String, List<Item>> parentToChildren,
+            @Nullable Locale locale) {
         List<Item> children = parentToChildren.getOrDefault(eq.getName(), List.of());
         List<EquipmentNode> subEquipments = new ArrayList<>();
         List<PointNode> points = new ArrayList<>();
 
         for (Item child : children) {
             if (SemanticTags.getEquipment(child) != null) {
-                subEquipments.add(buildEquipmentNode(child, parentToChildren));
+                subEquipments.add(buildEquipmentNode(child, parentToChildren, locale));
             } else if (SemanticTags.getPoint(child) != null || SemanticTags.getProperty(child) != null) {
-                points.add(buildPointNode(child));
+                points.add(buildPointNode(child, locale));
             }
         }
 
@@ -246,10 +258,11 @@ public class LLMItemSerializer {
         Class<? extends Equipment> eqType = SemanticTags.getEquipment(eq);
         String semType = eqType != null ? eqType.getSimpleName() : null;
 
-        return new EquipmentNode(eq.getName(), getOrNullLabel(eq), eq.getType(), semType, subEquipments, points);
+        return new EquipmentNode(eq.getName(), getOrNullLabel(eq), eq.getType(), semType, getCommandOptions(eq, locale),
+                subEquipments, points);
     }
 
-    private static PointNode buildPointNode(Item pt) {
+    private static PointNode buildPointNode(Item pt, @Nullable Locale locale) {
         Class<? extends Point> ptType = SemanticTags.getPoint(pt);
         String semType = ptType != null ? ptType.getSimpleName() : null;
 
@@ -264,7 +277,28 @@ public class LLMItemSerializer {
             Collections.sort(properties);
         }
 
-        return new PointNode(pt.getName(), getOrNullLabel(pt), pt.getType(), semType, properties);
+        return new PointNode(pt.getName(), getOrNullLabel(pt), pt.getType(), semType, properties,
+                getCommandOptions(pt, locale));
+    }
+
+    private static List<CommandOptionNode> getCommandOptions(Item item, @Nullable Locale locale) {
+        CommandDescription commandDesc = item.getCommandDescription(locale);
+        if (commandDesc == null) {
+            return List.of();
+        }
+        List<CommandOption> options = commandDesc.getCommandOptions();
+        if (options.isEmpty()) {
+            return List.of();
+        }
+        List<CommandOptionNode> commandOptions = new ArrayList<>();
+        for (CommandOption option : options) {
+            String label = option.getLabel();
+            if (label != null && label.isBlank()) {
+                label = null;
+            }
+            commandOptions.add(new CommandOptionNode(option.getCommand(), label));
+        }
+        return commandOptions;
     }
 
     private static @Nullable String getOrNullLabel(Item item) {

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
@@ -282,6 +282,7 @@ public class LLMItemSerializer {
     }
 
     private static List<CommandOptionNode> getCommandOptions(Item item, @Nullable Locale locale) {
+        @Nullable
         CommandDescription commandDesc = item.getCommandDescription(locale);
         if (commandDesc == null) {
             return List.of();

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
@@ -275,6 +275,7 @@ public class LLMItemSerializerTest {
                   - command: "OFF"
                 """;
 
-        assertEquals(expected, LLMItemSerializer.serialize(List.of(item1, item2, item3, locationItem, eqItem, ptItem), null));
+        assertEquals(expected,
+                LLMItemSerializer.serialize(List.of(item1, item2, item3, locationItem, eqItem, ptItem), null));
     }
 }

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
@@ -13,6 +13,7 @@
 package org.openhab.core.voice.text.interpreter.llm;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -31,6 +32,8 @@ import org.openhab.core.semantics.Location;
 import org.openhab.core.semantics.Point;
 import org.openhab.core.semantics.Property;
 import org.openhab.core.semantics.SemanticTags;
+import org.openhab.core.types.CommandDescription;
+import org.openhab.core.types.CommandOption;
 
 /**
  * Test class for {@link LLMItemSerializer}.
@@ -79,18 +82,29 @@ public class LLMItemSerializerTest {
     }
 
     private Item mockItem(String name, @Nullable String label, String type, Set<String> tags, List<String> groupNames) {
+        return mockItem(name, label, type, tags, groupNames, null);
+    }
+
+    private Item mockItem(String name, @Nullable String label, String type, Set<String> tags, List<String> groupNames,
+            @Nullable List<CommandOption> commandOptions) {
         Item item = mock(Item.class);
         when(item.getName()).thenReturn(name);
         when(item.getLabel()).thenReturn(label);
         when(item.getType()).thenReturn(type);
         when(item.getTags()).thenReturn(tags);
         when(item.getGroupNames()).thenReturn(groupNames);
+        if (commandOptions != null) {
+            CommandDescription desc = mock(CommandDescription.class);
+            when(desc.getCommandOptions()).thenReturn(commandOptions);
+            when(item.getCommandDescription()).thenReturn(desc);
+            when(item.getCommandDescription(any())).thenReturn(desc);
+        }
         return item;
     }
 
     @Test
     public void testSerializeNullOrEmpty() {
-        assertEquals("", LLMItemSerializer.serialize(Collections.emptyList()));
+        assertEquals("", LLMItemSerializer.serialize(Collections.emptyList(), null));
     }
 
     @Test
@@ -107,7 +121,7 @@ public class LLMItemSerializerTest {
                   type: Switch
                 """;
 
-        assertEquals(expected, LLMItemSerializer.serialize(List.of(item1, item2)));
+        assertEquals(expected, LLMItemSerializer.serialize(List.of(item1, item2), null));
     }
 
     @Test
@@ -171,7 +185,7 @@ public class LLMItemSerializerTest {
                   type: String
                 """;
 
-        assertEquals(expected, LLMItemSerializer.serialize(items));
+        assertEquals(expected, LLMItemSerializer.serialize(items, null));
     }
 
     @Test
@@ -189,6 +203,78 @@ public class LLMItemSerializerTest {
                   type: String
                 """;
 
-        assertEquals(expected, LLMItemSerializer.serialize(List.of(item1, item2)));
+        assertEquals(expected, LLMItemSerializer.serialize(List.of(item1, item2), null));
+    }
+
+    @Test
+    public void testSerializeWithCommandOptions() {
+        Item item1 = mockItem("ItemB", "Label B", "Switch", Set.of(), List.of(),
+                List.of(new CommandOption("ON", "On"), new CommandOption("OFF", "")));
+        Item item2 = mockItem("ItemA", null, "Dimmer", Set.of(), List.of(), null);
+        Item item3 = mockItem("Audio_Source", "Audio Source", "String", Set.of(), List.of(),
+                List.of(new CommandOption("TUNER", "Tuner"), new CommandOption("DAB", "DAB"),
+                        new CommandOption("AIRPLAY", "AirPlay")));
+
+        // Location Node should NOT have command options
+        Item locationItem = mockItem("LocationA", "Room", "Group", Set.of("Mock_Location_Room_LivingRoom"), List.of(),
+                List.of(new CommandOption("ON", "On"), new CommandOption("OFF", "Off")));
+
+        // Equipment Node should have command options
+        Item eqItem = mockItem("TV", "Living Room TV", "Group", Set.of("Mock_Equipment_Entertainment_TV"),
+                List.of("LocationA"), List.of(new CommandOption("ON", "On"), new CommandOption("OFF", "Off")));
+
+        // Point Node should have command options
+        Item ptItem = mockItem("Light", "Living Room Light", "Dimmer", Set.of("Mock_Point_Control_Light"),
+                List.of("TV"), List.of(new CommandOption("ON", "On"), new CommandOption("OFF", "Off")));
+
+        String expected = """
+                locationItems:
+                - name: LocationA
+                  label: Room
+                  type: Group
+                  semanticType: MockLivingRoom
+                  equipmentItems:
+                  - name: TV
+                    label: Living Room TV
+                    type: Group
+                    semanticType: MockTV
+                    commandOptions:
+                    - command: "ON"
+                      label: "On"
+                    - command: "OFF"
+                      label: "Off"
+                    pointItems:
+                    - name: Light
+                      label: Living Room Light
+                      type: Dimmer
+                      semanticType: MockLight
+                      commandOptions:
+                      - command: "ON"
+                        label: "On"
+                      - command: "OFF"
+                        label: "Off"
+                items:
+                - name: Audio_Source
+                  label: Audio Source
+                  type: String
+                  commandOptions:
+                  - command: TUNER
+                    label: Tuner
+                  - command: DAB
+                    label: DAB
+                  - command: AIRPLAY
+                    label: AirPlay
+                - name: ItemA
+                  type: Dimmer
+                - name: ItemB
+                  label: Label B
+                  type: Switch
+                  commandOptions:
+                  - command: "ON"
+                    label: "On"
+                  - command: "OFF"
+                """;
+
+        assertEquals(expected, LLMItemSerializer.serialize(List.of(item1, item2, item3, locationItem, eqItem, ptItem), null));
     }
 }

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
@@ -219,9 +219,9 @@ public class LLMItemSerializerTest {
         Item locationItem = mockItem("LocationA", "Room", "Group", Set.of("Mock_Location_Room_LivingRoom"), List.of(),
                 List.of(new CommandOption("ON", "On"), new CommandOption("OFF", "Off")));
 
-        // Equipment Node should have command options
+        // Equipment Node should NOT have command options
         Item eqItem = mockItem("TV", "Living Room TV", "Group", Set.of("Mock_Equipment_Entertainment_TV"),
-                List.of("LocationA"), List.of(new CommandOption("ON", "On"), new CommandOption("OFF", "Off")));
+                List.of("LocationA"), List.of());
 
         // Point Node should have command options
         Item ptItem = mockItem("Light", "Living Room Light", "Dimmer", Set.of("Mock_Point_Control_Light"),
@@ -238,11 +238,6 @@ public class LLMItemSerializerTest {
                     label: Living Room TV
                     type: Group
                     semanticType: MockTV
-                    commandOptions:
-                    - command: "ON"
-                      label: "On"
-                    - command: "OFF"
-                      label: "Off"
                     pointItems:
                     - name: Light
                       label: Living Room Light


### PR DESCRIPTION
This modifies the LLMItemSerializer to list command options (if defined).
Command options are derived from `stateDescription`/`commandDescription` metadata or channel types.