### PR TITLE
Log WebSocket: Require ADMIN role

### DIFF
--- a/bundles/org.openhab.core.io.websocket.audio/src/main/java/org/openhab/core/io/websocket/audio/internal/PCMWebSocketAdapter.java
+++ b/bundles/org.openhab.core.io.websocket.audio/src/main/java/org/openhab/core/io/websocket/audio/internal/PCMWebSocketAdapter.java
@@ -24,6 +24,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import javax.ws.rs.core.SecurityContext;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
@@ -98,8 +100,8 @@ public class PCMWebSocketAdapter implements WebSocketAdapter {
     }
 
     @Override
-    public Object createWebSocket(ServletUpgradeRequest servletUpgradeRequest,
-            ServletUpgradeResponse servletUpgradeResponse) {
+    public @Nullable Object createWebSocket(ServletUpgradeRequest servletUpgradeRequest,
+            ServletUpgradeResponse servletUpgradeResponse, SecurityContext securityContext) {
         logger.debug("creating connection");
         return new PCMWebSocketConnection(this, executor);
     }

--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/CommonWebSocketServlet.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/CommonWebSocketServlet.java
@@ -22,6 +22,7 @@ import java.util.regex.Pattern;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
+import javax.ws.rs.core.SecurityContext;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -137,7 +138,10 @@ public class CommonWebSocketServlet extends WebSocketServlet {
                 }
             }
 
