### PR TITLE
Addon Resource: Add installedOnly option to speed up UI binding selection

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
@@ -149,7 +149,7 @@ public abstract class AbstractRemoteAddonService implements AddonService {
             logger.error(
                     "Failed to read JSON database, trying to purge it. You might need to re-install {} from the '{}' service.",
                     installedAddonStorage.getKeys(), getId());
-            refreshSource();
+            refreshSource(installedOnly);
         }
 
         // remove not installed add-ons from the add-ons list, but remember their UIDs to re-install them

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
@@ -150,6 +150,7 @@ public abstract class AbstractRemoteAddonService implements AddonService {
                     "Failed to read JSON database, trying to purge it. You might need to re-install {} from the '{}' service.",
                     installedAddonStorage.getKeys(), getId());
             refreshSource(installedOnly);
+            return;
         }
 
         // remove not installed add-ons from the add-ons list, but remember their UIDs to re-install them

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
@@ -124,6 +124,10 @@ public abstract class AbstractRemoteAddonService implements AddonService {
 
     @Override
     public void refreshSource() {
+        refreshSource(false);
+    }
+
+    private void refreshSource(boolean installedOnly) {
         if (!addonHandlers.stream().allMatch(MarketplaceAddonHandler::isReady)) {
             logger.debug("Add-on service '{}' tried to refresh source before add-on handlers ready. Exiting.",
                     getClass());
@@ -157,7 +161,7 @@ public abstract class AbstractRemoteAddonService implements AddonService {
         List<String> currentAddonIds = addons.stream().map(Addon::getUid).toList();
 
         // get the remote addons
-        if (remoteEnabled()) {
+        if (!installedOnly && remoteEnabled()) {
             List<Addon> remoteAddons = Objects.requireNonNullElse(cachedRemoteAddons.getValue(), List.of());
             remoteAddons.stream().filter(a -> !currentAddonIds.contains(a.getUid())).forEach(addon -> {
                 setInstalled(addon);
@@ -181,7 +185,7 @@ public abstract class AbstractRemoteAddonService implements AddonService {
         cachedAddons = addons;
         this.installedAddonIds = currentAddonIds;
 
-        if (!missingAddons.isEmpty()) {
+        if (!installedOnly && !missingAddons.isEmpty()) {
             logger.info("Re-installing missing add-ons from remote repository: {}", missingAddons);
             scheduler.execute(() -> missingAddons.forEach(this::install));
         }
@@ -222,7 +226,13 @@ public abstract class AbstractRemoteAddonService implements AddonService {
 
     @Override
     public List<Addon> getAddons(@Nullable Locale locale) {
-        refreshSource();
+        refreshSource(false);
+        return cachedAddons;
+    }
+
+    @Override
+    public List<Addon> getAddons(@Nullable Locale locale, boolean installedOnly) {
+        refreshSource(installedOnly);
         return cachedAddons;
     }
 

--- a/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonServiceTest.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonServiceTest.java
@@ -146,6 +146,18 @@ public class AbstractRemoteAddonServiceTest {
     }
 
     @Test
+    public void testInstalledOnlyAddonsDoNotTriggerRemoteLookup() {
+        addonService.setInstalled(TEST_ADDON);
+        addonService.addToStorage(TEST_ADDON);
+
+        List<Addon> addons = addonService.getAddons(null, true);
+        assertThat(addons, hasSize(1));
+        assertThat(addons.getFirst().getUid(), is(getFullAddonId(TEST_ADDON)));
+        assertThat(addons.getFirst().isInstalled(), is(true));
+        assertThat(addonService.getRemoteCalls(), is(0));
+    }
+
+    @Test
     public void testIncompatibleAddonsNotIncludedByDefault() {
         assertThat(addonService.getAddons(null), hasSize(COMPATIBLE_ADDON_COUNT));
     }

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonService.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonService.java
@@ -64,6 +64,22 @@ public interface AddonService {
     List<Addon> getAddons(@Nullable Locale locale);
 
     /**
+     * Retrieves add-ons, optionally restricted to installed ones only.
+     *
+     * Implementations that can avoid remote lookups when {@code installedOnly} is {@code true} should do so.
+     *
+     * @param locale the locale to use for the result
+     * @param installedOnly {@code true} to return only installed add-ons
+     * @return the localized add-ons
+     */
+    default List<Addon> getAddons(@Nullable Locale locale, boolean installedOnly) {
+        if (installedOnly) {
+            return getAddons(locale).stream().filter(Addon::isInstalled).toList();
+        }
+        return getAddons(locale);
+    }
+
+    /**
      * Retrieves the add-on for the given id.
      *
      * @param id the id of the add-on

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
@@ -155,18 +155,22 @@ public class AddonResource implements RESTResource {
             @ApiResponse(responseCode = "404", description = "Service not found") })
     public Response getAddon(
             @HeaderParam("Accept-Language") @Parameter(description = "language") @Nullable String language,
-            @QueryParam("serviceId") @Parameter(description = "service ID") @Nullable String serviceId) {
+            @QueryParam("serviceId") @Parameter(description = "service ID") @Nullable String serviceId,
+            @QueryParam("installedOnly") @Parameter(description = "true to return only installed add-ons") @Nullable Boolean installedOnly) {
         logger.debug("Received HTTP GET request at '{}'", uriInfo.getPath());
 
         final Locale locale = localeService.getLocale(language);
+
         if ("all".equals(serviceId)) {
-            return Response.ok(new Stream2JSONInputStream(getAllAddons(locale))).build();
+            return Response.ok(new Stream2JSONInputStream(getAllAddons(locale, Boolean.TRUE.equals(installedOnly))))
+                    .build();
         } else {
             AddonService addonService = (serviceId != null) ? getServiceById(serviceId) : getDefaultService();
             if (addonService == null) {
                 return Response.status(HttpStatus.NOT_FOUND_404).build();
             }
-            return Response.ok(new Stream2JSONInputStream(addonService.getAddons(locale).stream())).build();
+            return Response.ok(new Stream2JSONInputStream(
+                    addonService.getAddons(locale, Boolean.TRUE.equals(installedOnly)).stream())).build();
         }
     }
 
@@ -412,8 +416,8 @@ public class AddonResource implements RESTResource {
                 .findFirst().orElse(addonServices.stream().findFirst().orElse(null));
     }
 
-    private Stream<Addon> getAllAddons(Locale locale) {
-        return addonServices.stream().map(s -> s.getAddons(locale)).flatMap(Collection::stream);
+    private Stream<Addon> getAllAddons(Locale locale, boolean installedOnly) {
+        return addonServices.stream().map(s -> s.getAddons(locale, installedOnly)).flatMap(Collection::stream);
     }
 
     private Set<AddonType> getAllAddonTypes(Locale locale) {


### PR DESCRIPTION
Fixes openhab/openhab-webui#2337

Don't fetch remote resources when requesting only the list of installed add-ons. This will significantly speed up the list of installed binding in the UI when adding a Thing.