### PR TITLE
[voice] Refactor LLMToolCall to a standard class to allow inheritance

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMToolCall.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMToolCall.java
@@ -13,23 +13,36 @@
 package org.openhab.core.voice.text.interpreter.llm;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
 /**
  * A DTO to store information about a tool call.
- * 
- * @param tool the UID of the {@link LLMTool}
- * @param params the params of the tool call
  *
  * @author Florian Hotze - Initial contribution
  */
 @NonNullByDefault
-public record LLMToolCall(String tool, Map<String, Object> params) {
-    private static final Gson GSON = new Gson();
+public class LLMToolCall {
+    protected static final Gson GSON = new Gson();
+
+    /**
+     * the UID of the {@link LLMTool}
+     */
+    public final String tool;
+    /**
+     * the params of the tool call
+     */
+    public final Map<String, Object> params;
+
+    public LLMToolCall(String tool, Map<String, Object> params) {
+        this.tool = tool;
+        this.params = params;
+    }
 
     public static LLMToolCall map(LLMTool tool, Map<String, Object> params) {
         return new LLMToolCall(tool.getUID(), params);
@@ -57,5 +70,18 @@ public record LLMToolCall(String tool, Map<String, Object> params) {
             throw new JsonSyntaxException("Deserialized LLMToolCall is null.");
         }
         return call;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (!(o instanceof LLMToolCall call)) {
+            return false;
+        }
+        return Objects.equals(tool, call.tool) && Objects.equals(params, call.params);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tool, params);
     }
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMToolCall.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMToolCall.java
@@ -40,8 +40,8 @@ public class LLMToolCall {
     public final Map<String, Object> params;
 
     public LLMToolCall(String tool, Map<String, Object> params) {
-        this.tool = tool;
-        this.params = params;
+        this.tool = Objects.requireNonNull(tool, "tool must not be null");
+        this.params = Objects.requireNonNull(params, "params must not be null");
     }
 
     public static LLMToolCall map(LLMTool tool, Map<String, Object> params) {
@@ -69,15 +69,23 @@ public class LLMToolCall {
         if (call == null) {
             throw new JsonSyntaxException("Deserialized LLMToolCall is null.");
         }
+        if (call.tool == null || call.params == null) {
+            throw new JsonSyntaxException("Deserialized LLMToolCall has null tool or params.");
+        }
         return call;
     }
 
     @Override
     public boolean equals(@Nullable Object o) {
-        if (!(o instanceof LLMToolCall call)) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        return Objects.equals(tool, call.tool) && Objects.equals(params, call.params);
+
+        LLMToolCall call = (LLMToolCall) o;
+        return tool.equals(call.tool) && params.equals(call.params);
     }
 
     @Override

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMToolCallTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMToolCallTest.java
@@ -87,6 +87,8 @@ public class LLMToolCallTest {
 
         LLMToolCall roundTrip = LLMToolCall.fromJson(serialized);
         assertEquals(call, roundTrip);
+        assertEquals(call.tool, roundTrip.tool);
+        assertEquals(call.params, roundTrip.params);
     }
 
     @ParameterizedTest(name = "{0}")
@@ -98,6 +100,8 @@ public class LLMToolCallTest {
 
         LLMToolCall deserialized = LLMToolCall.fromJson(json);
         assertEquals(original, deserialized);
+        assertEquals(original.tool, deserialized.tool);
+        assertEquals(original.params, deserialized.params);
     }
 
     @Test


### PR DESCRIPTION
This is required to fix issues thinking models and tool calling in the Gemini HLI service.