### PR TITLE
Fix ScriptProfile holding reference to old, disposed instance of ScriptTransformationService

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfile.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfile.java
@@ -14,6 +14,7 @@ package org.openhab.core.automation.module.script.profile;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import javax.script.ScriptException;
 
@@ -36,7 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The {@link ScriptProfile} is generic profile for managing values with scripts
+ * The {@link ScriptProfile} is generic profile for managing values with scripts.
  *
  * @author Jan N. Klug - Initial contribution
  */
@@ -51,7 +52,14 @@ public class ScriptProfile implements TimeSeriesProfile {
     private final Logger logger = LoggerFactory.getLogger(ScriptProfile.class);
 
     private final ProfileCallback callback;
-    private final TransformationService transformationService;
+    /**
+     * A supplier providing access to the current OSGi service instance of the {@link TransformationService}.
+     *
+     * <p>
+     * A normal reference to {@link TransformationService} would point to the old, disposed instance of the
+     * {@link TransformationService} after its restart.
+     */
+    private final Supplier<@Nullable TransformationService> transformationServiceSupplier;
 
     private final List<Class<? extends State>> acceptedDataTypes;
     private final List<Class<? extends Command>> acceptedCommandTypes;
@@ -65,10 +73,10 @@ public class ScriptProfile implements TimeSeriesProfile {
     private final boolean isConfigured;
 
     public ScriptProfile(ProfileTypeUID profileTypeUID, ProfileCallback callback, ProfileContext profileContext,
-            TransformationService transformationService) {
+            Supplier<@Nullable TransformationService> transformationServiceSupplier) {
         this.profileTypeUID = profileTypeUID;
         this.callback = callback;
-        this.transformationService = transformationService;
+        this.transformationServiceSupplier = transformationServiceSupplier;
 
         this.acceptedCommandTypes = profileContext.getAcceptedCommandTypes();
         this.acceptedDataTypes = profileContext.getAcceptedDataTypes();
@@ -181,6 +189,12 @@ public class ScriptProfile implements TimeSeriesProfile {
 
     private @Nullable String executeScript(String script, Type input) {
         if (!script.isBlank()) {
+            TransformationService transformationService = transformationServiceSupplier.get();
+            if (transformationService == null) {
+                logger.error("Failed to process script '{}' in link '{}': transformation service is not available.",
+                        script, callback.getItemChannelLink());
+                return null;
+            }
             try {
                 return transformationService.transform(script, input.toFullString());
             } catch (TransformationException e) {

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
@@ -36,7 +36,7 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 
 /**
- * The {@link ScriptProfileFactory} creates {@link ScriptProfile} instances
+ * The {@link ScriptProfileFactory} creates {@link ScriptProfile} instances.
  *
  * @author Jan N. Klug - Initial contribution
  */
@@ -51,8 +51,10 @@ public class ScriptProfileFactory implements ProfileFactory, ProfileTypeProvider
     public @Nullable Profile createProfile(ProfileTypeUID profileTypeUID, ProfileCallback callback,
             ProfileContext profileContext) {
         String serviceId = profileTypeUID.getId();
-        ScriptTransformationService transformationService = services.get(serviceId).service();
-        return new ScriptProfile(profileTypeUID, callback, profileContext, transformationService);
+        return new ScriptProfile(profileTypeUID, callback, profileContext, () -> {
+            ServiceRecord record = services.get(serviceId);
+            return record != null ? record.service() : null;
+        });
     }
 
     @Override

--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/profile/ScriptProfileTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/profile/ScriptProfileTest.java
@@ -73,8 +73,7 @@ public class ScriptProfileTest extends JavaTest {
 
         setupInterceptedLogger(ScriptProfile.class, LogLevel.ERROR);
 
-        ScriptProfile scriptProfile = new ScriptProfile(mock(ProfileTypeUID.class), profileCallback, profileContext,
-                transformationServiceMock);
+        ScriptProfile scriptProfile = createScriptProfile(profileContext);
 
         scriptProfile.onCommandFromHandler(OnOffType.ON);
         scriptProfile.onStateUpdateFromHandler(OnOffType.ON);
@@ -106,8 +105,7 @@ public class ScriptProfileTest extends JavaTest {
 
         setupInterceptedLogger(ScriptProfile.class, LogLevel.WARN);
 
-        ScriptProfile scriptProfile = new ScriptProfile(mock(ProfileTypeUID.class), profileCallback, profileContext,
-                transformationServiceMock);
+        ScriptProfile scriptProfile = createScriptProfile(profileContext);
 
         scriptProfile.onCommandFromHandler(DecimalType.ZERO);
         scriptProfile.onStateUpdateFromHandler(DecimalType.ZERO);
@@ -131,8 +129,7 @@ public class ScriptProfileTest extends JavaTest {
         when(transformationServiceMock.transform(any(), any()))
                 .thenThrow(new TransformationException("intentional failure"));
 
-        ScriptProfile scriptProfile = new ScriptProfile(mock(ProfileTypeUID.class), profileCallback, profileContext,
-                transformationServiceMock);
+        ScriptProfile scriptProfile = createScriptProfile(profileContext);
 
         scriptProfile.onCommandFromHandler(OnOffType.ON);
         scriptProfile.onStateUpdateFromHandler(OnOffType.ON);
@@ -154,8 +151,7 @@ public class ScriptProfileTest extends JavaTest {
 
         when(transformationServiceMock.transform(any(), any())).thenReturn(null);
 
-        ScriptProfile scriptProfile = new ScriptProfile(mock(ProfileTypeUID.class), profileCallback, profileContext,
-                transformationServiceMock);
+        ScriptProfile scriptProfile = createScriptProfile(profileContext);
 
         scriptProfile.onCommandFromHandler(OnOffType.ON);
         scriptProfile.onStateUpdateFromHandler(OnOffType.ON);
@@ -179,8 +175,7 @@ public class ScriptProfileTest extends JavaTest {
 
         when(transformationServiceMock.transform(any(), any())).thenReturn(OnOffType.OFF.toString());
 
-        ScriptProfile scriptProfile = new ScriptProfile(mock(ProfileTypeUID.class), profileCallback, profileContext,
-                transformationServiceMock);
+        ScriptProfile scriptProfile = createScriptProfile(profileContext);
 
         scriptProfile.onCommandFromHandler(DecimalType.ZERO);
         scriptProfile.onStateUpdateFromHandler(DecimalType.ZERO);
@@ -205,8 +200,7 @@ public class ScriptProfileTest extends JavaTest {
 
         when(transformationServiceMock.transform(any(), any())).thenReturn(OnOffType.OFF.toString());
 
-        ScriptProfile scriptProfile = new ScriptProfile(mock(ProfileTypeUID.class), profileCallback, profileContext,
-                transformationServiceMock);
+        ScriptProfile scriptProfile = createScriptProfile(profileContext);
 
         scriptProfile.onCommandFromHandler(DecimalType.ZERO);
         scriptProfile.onStateUpdateFromHandler(DecimalType.ZERO);
@@ -231,8 +225,7 @@ public class ScriptProfileTest extends JavaTest {
 
         when(transformationServiceMock.transform(any(), any())).thenReturn(OnOffType.OFF.toString());
 
-        ScriptProfile scriptProfile = new ScriptProfile(mock(ProfileTypeUID.class), profileCallback, profileContext,
-                transformationServiceMock);
+        ScriptProfile scriptProfile = createScriptProfile(profileContext);
 
         scriptProfile.onCommandFromHandler(DecimalType.ZERO);
         scriptProfile.onStateUpdateFromHandler(DecimalType.ZERO);
@@ -255,8 +248,7 @@ public class ScriptProfileTest extends JavaTest {
 
         when(transformationServiceMock.transform(any(), any())).thenReturn(OnOffType.OFF.toString());
 
-        ScriptProfile scriptProfile = new ScriptProfile(mock(ProfileTypeUID.class), profileCallback, profileContext,
-                transformationServiceMock);
+        ScriptProfile scriptProfile = createScriptProfile(profileContext);
 
         scriptProfile.onCommandFromHandler(DecimalType.ZERO);
         scriptProfile.onStateUpdateFromHandler(DecimalType.ZERO);
@@ -280,8 +272,7 @@ public class ScriptProfileTest extends JavaTest {
 
         when(transformationServiceMock.transform(any(), any())).thenReturn(OnOffType.OFF.toString());
 
-        ScriptProfile scriptProfile = new ScriptProfile(mock(ProfileTypeUID.class), profileCallback, profileContext,
-                transformationServiceMock);
+        ScriptProfile scriptProfile = createScriptProfile(profileContext);
 
         scriptProfile.onCommandFromHandler(DecimalType.ZERO);
         scriptProfile.onStateUpdateFromHandler(DecimalType.ZERO);
@@ -304,8 +295,7 @@ public class ScriptProfileTest extends JavaTest {
 
         when(transformationServiceMock.transform(any(), any())).thenReturn(OnOffType.OFF.toString());
 
-        ScriptProfile scriptProfile = new ScriptProfile(mock(ProfileTypeUID.class), profileCallback, profileContext,
-                transformationServiceMock);
+        ScriptProfile scriptProfile = createScriptProfile(profileContext);
 
         scriptProfile.onCommandFromHandler(DecimalType.ZERO);
         scriptProfile.onStateUpdateFromHandler(DecimalType.ZERO);
@@ -329,8 +319,7 @@ public class ScriptProfileTest extends JavaTest {
         when(transformationServiceMock.transform(any(), eq("0"))).thenReturn(OnOffType.OFF.toString());
         when(transformationServiceMock.transform(any(), eq("1"))).thenReturn(null);
 
-        ScriptProfile scriptProfile = new ScriptProfile(mock(ProfileTypeUID.class), profileCallback, profileContext,
-                transformationServiceMock);
+        ScriptProfile scriptProfile = createScriptProfile(profileContext);
 
         TimeSeries timeSeries = createTimeSeries(DecimalType.ZERO, DecimalType.valueOf("1"), DecimalType.ZERO);
         scriptProfile.onTimeSeriesFromHandler(timeSeries);
@@ -344,6 +333,11 @@ public class ScriptProfileTest extends JavaTest {
             }
         });
         verify(profileCallback).sendTimeSeries(transformedTimeSeries);
+    }
+
+    private ScriptProfile createScriptProfile(ProfileContext profileContext) {
+        return new ScriptProfile(mock(ProfileTypeUID.class), profileCallback, profileContext,
+                () -> transformationServiceMock);
     }
 
     private TimeSeries createTimeSeries(State... states) {

--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/profile/ScriptProfileTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/profile/ScriptProfileTest.java
@@ -335,6 +335,42 @@ public class ScriptProfileTest extends JavaTest {
         verify(profileCallback).sendTimeSeries(transformedTimeSeries);
     }
 
+    @Test
+    public void scriptNotExecutedIfTransformationServiceSupplierReturnsNull() throws TransformationException {
+        ProfileContext profileContext = ProfileContextBuilder.create().withToItemScript("inScript")
+                .withToHandlerScript("outScript").withCommandFromItemScript("itemCommandScript")
+                .withStateFromItemScript("itemStateScript").withAcceptedCommandTypes(List.of(OnOffType.class))
+                .withAcceptedDataTypes(List.of(OnOffType.class))
+                .withHandlerAcceptedCommandTypes(List.of(OnOffType.class)).build();
+
+        ItemChannelLink link = new ItemChannelLink("DummyItem", new ChannelUID("foo:bar:baz:qux"));
+        when(profileCallback.getItemChannelLink()).thenReturn(link);
+
+        setupInterceptedLogger(ScriptProfile.class, LogLevel.ERROR);
+
+        ScriptProfile scriptProfile = new ScriptProfile(mock(ProfileTypeUID.class), profileCallback, profileContext,
+                () -> null);
+
+        scriptProfile.onCommandFromHandler(OnOffType.ON);
+        scriptProfile.onStateUpdateFromHandler(OnOffType.ON);
+        scriptProfile.onTimeSeriesFromHandler(createTimeSeries(OnOffType.ON));
+        scriptProfile.onCommandFromItem(OnOffType.ON);
+        scriptProfile.onStateUpdateFromItem(OnOffType.ON);
+
+        verify(transformationServiceMock, never()).transform(any(), any());
+        verify(profileCallback, never()).handleCommand(any());
+        verify(profileCallback, never()).sendTimeSeries(any());
+        verify(profileCallback, never()).sendUpdate(any());
+        verify(profileCallback, never()).sendCommand(any());
+
+        assertLogMessage(ScriptProfile.class, LogLevel.ERROR,
+                "Failed to process script 'inScript' in link '" + link + "': transformation service is not available.");
+        assertLogMessage(ScriptProfile.class, LogLevel.ERROR, "Failed to process script 'itemCommandScript' in link '"
+                + link + "': transformation service is not available.");
+        assertLogMessage(ScriptProfile.class, LogLevel.ERROR, "Failed to process script 'itemStateScript' in link '"
+                + link + "': transformation service is not available.");
+    }
+
     private ScriptProfile createScriptProfile(ProfileContext profileContext) {
         return new ScriptProfile(mock(ProfileTypeUID.class), profileCallback, profileContext,
                 () -> transformationServiceMock);


### PR DESCRIPTION
Fixes #5668.

When a ScriptTransformationService OSGi service instance restarted, a ScriptProfile still hold a reference to the old and now disposed instance. When using JS Scripting, this led to the famous "The context is already closed" errors, because the ScriptEngines used by the disposed ScriptTransformationService instance were already closed.