### PR TITLE
[voice] LLMItemSerializer: Serialize to a token-optimized format instead of YAML

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemCommandLLMTool.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemCommandLLMTool.java
@@ -73,7 +73,7 @@ public class ItemCommandLLMTool implements LLMTool {
 
     @Override
     public String getShortDescription(@Nullable Locale locale) {
-        return "Sends a command to an Item.";
+        return "Sends a command to an item.";
     }
 
     @Override

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemCommandLLMTool.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemCommandLLMTool.java
@@ -113,6 +113,11 @@ public class ItemCommandLLMTool implements LLMTool {
             throw new LLMToolException("Missing or invalid required parameters 'itemName' and 'command'");
         }
 
+        int lastDot = itemName.lastIndexOf('.');
+        if (lastDot != -1) {
+            itemName = itemName.substring(lastDot + 1);
+        }
+
         Item item;
         try {
             item = itemRegistry.getItem(itemName);

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMTool.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMTool.java
@@ -73,7 +73,7 @@ public class ItemStateLLMTool implements LLMTool {
 
     @Override
     public String getDescription(@Nullable Locale locale) {
-        return "This tool allows to retrieve the current state of an item. It returns the display state and the raw state if a display state is available, otherwise only the raw state.";
+        return "Get the current state of an item. Returns display and raw state if display state is available, otherwise only raw state.";
     }
 
     @Override

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMTool.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMTool.java
@@ -90,6 +90,11 @@ public class ItemStateLLMTool implements LLMTool {
             throw new LLMToolException("Missing or invalid required parameter 'itemName'");
         }
 
+        int lastDot = itemName.lastIndexOf('.');
+        if (lastDot != -1) {
+            itemName = itemName.substring(lastDot + 1);
+        }
+
         Item item;
         try {
             item = itemRegistry.getItem(itemName);

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
@@ -288,20 +288,32 @@ public class LLMItemSerializer {
             return "";
         }
         StringBuilder sb = new StringBuilder();
-        for (LocationNode loc : root.locationItems()) {
-            formatLocationNode(loc, 0, sb);
+        sb.append(
+                "# Format: [..]name [type] [\"label\"] [:semanticClass] [[properties]] [(commandOptions: COMMAND=Label)]\n\n");
+
+        boolean hasSemanticItems = !root.locationItems().isEmpty() || !root.equipmentItems().isEmpty()
+                || !root.pointItems().isEmpty();
+
+        if (hasSemanticItems) {
+            sb.append("# Semantic Items\n");
+            for (LocationNode loc : root.locationItems()) {
+                formatLocationNode(loc, 0, sb);
+            }
+            for (EquipmentNode eq : root.equipmentItems()) {
+                formatEquipmentNode(eq, 0, sb);
+            }
+            for (PointNode pt : root.pointItems()) {
+                formatPointNode(pt, 0, sb);
+            }
         }
-        for (EquipmentNode eq : root.equipmentItems()) {
-            formatEquipmentNode(eq, 0, sb);
-        }
-        for (PointNode pt : root.pointItems()) {
-            formatPointNode(pt, 0, sb);
-        }
-        if (!sb.isEmpty() && !root.items().isEmpty()) {
-            sb.append("\n");
-        }
-        for (NonSemanticItemNode item : root.items()) {
-            formatNonSemanticItemNode(item, sb);
+        if (!root.items().isEmpty()) {
+            if (hasSemanticItems) {
+                sb.append("\n");
+            }
+            sb.append("# Non-semantic Items\n");
+            for (NonSemanticItemNode item : root.items()) {
+                formatNonSemanticItemNode(item, sb);
+            }
         }
         return sb.toString();
     }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
@@ -35,18 +35,12 @@ import org.openhab.core.semantics.Tag;
 import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.CommandOption;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
-
 /**
  * {@link LLMItemSerializer} is a utility class to serialize a collection of items (both semantic and non-semantic) into
  * a structured,
  * hierarchical string representation for passing into the context of a Large Language Model (LLM) based
  * {@link org.openhab.core.voice.text.HumanLanguageInterpreter}.
- * The output format is YAML, as this is hierarchical and token-efficient, as well as easy to generate using Jackson.
+ * The output format is a custom format designed to be highly token-efficient.
  *
  * @author Florian Hotze - Initial contribution
  */
@@ -54,39 +48,26 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 public class LLMItemSerializer {
 
     private static final Comparator<Item> ITEM_COMPARATOR = Comparator.comparing(Item::getName);
-    private static final ObjectMapper mapper;
 
-    static {
-        YAMLFactory yamlFactory = new YAMLFactory().disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
-                .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES);
-        mapper = new ObjectMapper(yamlFactory);
-    }
-
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record LocationNode(String name, @Nullable String label, String type, @Nullable String semanticType,
             List<LocationNode> locationItems, List<EquipmentNode> equipmentItems, List<PointNode> pointItems) {
     }
 
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record CommandOptionNode(String command, @Nullable String label) {
     }
 
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record EquipmentNode(String name, @Nullable String label, String type, @Nullable String semanticType,
             List<CommandOptionNode> commandOptions, List<EquipmentNode> equipmentItems, List<PointNode> pointItems) {
     }
 
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record PointNode(String name, @Nullable String label, String type, @Nullable String semanticType,
             List<String> properties, List<CommandOptionNode> commandOptions) {
     }
 
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record NonSemanticItemNode(String name, @Nullable String label, String type,
             List<CommandOptionNode> commandOptions) {
     }
 
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record RootNode(List<LocationNode> locationItems, List<EquipmentNode> equipmentItems,
             List<PointNode> pointItems, List<NonSemanticItemNode> items) {
     }
@@ -200,14 +181,8 @@ public class LLMItemSerializer {
             nonSemanticNodes.add(new NonSemanticItemNode(item.getName(), getOrNullLabel(item), item.getType(),
                     getCommandOptions(item, locale)));
         }
-
         RootNode root = new RootNode(rootLocNodes, rootEqNodes, rootPtNodes, nonSemanticNodes);
-
-        try {
-            return mapper.writeValueAsString(root);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("Failed to serialize items to YAML", e);
-        }
+        return formatRoot(root);
     }
 
     private static LocationNode buildLocationNode(Item loc, Map<String, List<Item>> parentToChildren,
@@ -305,5 +280,142 @@ public class LLMItemSerializer {
     private static @Nullable String getOrNullLabel(Item item) {
         String label = item.getLabel();
         return (label == null || label.isBlank()) ? null : label;
+    }
+
+    private static String formatRoot(RootNode root) {
+        if (root.locationItems().isEmpty() && root.equipmentItems().isEmpty() && root.pointItems().isEmpty()
+                && root.items().isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (LocationNode loc : root.locationItems()) {
+            formatLocationNode(loc, 0, sb);
+        }
+        for (EquipmentNode eq : root.equipmentItems()) {
+            formatEquipmentNode(eq, 0, sb);
+        }
+        for (PointNode pt : root.pointItems()) {
+            formatPointNode(pt, 0, sb);
+        }
+        if (!sb.isEmpty() && !root.items().isEmpty()) {
+            sb.append("\n");
+        }
+        for (NonSemanticItemNode item : root.items()) {
+            formatNonSemanticItemNode(item, sb);
+        }
+        return sb.toString();
+    }
+
+    private static void formatLocationNode(LocationNode loc, int depth, StringBuilder sb) {
+        sb.append(getIndent(depth)).append(loc.name());
+
+        if (!"Group".equals(loc.type())) {
+            sb.append(" ").append(loc.type());
+        }
+        if (shouldPrintLabel(loc.name(), loc.label())) {
+            sb.append(" \"").append(loc.label().replace("\"", "\\\"")).append("\"");
+        }
+        if (loc.semanticType() != null) {
+            sb.append(" :").append(loc.semanticType());
+        }
+        sb.append("\n");
+
+        for (LocationNode subLoc : loc.locationItems()) {
+            formatLocationNode(subLoc, depth + 1, sb);
+        }
+        for (EquipmentNode eq : loc.equipmentItems()) {
+            formatEquipmentNode(eq, depth + 1, sb);
+        }
+        for (PointNode pt : loc.pointItems()) {
+            formatPointNode(pt, depth + 1, sb);
+        }
+    }
+
+    private static void formatEquipmentNode(EquipmentNode eq, int depth, StringBuilder sb) {
+        sb.append(getIndent(depth)).append(eq.name());
+
+        if (!"Group".equals(eq.type())) {
+            sb.append(" ").append(eq.type());
+        }
+        if (shouldPrintLabel(eq.name(), eq.label())) {
+            sb.append(" \"").append(eq.label().replace("\"", "\\\"")).append("\"");
+        }
+        if (eq.semanticType() != null) {
+            sb.append(" :").append(eq.semanticType());
+        }
+        if (!eq.commandOptions().isEmpty()) {
+            sb.append(" (").append(formatCommandOptions(eq.commandOptions())).append(")");
+        }
+        sb.append("\n");
+
+        for (EquipmentNode subEq : eq.equipmentItems()) {
+            formatEquipmentNode(subEq, depth + 1, sb);
+        }
+        for (PointNode pt : eq.pointItems()) {
+            formatPointNode(pt, depth + 1, sb);
+        }
+    }
+
+    private static void formatPointNode(PointNode pt, int depth, StringBuilder sb) {
+        sb.append(getIndent(depth)).append(pt.name());
+
+        if (!"Group".equals(pt.type())) {
+            sb.append(" ").append(pt.type());
+        }
+        if (shouldPrintLabel(pt.name(), pt.label())) {
+            sb.append(" \"").append(pt.label().replace("\"", "\\\"")).append("\"");
+        }
+        if (pt.semanticType() != null) {
+            sb.append(" :").append(pt.semanticType());
+        }
+        if (!pt.properties().isEmpty()) {
+            sb.append(" [").append(String.join(",", pt.properties())).append("]");
+        }
+        if (!pt.commandOptions().isEmpty()) {
+            sb.append(" (").append(formatCommandOptions(pt.commandOptions())).append(")");
+        }
+        sb.append("\n");
+    }
+
+    private static void formatNonSemanticItemNode(NonSemanticItemNode item, StringBuilder sb) {
+        sb.append(item.name());
+
+        if (!"Group".equals(item.type())) {
+            sb.append(" ").append(item.type());
+        }
+        if (shouldPrintLabel(item.name(), item.label())) {
+            sb.append(" \"").append(item.label().replace("\"", "\\\"")).append("\"");
+        }
+        if (!item.commandOptions().isEmpty()) {
+            sb.append(" (").append(formatCommandOptions(item.commandOptions())).append(")");
+        }
+        sb.append("\n");
+    }
+
+    private static boolean shouldPrintLabel(String name, @Nullable String label) {
+        if (label == null || label.isBlank()) {
+            return false;
+        }
+        String cleanLabel = label.replace(" ", "").replace("_", "");
+        String cleanName = name.replace("_", "");
+        return !cleanLabel.equalsIgnoreCase(cleanName);
+    }
+
+    private static String getIndent(int depth) {
+        StringBuilder sb = new StringBuilder();
+        sb.repeat("..", Math.max(0, depth));
+        return sb.toString();
+    }
+
+    private static String formatCommandOptions(List<CommandOptionNode> commandOptions) {
+        List<String> formatted = new ArrayList<>();
+        for (CommandOptionNode option : commandOptions) {
+            if (option.label() != null && !option.label().isBlank()) {
+                formatted.add(option.command() + "=" + option.label());
+            } else {
+                formatted.add(option.command());
+            }
+        }
+        return String.join(",", formatted);
     }
 }

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemCommandLLMToolTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemCommandLLMToolTest.java
@@ -117,4 +117,11 @@ public class ItemCommandLLMToolTest {
     public void callThrowsLTEOnMissingParams() {
         assertThrows(LLMToolException.class, () -> tool.call(Map.of(), Locale.ENGLISH));
     }
+
+    @Test
+    public void callSendsCommandWithDotPrefixedItem() throws LLMToolException {
+        String result = tool.call(Map.of("itemName", "......" + ITEM_NAME, "command", "ON"), Locale.ENGLISH);
+        assertTrue(result.contains("Successfully sent command 'ON' to item 'TestItem'"));
+        verify(eventPublisher).post(any());
+    }
 }

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMToolTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/llm/ItemStateLLMToolTest.java
@@ -118,4 +118,11 @@ public class ItemStateLLMToolTest {
     public void callThrowsLTEOnMissingParams() {
         assertThrows(LLMToolException.class, () -> tool.call(Map.of(), Locale.ENGLISH));
     }
+
+    @Test
+    public void callReturnsStateWithDotPrefixedItem() throws LLMToolException {
+        when(item.getStateDescription(Locale.ENGLISH)).thenReturn(null);
+        String result = tool.call(Map.of("itemName", "......" + ITEM_NAME), Locale.ENGLISH);
+        assertEquals("ON", result);
+    }
 }

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
@@ -58,6 +58,9 @@ public class LLMItemSerializerTest {
     private interface MockPower extends Point {
     }
 
+    private interface MockSource extends Point {
+    }
+
     private interface MockPowerProperty extends Property {
     }
 
@@ -65,9 +68,10 @@ public class LLMItemSerializerTest {
     public static void setUpTags() {
         SemanticTags.addTagSet("Mock_Location_Floor", MockFloor.class);
         SemanticTags.addTagSet("Mock_Location_Room_LivingRoom", MockLivingRoom.class);
-        SemanticTags.addTagSet("Mock_Equipment_Entertainment_TV", MockTV.class);
+        SemanticTags.addTagSet("Mock_Equipment_Television", MockTV.class);
         SemanticTags.addTagSet("Mock_Point_Control_Light", MockLight.class);
         SemanticTags.addTagSet("Mock_Point_Control_Power", MockPower.class);
+        SemanticTags.addTagSet("Mock_Point_Control_Source", MockSource.class);
         SemanticTags.addTagSet("Mock_Property_Power", MockPowerProperty.class);
     }
 
@@ -75,9 +79,10 @@ public class LLMItemSerializerTest {
     public static void tearDownTags() {
         SemanticTags.removeTagSet("Mock_Location_Floor", MockFloor.class);
         SemanticTags.removeTagSet("Mock_Location_Room_LivingRoom", MockLivingRoom.class);
-        SemanticTags.removeTagSet("Mock_Equipment_Entertainment_TV", MockTV.class);
+        SemanticTags.removeTagSet("Mock_Equipment_Television", MockTV.class);
         SemanticTags.removeTagSet("Mock_Point_Control_Light", MockLight.class);
         SemanticTags.removeTagSet("Mock_Point_Control_Power", MockPower.class);
+        SemanticTags.removeTagSet("Mock_Point_Control_Source", MockSource.class);
         SemanticTags.removeTagSet("Mock_Property_Power", MockPowerProperty.class);
     }
 
@@ -113,12 +118,8 @@ public class LLMItemSerializerTest {
         Item item2 = mockItem("ItemA", null, "Dimmer", Set.of(), List.of());
 
         String expected = """
-                items:
-                - name: ItemA
-                  type: Dimmer
-                - name: ItemB
-                  label: Label B
-                  type: Switch
+                ItemA Dimmer
+                ItemB Switch "Label B"
                 """;
 
         assertEquals(expected, LLMItemSerializer.serialize(List.of(item1, item2), null));
@@ -134,8 +135,7 @@ public class LLMItemSerializerTest {
                 List.of("GF"));
 
         // TV Equipment inside LivingRoom
-        Item tv = mockItem("TV", "Living Room TV", "Group", Set.of("Mock_Equipment_Entertainment_TV"),
-                List.of("LivingRoom"));
+        Item tv = mockItem("TV", "Living Room TV", "Group", Set.of("Mock_Equipment_Television"), List.of("LivingRoom"));
 
         // TV Power Control inside TV
         Item tvPower = mockItem("TV_Power", "TV Power", "Switch",
@@ -152,58 +152,16 @@ public class LLMItemSerializerTest {
         List<Item> items = List.of(tvPower, livingRoom, systemMode, lrLight, tv, gf);
 
         String expected = """
-                locationItems:
-                - name: GF
-                  label: Ground Floor
-                  type: Group
-                  semanticType: MockFloor
-                  locationItems:
-                  - name: LivingRoom
-                    label: Living Room
-                    type: Group
-                    semanticType: MockLivingRoom
-                    equipmentItems:
-                    - name: TV
-                      label: Living Room TV
-                      type: Group
-                      semanticType: MockTV
-                      pointItems:
-                      - name: TV_Power
-                        label: TV Power
-                        type: Switch
-                        semanticType: MockPower
-                        properties:
-                        - MockPowerProperty
-                    pointItems:
-                    - name: LivingRoom_Light
-                      label: Living Room Light
-                      type: Dimmer
-                      semanticType: MockLight
-                items:
-                - name: System_Mode
-                  label: System Mode
-                  type: String
+                GF "Ground Floor" :MockFloor
+                ..LivingRoom :MockLivingRoom
+                ....TV "Living Room TV" :MockTV
+                ......TV_Power Switch :MockPower [MockPowerProperty]
+                ....LivingRoom_Light Dimmer :MockLight
+
+                System_Mode String
                 """;
 
         assertEquals(expected, LLMItemSerializer.serialize(items, null));
-    }
-
-    @Test
-    public void testSerializeEscapingAndReservedWords() {
-        Item item1 = mockItem("item:with:colon", "label # with hash", "Switch", Set.of(), List.of());
-        Item item2 = mockItem("yes", "true", "String", Set.of(), List.of());
-
-        String expected = """
-                items:
-                - name: item:with:colon
-                  label: "label # with hash"
-                  type: Switch
-                - name: "yes"
-                  label: "true"
-                  type: String
-                """;
-
-        assertEquals(expected, LLMItemSerializer.serialize(List.of(item1, item2), null));
     }
 
     @Test
@@ -220,54 +178,21 @@ public class LLMItemSerializerTest {
                 List.of(new CommandOption("ON", "On"), new CommandOption("OFF", "Off")));
 
         // Equipment Node should NOT have command options
-        Item eqItem = mockItem("TV", "Living Room TV", "Group", Set.of("Mock_Equipment_Entertainment_TV"),
+        Item eqItem = mockItem("TV", "Living Room TV", "Group", Set.of("Mock_Equipment_Television"),
                 List.of("LocationA"), List.of());
 
         // Point Node should have command options
-        Item ptItem = mockItem("Light", "Living Room Light", "Dimmer", Set.of("Mock_Point_Control_Light"),
-                List.of("TV"), List.of(new CommandOption("ON", "On"), new CommandOption("OFF", "Off")));
+        Item ptItem = mockItem("TV_Channel", "TV Channel", "String", Set.of("Mock_Point_Control_Source"), List.of("TV"),
+                List.of(new CommandOption("CH1", "Channel 1"), new CommandOption("CH2", "Channel 2")));
 
         String expected = """
-                locationItems:
-                - name: LocationA
-                  label: Room
-                  type: Group
-                  semanticType: MockLivingRoom
-                  equipmentItems:
-                  - name: TV
-                    label: Living Room TV
-                    type: Group
-                    semanticType: MockTV
-                    pointItems:
-                    - name: Light
-                      label: Living Room Light
-                      type: Dimmer
-                      semanticType: MockLight
-                      commandOptions:
-                      - command: "ON"
-                        label: "On"
-                      - command: "OFF"
-                        label: "Off"
-                items:
-                - name: Audio_Source
-                  label: Audio Source
-                  type: String
-                  commandOptions:
-                  - command: TUNER
-                    label: Tuner
-                  - command: DAB
-                    label: DAB
-                  - command: AIRPLAY
-                    label: AirPlay
-                - name: ItemA
-                  type: Dimmer
-                - name: ItemB
-                  label: Label B
-                  type: Switch
-                  commandOptions:
-                  - command: "ON"
-                    label: "On"
-                  - command: "OFF"
+                LocationA "Room" :MockLivingRoom
+                ..TV "Living Room TV" :MockTV
+                ....TV_Channel String :MockSource (CH1=Channel 1,CH2=Channel 2)
+
+                Audio_Source String (TUNER=Tuner,DAB=DAB,AIRPLAY=AirPlay)
+                ItemA Dimmer
+                ItemB Switch "Label B" (ON=On,OFF)
                 """;
 
         assertEquals(expected,

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
@@ -118,6 +118,9 @@ public class LLMItemSerializerTest {
         Item item2 = mockItem("ItemA", null, "Dimmer", Set.of(), List.of());
 
         String expected = """
+                # Format: [..]name [type] ["label"] [:semanticClass] [[properties]] [(commandOptions: COMMAND=Label)]
+
+                # Non-semantic Items
                 ItemA Dimmer
                 ItemB Switch "Label B"
                 """;
@@ -152,12 +155,16 @@ public class LLMItemSerializerTest {
         List<Item> items = List.of(tvPower, livingRoom, systemMode, lrLight, tv, gf);
 
         String expected = """
+                # Format: [..]name [type] ["label"] [:semanticClass] [[properties]] [(commandOptions: COMMAND=Label)]
+
+                # Semantic Items
                 GF "Ground Floor" :MockFloor
                 ..LivingRoom :MockLivingRoom
                 ....TV "Living Room TV" :MockTV
                 ......TV_Power Switch :MockPower [MockPowerProperty]
                 ....LivingRoom_Light Dimmer :MockLight
 
+                # Non-semantic Items
                 System_Mode String
                 """;
 
@@ -186,10 +193,14 @@ public class LLMItemSerializerTest {
                 List.of(new CommandOption("CH1", "Channel 1"), new CommandOption("CH2", "Channel 2")));
 
         String expected = """
+                # Format: [..]name [type] ["label"] [:semanticClass] [[properties]] [(commandOptions: COMMAND=Label)]
+
+                # Semantic Items
                 LocationA "Room" :MockLivingRoom
                 ..TV "Living Room TV" :MockTV
                 ....TV_Channel String :MockSource (CH1=Channel 1,CH2=Channel 2)
 
+                # Non-semantic Items
                 Audio_Source String (TUNER=Tuner,DAB=DAB,AIRPLAY=AirPlay)
                 ItemA Dimmer
                 ItemB Switch "Label B" (ON=On,OFF)


### PR DESCRIPTION
Modify the LLMItemSerializer to write to a custom, hierarchical and highly token-efficient format.
For the LLMItemSerializerTest cases, this reduces token usage by approximately 60%.

Modify the Item-related `LLMTool`s to strip the dots indentation from provided itemName params in case an LLM fails to remove them when calling the tool.