### PR TITLE
[automation] ScriptEngineManagerImpl: Fix exception in scriptUnloaded fails engine removal

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -247,12 +247,13 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
                     while (cause.getCause() != null) {
                         cause = cause.getCause();
                     }
-                    // Ignore ISE thrown by Graal languages if underlying org.graalvm.polyglot.Engine is closed
                     if (cause instanceof IllegalStateException
                             && "The Context is already closed.".equals(cause.getMessage())) {
+                        // Ignore ISE thrown by Graal languages if underlying org.graalvm.polyglot.Engine is closed
                         logger.debug("ScriptEngine '{}' already closed when attempting to execute scriptUnloaded()",
                                 engineIdentifier);
                     } else {
+                        // Do NOT rethrow, we always want to close the engine and remove script extensions.
                         logger.warn("Error attempting to execute scriptUnloaded() of ScriptEngine '{}', ScriptEngine",
                                 engineIdentifier, e);
                     }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -240,10 +240,10 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
                     inv.invokeFunction("scriptUnloaded");
                 } catch (NoSuchMethodException e) {
                     logger.trace("scriptUnloaded() is not defined in ScriptEngine '{}'", engineIdentifier);
-                }
+                } catch (ScriptException ex) {
                     logger.error("Error executing scriptUnloaded() of ScriptEngine '{}'", engineIdentifier, ex);
                 } catch (RuntimeException e) {
-                    Throwable cause = e.getCause();
+                    Throwable cause = e;
                     while (cause != null && cause.getCause() != null) {
                         cause = cause.getCause();
                     }
@@ -254,7 +254,9 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
                                 engineIdentifier);
                     } else {
                         // Do NOT rethrow, we always want to close the engine and remove script extensions.
-                        logger.warn("Error attempting to execute scriptUnloaded() of ScriptEngine '{}' (continuing cleanup)", engineIdentifier, e);
+                        logger.warn(
+                                "Error attempting to execute scriptUnloaded() of ScriptEngine '{}' (continuing cleanup)",
+                                engineIdentifier, e);
                     }
                 }
             } else {

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -239,8 +239,8 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
                 try {
                     inv.invokeFunction("scriptUnloaded");
                 } catch (NoSuchMethodException e) {
-                    logger.trace("scriptUnloaded() is not defined in the script");
-                } catch (ScriptException ex) {
+                    logger.trace("scriptUnloaded() is not defined in ScriptEngine '{}'", engineIdentifier);
+                }
                     logger.error("Error executing scriptUnloaded() of ScriptEngine '{}'", engineIdentifier, ex);
                 } catch (RuntimeException e) {
                     Throwable cause = e.getCause();
@@ -254,8 +254,7 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
                                 engineIdentifier);
                     } else {
                         // Do NOT rethrow, we always want to close the engine and remove script extensions.
-                        logger.warn("Error attempting to execute scriptUnloaded() of ScriptEngine '{}', ScriptEngine",
-                                engineIdentifier, e);
+                        logger.warn("Error attempting to execute scriptUnloaded() of ScriptEngine '{}' (continuing cleanup)", engineIdentifier, e);
                     }
                 }
             } else {

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -242,9 +242,9 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
                     logger.trace("scriptUnloaded() is not defined in the script");
                 } catch (ScriptException ex) {
                     logger.error("Error executing scriptUnloaded() of ScriptEngine '{}'", engineIdentifier, ex);
-                } catch (Exception e) {
+                } catch (RuntimeException e) {
                     Throwable cause = e.getCause();
-                    while (cause.getCause() != null) {
+                    while (cause != null && cause.getCause() != null) {
                         cause = cause.getCause();
                     }
                     if (cause instanceof IllegalStateException

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -241,12 +241,25 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
                 } catch (NoSuchMethodException e) {
                     logger.trace("scriptUnloaded() is not defined in the script");
                 } catch (ScriptException ex) {
-                    logger.error("Error while executing script", ex);
+                    logger.error("Error executing scriptUnloaded() of ScriptEngine '{}'", engineIdentifier, ex);
+                } catch (Exception e) {
+                    Throwable cause = e.getCause();
+                    while (cause.getCause() != null) {
+                        cause = cause.getCause();
+                    }
+                    // Ignore ISE thrown by Graal languages if underlying org.graalvm.polyglot.Engine is closed
+                    if (cause instanceof IllegalStateException
+                            && "The Context is already closed.".equals(cause.getMessage())) {
+                        logger.debug("ScriptEngine '{}' already closed when attempting to execute scriptUnloaded()",
+                                engineIdentifier);
+                    } else {
+                        logger.warn("Error attempting to execute scriptUnloaded() of ScriptEngine '{}', ScriptEngine",
+                                engineIdentifier, e);
+                    }
                 }
             } else {
-                logger.trace("ScriptEngine does not support Invocable interface");
+                logger.trace("ScriptEngine '{}' does not support Invocable interface", engineIdentifier);
             }
-
             if (scriptEngine instanceof AutoCloseable closeable) {
                 // we cannot not use ScheduledExecutorService.execute here as it might execute the task in the calling
                 // thread (calling ScriptEngine.close in the same thread may result in a deadlock if the ScriptEngine
@@ -255,22 +268,22 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
                     try {
                         closeable.close();
                     } catch (Exception e) {
-                        logger.error("Error while closing script engine", e);
+                        logger.error("Error closing ScriptEngine '{}'", engineIdentifier, e);
                     }
                 }, 0, TimeUnit.SECONDS);
             } else {
-                logger.trace("ScriptEngine does not support AutoCloseable interface");
+                logger.trace("ScriptEngine '{}' does not support AutoCloseable interface", engineIdentifier);
             }
 
             removeScriptExtensions(engineIdentifier);
         }
     }
 
