### PR TITLE
Make add-on installation resilient to a single failing add-on (upgrade resilience, #5694)

### DIFF
--- a/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/internal/MDNSClientImpl.java
+++ b/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/internal/MDNSClientImpl.java
@@ -25,11 +25,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import javax.jmdns.JmDNS;
 import javax.jmdns.ServiceInfo;
 import javax.jmdns.ServiceListener;
 
+import org.openhab.core.common.NamedThreadFactory;
 import org.openhab.core.io.transport.mdns.MDNSClient;
 import org.openhab.core.io.transport.mdns.ServiceDescription;
 import org.openhab.core.net.CidrAddress;
@@ -57,6 +61,12 @@ public class MDNSClientImpl implements MDNSClient, NetworkAddressChangeListener 
     private final Set<ServiceDescription> activeServices = ConcurrentHashMap.newKeySet();
 
     private final NetworkAddressService networkAddressService;
+
+    /**
+     * Single thread executor used to spin up the JmDNS instances asynchronously, so that the OSGi component
+     * activation does not block (and hold the bundle's state change lock) while network I/O is performed.
+     */
+    private final ExecutorService startExecutor = Executors.newSingleThreadExecutor(new NamedThreadFactory("mdns"));
 
     @Activate
     public MDNSClientImpl(final @Reference NetworkAddressService networkAddressService) {
@@ -138,7 +148,12 @@ public class MDNSClientImpl implements MDNSClient, NetworkAddressChangeListener 
     @Activate
     protected void activate() {
         networkAddressService.addNetworkAddressChangeListener(this);
-        start();
+        // Creating the JmDNS instances performs blocking network I/O for every interface/address, which can
+        // take a considerable amount of time (especially on hosts with many network interfaces). Running this
+        // on the component activation thread holds the bundle's state change lock and can stall the activation
+        // of other bundles and the installation of features. Therefore the JmDNS instances are started
+        // asynchronously so that activation returns immediately.
+        startExecutor.execute(this::start);
     }
 
     private void start() {
@@ -156,6 +171,12 @@ public class MDNSClientImpl implements MDNSClient, NetworkAddressChangeListener 
 
     @Deactivate
     public void deactivate() {
+        startExecutor.shutdownNow();
+        try {
+            startExecutor.awaitTermination(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
         close();
         activeServices.clear();
         networkAddressService.removeNetworkAddressChangeListener(this);

--- a/bundles/org.openhab.core.karaf/pom.xml
+++ b/bundles/org.openhab.core.karaf/pom.xml
@@ -71,6 +71,12 @@
       <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
@@ -436,7 +436,8 @@ public class FeatureInstaller implements ConfigurationListener {
         }
     }
 
-    private void installFeatures(Set<String> addons) {
+    /* package-private (instead of private) for testing */
+    void installFeatures(Set<String> addons) {
         Set<String> failed = installFeatureSet(addons);
 
         // If more than one add-on was requested and some failed, a single add-on that cannot be resolved or

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
@@ -109,6 +109,10 @@ public class FeatureInstaller implements ConfigurationListener {
                                           // configuration as this must be waited for before trying to add feature repos
     private @Nullable Map<String, Object> configMapCache;
 
+    private static final int MAX_INSTALL_ATTEMPTS = 5;
+    private Set<String> failedInstallAddons = Set.of();
+    private int failedInstallAttempts;
+
     @Activate
     public FeatureInstaller(final @Reference ConfigurationAdmin configurationAdmin,
             final @Reference FeaturesService featuresService, final @Reference KarService karService,
@@ -433,40 +437,87 @@ public class FeatureInstaller implements ConfigurationListener {
     }
 
     private void installFeatures(Set<String> addons) {
+        Set<String> failed = installFeatureSet(addons);
+
+        // If more than one add-on was requested and some failed, a single add-on that cannot be resolved or
+        // downloaded may have aborted the whole (transactional) installation and thereby blocked the other,
+        // working add-ons. Retry the failed add-ons individually so that one broken add-on cannot prevent the
+        // others from being installed.
+        if (!failed.isEmpty() && addons.size() > 1) {
+            logger.warn("Installing add-ons '{}' as a group failed. Retrying them individually so that a single "
+                    + "failing add-on does not block the others.", String.join(", ", failed));
+            Set<String> stillFailed = new HashSet<>();
+            for (String addon : failed) {
+                stillFailed.addAll(installFeatureSet(Set.of(addon)));
+            }
+            failed = stillFailed;
+        }
+
+        if (failed.isEmpty()) {
+            failedInstallAddons = Set.of();
+            failedInstallAttempts = 0;
+            return;
+        }
+
+        // Bound the number of automatic retries for a persistently failing set of add-ons. Without this, a
+        // permanently unavailable add-on (e.g. removed from the repository) is retried every minute forever,
+        // repeatedly refreshing bundles and never giving up, which can also block other operations.
+        if (failed.equals(failedInstallAddons)) {
+            failedInstallAttempts++;
+        } else {
+            failedInstallAddons = failed;
+            failedInstallAttempts = 1;
+        }
+
+        if (failedInstallAttempts < MAX_INSTALL_ATTEMPTS) {
+            logger.error("Failed installing add-ons '{}' (attempt {} of {}). Will retry.", String.join(", ", failed),
+                    failedInstallAttempts, MAX_INSTALL_ATTEMPTS);
+            configMapCache = null; // make sure we retry the installation
+        } else {
+            logger.error("Failed installing add-ons '{}' after {} attempts. Giving up until the add-on configuration "
+                    + "changes or the server is restarted. Please check repository/network access for these "
+                    + "add-ons.", String.join(", ", failed), failedInstallAttempts);
+            // Intentionally do not reset configMapCache here so that the periodic sync job stops retrying.
+        }
+    }
+
+    /**
+     * Installs the given set of add-on features and returns the sub-set that is not installed afterwards.
+     *
+     * @param addons the add-on feature names to install
+     * @return the add-on feature names that could not be installed
+     */
+    private Set<String> installFeatureSet(Set<String> addons) {
         try {
             if (logger.isDebugEnabled()) {
                 logger.debug("Installing '{}'", String.join(", ", addons));
             }
             featuresService.installFeatures(addons, EnumSet.of(FeaturesService.Option.NoAutoRefreshBundles,
                     FeaturesService.Option.Upgrade, FeaturesService.Option.NoFailOnFeatureNotFound));
-            try {
-                Feature[] features = featuresService.listInstalledFeatures();
-                Set<String> installed = new HashSet<>();
-                Set<String> failed = new HashSet<>();
-
-                for (String addon : addons) {
-                    if (anyMatchingFeature(features, withName(addon))) {
-                        installed.add(addon);
-                    } else {
-                        failed.add(addon);
-                    }
-                }
-
-                if (!installed.isEmpty() && logger.isDebugEnabled()) {
-                    logger.debug("Installed '{}'", String.join(", ", installed));
-                }
-                if (!failed.isEmpty()) {
-                    logger.error("Failed installing '{}'", String.join(", ", failed));
-                    configMapCache = null; // make sure we retry the installation
-                }
-                installed.forEach(this::postInstalledEvent);
-            } catch (Exception e) {
-                logger.error("Failed retrieving features: {}", e.getMessage(), debugException(e));
-                configMapCache = null; // make sure we retry the installation
-            }
         } catch (Exception e) {
-            logger.error("Failed installing '{}': {}", String.join(", ", addons), e.getMessage(), debugException(e));
-            configMapCache = null; // make sure we retry the installation
+            logger.debug("Installing '{}' failed: {}", String.join(", ", addons), e.getMessage(), debugException(e));
+        }
+        try {
+            Feature[] features = featuresService.listInstalledFeatures();
+            Set<String> installed = new HashSet<>();
+            Set<String> failed = new HashSet<>();
+
+            for (String addon : addons) {
+                if (anyMatchingFeature(features, withName(addon))) {
+                    installed.add(addon);
+                } else {
+                    failed.add(addon);
+                }
+            }
+
+            if (!installed.isEmpty() && logger.isDebugEnabled()) {
+                logger.debug("Installed '{}'", String.join(", ", installed));
+            }
+            installed.forEach(this::postInstalledEvent);
+            return failed;
+        } catch (Exception e) {
+            logger.error("Failed retrieving features: {}", e.getMessage(), debugException(e));
+            return addons;
         }
     }
 

--- a/bundles/org.openhab.core.karaf/src/test/java/org/openhab/core/karaf/internal/FeatureInstallerTest.java
+++ b/bundles/org.openhab.core.karaf/src/test/java/org/openhab/core/karaf/internal/FeatureInstallerTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.karaf.internal;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.karaf.features.Feature;
+import org.apache.karaf.features.FeaturesService;
+import org.apache.karaf.kar.KarService;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.events.EventPublisher;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * Tests for the add-on installation resilience of {@link FeatureInstaller}: a single add-on that cannot be
+ * downloaded/resolved must not block the other add-ons, and a persistently failing add-on must not be retried
+ * forever.
+ *
+ * @author openHAB contributors - Initial contribution
+ */
+@NonNullByDefault
+public class FeatureInstallerTest {
+
+    private static final String ADDON_A = "openhab-binding-a";
+    private static final String ADDON_B = "openhab-binding-b";
+    private static final String ADDON_BAD = "openhab-binding-bad";
+
+    private @NonNullByDefault({}) FeaturesService featuresService;
+    private @NonNullByDefault({}) EventPublisher eventPublisher;
+    private @NonNullByDefault({}) FeatureInstaller featureInstaller;
+
+    /** The names of the features the mocked {@link FeaturesService} considers currently installed. */
+    private final Set<String> installedFeatures = new HashSet<>();
+
+    @BeforeEach
+    public void setUp() {
+        ConfigurationAdmin configurationAdmin = mock(ConfigurationAdmin.class);
+        featuresService = mock(FeaturesService.class);
+        KarService karService = mock(KarService.class);
+        eventPublisher = mock(EventPublisher.class);
+
+        featureInstaller = new FeatureInstaller(configurationAdmin, featuresService, karService, eventPublisher,
+                Map.of());
+        // Stop the background scheduler and discard the interactions triggered by the constructor so that the
+        // tests can drive installFeatures(...) deterministically.
+        featureInstaller.deactivate();
+        reset(featuresService, eventPublisher);
+    }
+
+    /**
+     * A failing group installation (as thrown by the transactional Karaf {@code installFeatures} when one add-on
+     * cannot be downloaded) must fall back to installing the add-ons individually, so that the healthy add-ons are
+     * still installed.
+     */
+    @Test
+    public void groupFailureFallsBackToIndividualInstalls() throws Exception {
+        when(featuresService.listInstalledFeatures()).thenAnswer(invocation -> featuresFor(installedFeatures));
+        installEverythingButBrokenAddon();
+
+        featureInstaller.installFeatures(Set.of(ADDON_A, ADDON_B, ADDON_BAD));
+
+        // The two healthy add-ons are installed despite the broken one, which is not.
+        assertThat(installedFeatures, hasItems(ADDON_A, ADDON_B));
+        assertThat(installedFeatures, not(hasItem(ADDON_BAD)));
+
+        // The healthy add-ons were retried individually after the group install failed.
+        verify(featuresService).installFeatures(eq(Set.of(ADDON_A)), any());
+        verify(featuresService).installFeatures(eq(Set.of(ADDON_B)), any());
+    }
+
+    /**
+     * A persistently failing add-on must be retried only a bounded number of times. Up to the limit the
+     * configuration cache is cleared so that the periodic sync job retries; once the limit is reached the cache is
+     * left intact so that the retry storm stops.
+     */
+    @Test
+    public void persistentFailureStopsRetryingAfterMaxAttempts() throws Exception {
+        when(featuresService.listInstalledFeatures()).thenAnswer(invocation -> featuresFor(installedFeatures));
+        installEverythingButBrokenAddon();
+
+        Map<String, Object> sentinelConfig = new HashMap<>();
+        sentinelConfig.put("key", "value");
+
+        // Attempts before the limit clear the config cache so that the sync job retries the installation.
+        for (int attempt = 1; attempt < 5; attempt++) {
+            setConfigMapCache(sentinelConfig);
+            featureInstaller.installFeatures(Set.of(ADDON_BAD));
+            assertThat("attempt " + attempt + " should schedule a retry", getConfigMapCache(), is(nullValue()));
+        }
+
+        // The final attempt gives up and keeps the cache so that the periodic sync job stops retrying.
+        setConfigMapCache(sentinelConfig);
+        featureInstaller.installFeatures(Set.of(ADDON_BAD));
+        assertThat("the retry storm should stop after the maximum number of attempts", getConfigMapCache(),
+                is(sameInstance(sentinelConfig)));
+    }
+
+    /**
+     * Makes the mocked {@link FeaturesService} fail any installation request that contains the broken add-on and
+     * succeed for all other requests, tracking the successfully installed features.
+     */
+    @SuppressWarnings("unchecked")
+    private void installEverythingButBrokenAddon() throws Exception {
+        doAnswer(invocation -> {
+            Set<String> requested = invocation.getArgument(0, Set.class);
+            if (requested.contains(ADDON_BAD)) {
+                throw new Exception("simulated download failure of " + ADDON_BAD);
+            }
+            installedFeatures.addAll(requested);
+            return null;
+        }).when(featuresService).installFeatures(any(Set.class), any(EnumSet.class));
+    }
+
+    private Feature[] featuresFor(Set<String> names) {
+        return names.stream().map(name -> {
+            Feature feature = mock(Feature.class);
+            when(feature.getName()).thenReturn(name);
+            return feature;
+        }).toArray(Feature[]::new);
+    }
+
+    private void setConfigMapCache(@Nullable Map<String, Object> value) throws Exception {
+        Field field = FeatureInstaller.class.getDeclaredField("configMapCache");
+        field.setAccessible(true);
+        field.set(featureInstaller, value);
+    }
+
+    private @Nullable Object getConfigMapCache() throws Exception {
+        Field field = FeatureInstaller.class.getDeclaredField("configMapCache");
+        field.setAccessible(true);
+        return field.get(featureInstaller);
+    }
+}

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
@@ -331,6 +331,14 @@ public class ModelRepositoryImpl implements ModelRepository {
             throws IOException {
         // use another resource for validation in order to keep the original one for emergency-removal in case of errors
         Resource resource = resourceSet.createResource(URI.createURI(PREFIX_TMP_MODEL + name));
+        if (resource == null) {
+            // No resource factory is registered (yet) for this model's file extension. This can happen during
+            // startup when the bundle providing the parser for this model type is not active yet. In that case
+            // the model cannot be validated; report no validation errors and let addOrRefreshModel() handle the
+            // missing parser gracefully instead of throwing a NullPointerException here.
+            logger.debug("Cannot validate model '{}' as no resource factory is registered for it (yet).", name);
+            return true;
+        }
         try {
             resource.load(inputStream, resourceOptions);
 


### PR DESCRIPTION
> [!NOTE]
> **This is an AI-driven pull request.** The analysis, code changes, commit messages and the reproduction below were produced by an AI agent (GitHub Copilot CLI, Claude Opus) working under the direction of, and reviewed by, @JonathanGiles, who takes responsibility for the contribution and has signed off all commits (DCO).

## Background

This addresses the resilience problems discussed in openhab/openhab-core#5694 ("openHAB does not start after upgrade to 5.2.0"). That issue collects several distinct failure modes; this PR targets the mechanism where an **add-on that fails to download/resolve during an upgrade cascades into a total, self-perpetuating outage** (bindings missing, `Unable to acquire the state change lock`, and `ModelRepositoryImpl` NullPointerExceptions on every `.items`/`.rules` file), matching the maintainer's own suggestions in that thread:

> I also think we need to look at FeatureInstaller, because as far as I can see, it never gives up on trying a failed installation, and you can't abort it. This seems to block the installation of other, working, features/bundles.

> There's no reason for the [mDNS] bundle activation to wait for all the JmDNS instances to spin up.

## What changes

Three small, independent fixes (one commit each):

### 1. `[karaf]` FeatureInstaller: isolate failures + bound retries
`FeatureInstaller.installFeatures()` installed **all** requested add-ons in a single transactional `featuresService.installFeatures(set, …)` call. If **one** add-on could not be resolved/downloaded, the whole batch was aborted and **none** of the add-ons installed. Worse, any failure set `configMapCache = null` unconditionally, so the periodic sync job retried the install — and a bundle refresh — **every minute, forever, with no way to give up**.

- On a group-install failure, the failed add-ons are now retried **individually**, so one broken add-on can no longer block the working ones.
- The number of automatic retries for a persistently failing set is **bounded** (`MAX_INSTALL_ATTEMPTS`), after which it logs an actionable error and stops, instead of looping forever. It retries again when the add-on config changes or the server restarts.

### 2. `[mdns]` Start JmDNS asynchronously on activation
`MDNSClientImpl.activate()` synchronously created a `JmDNS` instance per interface/address (blocking network I/O) while holding the bundle's OSGi state-change lock, which can stall other bundles' activation and feature installs. The JmDNS instances are now started on a single-threaded executor so activation returns immediately (executor is shut down on deactivate).

### 3. `[model.core]` Guard against NPE when no parser is registered yet
`ModelRepositoryImpl.validateModel()` called `Resource.load()` on a possibly-null resource returned by `resourceSet.createResource()` (null when no resource factory is registered yet, e.g. during startup before the parser bundle is active), throwing an NPE for every affected model file. It now returns gracefully and lets `addOrRefreshModel()` handle the missing parser as it already does elsewhere.

## Testing

The FeatureInstaller behaviour was **reproduced and diagnosed live** in an isolated openHAB **5.2.0** Docker container (never against production), by faithfully modelling "12 add-ons downloaded, 1 failed during upgrade":

- 12 requested bindings pre-seeded into the local mvn cache (resolvable offline) + one known binding (`zwave`) left uncached, with the online repo blackholed so only the uncached add-on fails to download — exactly the transient-download-failure scenario.

**Before (stock 5.2.0), a single failing add-on:**

```
[DEBUG] FeatureInstaller - Installing 'openhab-binding-gree, openhab-binding-teslascope, openhab-binding-unifi, openhab-binding-daikin, openhab-binding-zwave'
[ERROR] FeatureInstaller - Failed installing 'openhab-binding-gree, openhab-binding-teslascope, openhab-binding-unifi, openhab-binding-daikin, openhab-binding-zwave'
        Error downloading mvn:org.openhab.addons.bundles/org.openhab.binding.zwave/5.2.0
        org.apache.karaf.features.internal.util.MultiException: Error:
```

→ the **four perfectly-resolvable bindings were NOT installed** solely because `zwave` could not be downloaded (transactional rollback), and the install + bundle refresh **retried every 60 s indefinitely** (`12:57:34 → 12:58:34 → 12:59:34 …`) — the amplifier that turns one download hiccup into the observed meltdown.

With this change, the group failure falls back to individual installs (the four good bindings install, only `zwave` is reported failed) and the retries are bounded. This was also confirmed with a full before/after run of the **fixed** FeatureInstaller image (results posted in the comments below).

The `[karaf]` fix is covered by unit tests (`FeatureInstallerTest`) that fail against the previous implementation and pass with the fix: one verifies a failing group install falls back to individual installs so the healthy add-ons still install, the other verifies the retries are bounded and stop.

- ✅ All three patched bundles compile against 5.2.0 and `main` (the touched files are identical on both), and pass `spotless:check`.
- The `mdns` and `model.core` fixes are supported by the stack traces and lock errors in #5694 and by code analysis.

This is ready for review. Feedback on the approach is welcome, and I'm happy to split it into separate PRs per bundle if preferred.

Signed-off-by: Jonathan Giles <jonathan@jonathangiles.net>

