### PR TITLE
[automation] Fix exception swallowing during script file unload

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcher.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcher.java
@@ -271,6 +271,9 @@ public abstract class AbstractScriptFileWatcher implements WatchService.WatchEve
 
                     return null;
                 });
+            } catch (Throwable t) {
+                logger.error("Exception occurred while unloading script '{}'", scriptIdentifier, t);
+                throw t; // Re-throw to propagate it to the CompletableFuture
             } finally {
                 if (scriptMap.containsKey(scriptIdentifier)) {
                     logger.warn("Failed to unload script '{}'", scriptIdentifier);


### PR DESCRIPTION
During script file unload, exceptions are silently swallowed as the result of the asynchronous file removal isn't processed anywhere. This adds logging to the async file removal to log any throwable that occurs during engine removal and then rethrows it.