-    private void removeScriptExtensions(String pathIdentifier) {
+    private void removeScriptExtensions(String engineIdentifier) {
         try {
-            scriptExtensionManager.dispose(pathIdentifier);
+            scriptExtensionManager.dispose(engineIdentifier);
         } catch (Exception ex) {
-            logger.error("Error removing ScriptEngine", ex);
+            logger.error("Error removing ScriptEngine '{}'", engineIdentifier, ex);
         }
     }
 

--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImplTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImplTest.java
@@ -16,8 +16,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 import static org.openhab.core.automation.module.script.ScriptEngineFactory.CONTEXT_KEY_DEPENDENCY_LISTENER;
 
 import java.io.ByteArrayInputStream;
@@ -26,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.Consumer;
 
+import javax.script.Invocable;
 import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 
@@ -102,5 +105,29 @@ public class ScriptEngineManagerImplTest {
         // verify tracking is stopped when script engine is removed
         scriptEngineManager.removeEngine(engineIdentifier);
         verify(scriptDependencyTrackerMock).removeTracking(eq(engineIdentifier));
+    }
+
+    @Test
+    public void testRemoveEngineContinuesRemovalOnRuntimeExceptionFromScriptUnloaded() throws Exception {
+        String engineIdentifier = "testIdentifier";
+
+        // Create a mock script engine that implements Invocable
+        ScriptEngine invocableEngine = mock(ScriptEngine.class, withSettings().extraInterfaces(Invocable.class));
+        when(invocableEngine.getFactory()).thenReturn(internalScriptEngineFactoryMock);
+        when(invocableEngine.getContext()).thenReturn(scriptContextMock);
+
+        // Configure the factory to return our invocableEngine
+        when(scriptEngineFactoryMock.createScriptEngine(SUPPORTED_SCRIPT_TYPE)).thenReturn(invocableEngine);
+
+        // Set up the mock to throw RuntimeException when scriptUnloaded is called
+        Invocable invocable = (Invocable) invocableEngine;
+        when(invocable.invokeFunction("scriptUnloaded")).thenThrow(new RuntimeException("Test Exception"));
+
+        scriptEngineManager.createScriptEngine(SUPPORTED_SCRIPT_TYPE, engineIdentifier);
+
+        // Remove engine and verify scriptExtensionManager.dispose is still called
+        scriptEngineManager.removeEngine(engineIdentifier);
+
+        verify(scriptExtensionManagerMock).dispose(eq(engineIdentifier));
     }
 }


### PR DESCRIPTION
When `inv.invokeFunction("scriptUnloaded")` throws an arbitrary exception that is not NSME or SE, removeEngine fails without closing the engine and removing script extensions. Due to exception swallowing in AbstractScriptFileWatcher::removeFile (see https://github.com/openhab/openhab-core/pull/5682), the engine removal fail was silent and not directly noticeable.

However did this cause a situation where rules (and other stuff) created in script files kept existing, causing failure of script file reloading in AbstractScriptFileWatcher. In JS Scripting, additionally to the reloading failure, the still existing rules may fail to execute due to closed org.graalvm.polyglot.Engine context.

This also improves logging related to script engine removal.