-            if (accessToken != null ? isAuthorizedRequest(accessToken) : isAuthorizedRequest(servletUpgradeRequest)) {
+            SecurityContext securityContext = accessToken != null ? getSecurityContext(accessToken)
+                    : getSecurityContext(servletUpgradeRequest);
+
+            if (isAuthorizedRequest(securityContext)) {
                 String requestPath = servletUpgradeRequest.getRequestURI().getPath();
                 String pathPrefix = SERVLET_PATH + "/";
                 boolean useDefaultAdapter = requestPath.equals(pathPrefix) || !requestPath.startsWith(pathPrefix);
@@ -157,7 +161,7 @@ public class CommonWebSocketServlet extends WebSocketServlet {
                     }
                 }
                 logger.debug("New connection handled by {}", wsAdapter.getId());
-                return wsAdapter.createWebSocket(servletUpgradeRequest, servletUpgradeResponse);
+                return wsAdapter.createWebSocket(servletUpgradeRequest, servletUpgradeResponse, securityContext);
             } else {
                 logger.warn("Unauthenticated request to create a websocket from {}.",
                         servletUpgradeRequest.getRemoteAddress());
@@ -165,26 +169,26 @@ public class CommonWebSocketServlet extends WebSocketServlet {
             return null;
         }
 
-        private boolean isAuthorizedRequest(String bearerToken) {
+        private boolean isAuthorizedRequest(@Nullable SecurityContext securityContext) {
+            return securityContext != null
+                    && (securityContext.isUserInRole(Role.USER) || securityContext.isUserInRole(Role.ADMIN));
+        }
+
+        private @Nullable SecurityContext getSecurityContext(String bearerToken) {
             try {
-                var securityContext = authFilter.getSecurityContext(bearerToken);
-                return securityContext != null
-                        && (securityContext.isUserInRole(Role.USER) || securityContext.isUserInRole(Role.ADMIN));
+                return authFilter.getSecurityContext(bearerToken);
             } catch (AuthenticationException e) {
                 logger.warn("Error handling WebSocket authorization", e);
-                return false;
+                return null;
             }
         }
 
-        private boolean isAuthorizedRequest(ServletUpgradeRequest servletUpgradeRequest) {
+        private @Nullable SecurityContext getSecurityContext(ServletUpgradeRequest servletUpgradeRequest) {
             try {
-                var securityContext = authFilter.getSecurityContext(servletUpgradeRequest.getHttpServletRequest(),
-                        true);
-                return securityContext != null
-                        && (securityContext.isUserInRole(Role.USER) || securityContext.isUserInRole(Role.ADMIN));
+                return authFilter.getSecurityContext(servletUpgradeRequest.getHttpServletRequest(), true);
             } catch (AuthenticationException | IOException e) {
                 logger.warn("Error handling WebSocket authorization", e);
-                return false;
+                return null;
             }
         }
     }

--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/WebSocketAdapter.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/WebSocketAdapter.java
@@ -12,7 +12,10 @@
  */
 package org.openhab.core.io.websocket;
 
+import javax.ws.rs.core.SecurityContext;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
 
@@ -40,5 +43,7 @@ public interface WebSocketAdapter {
      * 
      * @return a websocket instance.
      */
-    Object createWebSocket(ServletUpgradeRequest servletUpgradeRequest, ServletUpgradeResponse servletUpgradeResponse);
+    @Nullable
+    Object createWebSocket(ServletUpgradeRequest servletUpgradeRequest, ServletUpgradeResponse servletUpgradeResponse,
+            SecurityContext securityContext);
 }

--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/event/EventWebSocketAdapter.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/event/EventWebSocketAdapter.java
@@ -15,7 +15,10 @@ package org.openhab.core.io.websocket.event;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+import javax.ws.rs.core.SecurityContext;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
 import org.openhab.core.events.Event;
@@ -74,8 +77,8 @@ public class EventWebSocketAdapter implements EventSubscriber, WebSocketAdapter 
     }
 
     @Override
-    public Object createWebSocket(ServletUpgradeRequest servletUpgradeRequest,
-            ServletUpgradeResponse servletUpgradeResponse) {
+    public @Nullable Object createWebSocket(ServletUpgradeRequest servletUpgradeRequest,
+            ServletUpgradeResponse servletUpgradeResponse, SecurityContext securityContext) {
         return new EventWebSocket(gson, EventWebSocketAdapter.this, itemEventUtility, eventPublisher);
     }
 }

--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/log/LogWebSocketAdapter.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/log/LogWebSocketAdapter.java
@@ -16,9 +16,13 @@ import java.util.Enumeration;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+import javax.ws.rs.core.SecurityContext;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
+import org.openhab.core.auth.Role;
 import org.openhab.core.io.websocket.WebSocketAdapter;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -26,6 +30,8 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.log.LogEntry;
 import org.osgi.service.log.LogReaderService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 
@@ -38,6 +44,8 @@ import com.google.gson.Gson;
 @Component(immediate = true, service = { WebSocketAdapter.class })
 public class LogWebSocketAdapter implements WebSocketAdapter {
     public static final String ADAPTER_ID = "logs";
+
+    private final Logger logger = LoggerFactory.getLogger(LogWebSocketAdapter.class);
     private final Gson gson = new Gson();
     private final Set<LogWebSocket> webSockets = new CopyOnWriteArraySet<>();
     private final LogReaderService logReaderService;
@@ -68,9 +76,14 @@ public class LogWebSocketAdapter implements WebSocketAdapter {
     }
 
     @Override
-    public Object createWebSocket(ServletUpgradeRequest servletUpgradeRequest,
-            ServletUpgradeResponse servletUpgradeResponse) {
-        return new LogWebSocket(gson, LogWebSocketAdapter.this);
+    public @Nullable Object createWebSocket(ServletUpgradeRequest servletUpgradeRequest,
+            ServletUpgradeResponse servletUpgradeResponse, SecurityContext securityContext) {
+        if (securityContext.isUserInRole(Role.ADMIN)) {
+            return new LogWebSocket(gson, LogWebSocketAdapter.this);
+        }
+        logger.warn("Unauthorized access to log websocket from {}, admin role required.",
+                servletUpgradeRequest.getRemoteAddress());
+        return null;
     }
 
     public Enumeration<LogEntry> getLog() {

--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/log/LogWebSocketAdapter.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/log/LogWebSocketAdapter.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.io.websocket.log;
 
+import java.io.IOException;
 import java.util.Enumeration;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -81,8 +82,11 @@ public class LogWebSocketAdapter implements WebSocketAdapter {
         if (securityContext.isUserInRole(Role.ADMIN)) {
             return new LogWebSocket(gson, LogWebSocketAdapter.this);
         }
-        logger.warn("Unauthorized access to log websocket from {}, admin role required.",
-                servletUpgradeRequest.getRemoteAddress());
+        try {
+            servletUpgradeResponse.sendForbidden("Admin role required.");
+        } catch (IOException e) {
+            logger.warn("Failed to send forbidden response to {}", servletUpgradeRequest.getRemoteAddress(), e);
+        }
         return null;
     }
 

--- a/bundles/org.openhab.core.io.websocket/src/test/java/org/openhab/core/io/websocket/CommonWebSocketServletTest.java
+++ b/bundles/org.openhab.core.io.websocket/src/test/java/org/openhab/core/io/websocket/CommonWebSocketServletTest.java
@@ -13,6 +13,7 @@
 package org.openhab.core.io.websocket;
 
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -43,11 +44,10 @@ import org.mockito.quality.Strictness;
 import org.openhab.core.auth.AuthenticationException;
 import org.openhab.core.io.rest.auth.AnonymousUserSecurityContext;
 import org.openhab.core.io.rest.auth.AuthFilter;
-import org.openhab.core.io.websocket.event.EventWebSocket;
 import org.osgi.service.http.NamespaceException;
 
 /**
- * The {@link CommonWebSocketServletTest} contains tests for the {@link EventWebSocket}
+ * The {@link CommonWebSocketServletTest} contains tests for the {@link CommonWebSocketServlet}
  *
  * @author Jan N. Klug - Initial contribution
  */
@@ -86,13 +86,13 @@ public class CommonWebSocketServletTest {
     public void createWebsocketUsingDefaultAdapterPath() throws URISyntaxException {
         when(request.getRequestURI()).thenReturn(new URI("http://127.0.0.1:8080/ws"));
         webSocketCreatorAC.getValue().createWebSocket(request, response);
-        verify(testDefaultWsAdapter, times(1)).createWebSocket(request, response);
+        verify(testDefaultWsAdapter, times(1)).createWebSocket(eq(request), eq(response), any());
     }
 
     @Test
     public void createWebsocketUsingAdapterPath() throws URISyntaxException {
         when(request.getRequestURI()).thenReturn(new URI("http://127.0.0.1:8080/ws/" + testAdapterId));
         webSocketCreatorAC.getValue().createWebSocket(request, response);
-        verify(testWsAdapter, times(1)).createWebSocket(request, response);
+        verify(testWsAdapter, times(1)).createWebSocket(eq(request), eq(response), any());
     }
 }

--- a/bundles/org.openhab.core.io.websocket/src/test/java/org/openhab/core/io/websocket/log/LogWebSocketAdapterTest.java
+++ b/bundles/org.openhab.core.io.websocket/src/test/java/org/openhab/core/io/websocket/log/LogWebSocketAdapterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.io.websocket.log;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.ws.rs.core.SecurityContext;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.auth.Role;
+import org.osgi.service.log.LogReaderService;
+
+/**
+ * The {@link LogWebSocketAdapterTest} contains tests for the {@link LogWebSocketAdapter}.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+@ExtendWith(MockitoExtension.class)
+public class LogWebSocketAdapterTest {
+
+    private @Mock @NonNullByDefault({}) LogReaderService logReaderService;
+    private @Mock @NonNullByDefault({}) ServletUpgradeRequest request;
+    private @Mock @NonNullByDefault({}) ServletUpgradeResponse response;
+
+    private @NonNullByDefault({}) LogWebSocketAdapter logWsAdapter;
+
+    @BeforeEach
+    public void setup() {
+        logWsAdapter = new LogWebSocketAdapter(logReaderService);
+    }
+
+    @Test
+    public void createWebSocketBlockedForUserRole() {
+        SecurityContext userContext = mock(SecurityContext.class);
+        when(userContext.isUserInRole(Role.ADMIN)).thenReturn(false);
+
+        Object result = logWsAdapter.createWebSocket(request, response, userContext);
+        assertNull(result);
+    }
+
+    @Test
+    public void createWebSocketAllowedForAdminRole() {
+        SecurityContext adminContext = mock(SecurityContext.class);
+        when(adminContext.isUserInRole(Role.ADMIN)).thenReturn(true);
+
+        Object result = logWsAdapter.createWebSocket(request, response, adminContext);
+        assertNotNull(result);
+    }
+}


### PR DESCRIPTION
The log WebSocket is currently accessible to all authenticated users, allowing log access for normal users.
Normal users should not be able to access sensitive information such as logs, so restrict access to the log WebSocket to administrators.