### PR TITLE
ScriptTransformationService: Fix exception during script disposal aborts disposal

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -305,7 +305,12 @@ public class ScriptTransformationService
         try {
             ScriptEngineContainer scriptEngineContainer = scriptRecord.scriptEngineContainer;
             if (scriptEngineContainer != null) {
-                scriptEngineManager.removeEngine(scriptEngineContainer.getIdentifier());
+                try {
+                    scriptEngineManager.removeEngine(scriptEngineContainer.getIdentifier());
+                } catch (Exception e) {
+                    logger.error("Exception occurred while disposing script {}", scriptEngineContainer.getIdentifier(),
+                            e);
+                }
                 scriptRecord.scriptEngineContainer = null;
             }
             scriptRecord.compiledScript = null;


### PR DESCRIPTION
At the moment, any exception thrown during script engine removal is able to abort disposal of the related script record. This even propagates up so a single exception in any engine removal can make disposal of the script transformation service abort.