### PR TITLE
Rearrange YAML rule and rule template module order

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/fileformat/FileFormatResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/fileformat/FileFormatResource.java
@@ -259,6 +259,11 @@ public class FileFormatResource implements RESTResource {
               MyRule:
                 label: My Rule
                 description: My rule description
+                triggers:
+                  - id: "1"
+                    config:
+                      time: 12:00
+                    type: TimeOfDay
                 actions:
                   - id: "2"
                     config:
@@ -266,11 +271,6 @@ public class FileFormatResource implements RESTResource {
                       script: |
                         logInfo("Test", "MyRule is running")
                     type: Script
-                triggers:
-                  - id: "1"
-                    config:
-                      time: 12:00
-                    type: TimeOfDay
             """;
 
     private static final String JSON_RULE_UID_CHECK_EXAMPLE = """
@@ -359,13 +359,6 @@ public class FileFormatResource implements RESTResource {
                     advanced: false
                     verify: false
                     limitToOptions: true
-                actions:
-                  - id: "2"
-                    config:
-                      type: DSL
-                      script: |
-                        logInfo("Test", "{{sourceItem}} turned on")
-                    type: Script
                 triggers:
                   - id: "1"
                     config:
@@ -373,6 +366,13 @@ public class FileFormatResource implements RESTResource {
                       state: "ON"
                       previousState: "OFF"
                     type: ItemChanged
+                actions:
+                  - id: "2"
+                    config:
+                      type: DSL
+                      script: |
+                        logInfo("Test", "{{sourceItem}} turned on")
+                    type: Script
             """;
 
     private static final String DSL_SITEMAPS_EXAMPLE = """
@@ -460,16 +460,16 @@ public class FileFormatResource implements RESTResource {
             rules:
               MyRule:
                 label: Label
+                triggers:
+                  - config:
+                      itemName: MyItem
+                    type: ItemReceivedCommand
                 actions:
                   - config:
                       type: DSL
                       script: |
                         logInfo("Test", "MyRule is running")
                     type: Script
-                triggers:
-                  - config:
-                      itemName: MyItem
-                    type: ItemReceivedCommand
             ruleTemplates:
               my-template:
                 label: My Template
@@ -486,13 +486,6 @@ public class FileFormatResource implements RESTResource {
                     advanced: false
                     verify: false
                     limitToOptions: true
-                actions:
-                  - id: "2"
-                    config:
-                      type: DSL
-                      script: |
-                        logInfo("Test", "{{sourceItem}} turned on")
-                    type: Script
                 triggers:
                   - id: "1"
                     config:
@@ -500,6 +493,13 @@ public class FileFormatResource implements RESTResource {
                       state: "ON"
                       previousState: "OFF"
                     type: ItemChanged
+                actions:
+                  - id: "2"
+                    config:
+                      type: DSL
+                      script: |
+                        logInfo("Test", "{{sourceItem}} turned on")
+                    type: Script
             sitemaps:
               MySitemap:
                 label: My Sitemap

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/rules/YamlRuleDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/rules/YamlRuleDTO.java
@@ -63,9 +63,9 @@ public class YamlRuleDTO implements ModularDTO<YamlRuleDTO, ObjectMapper, JsonNo
     public Visibility visibility;
     public Map<@NonNull String, @NonNull Object> config;
     public Map<@NonNull String, @NonNull YamlConfigDescriptionParameterDTO> configDescriptions;
+    public List<@NonNull YamlModuleDTO> triggers;
     public List<@NonNull YamlConditionDTO> conditions;
     public List<@NonNull YamlActionDTO> actions;
-    public List<@NonNull YamlModuleDTO> triggers;
 
     /**
      * Creates a new instance.
@@ -212,21 +212,21 @@ public class YamlRuleDTO implements ModularDTO<YamlRuleDTO, ObjectMapper, JsonNo
                 result.configDescriptions = configDescriptions;
             }
 
-            if (partial.actions != null && !partial.actions.isEmpty()) {
-                if (!partial.actions.isArray()) {
-                    throw new SerializationException("Expected actions to be an array node");
+            if (partial.triggers != null && !partial.triggers.isEmpty()) {
+                if (!partial.triggers.isArray()) {
+                    throw new SerializationException("Expected triggers to be an array node");
                 }
-                List<YamlActionDTO> actions = new ArrayList<>(partial.actions.size());
-                JsonNode actionNode;
-                YamlActionDTO action;
-                for (Iterator<JsonNode> iterator = partial.actions.elements(); iterator.hasNext();) {
-                    actionNode = iterator.next();
-                    action = mapper.treeToValue(actionNode, YamlActionDTO.class);
-                    action.type = ModuleTypeAliases.aliasToType(Action.class, action.type);
-                    translateMIMETypeAliases(action);
-                    actions.add(action);
+                List<YamlModuleDTO> triggers = new ArrayList<>(partial.triggers.size());
+                JsonNode triggerNode;
+                YamlModuleDTO trigger;
+                for (Iterator<JsonNode> iterator = partial.triggers.elements(); iterator.hasNext();) {
+                    triggerNode = iterator.next();
+                    trigger = mapper.treeToValue(triggerNode, YamlModuleDTO.class);
+                    trigger.type = ModuleTypeAliases.aliasToType(Trigger.class, trigger.type);
+                    translateMIMETypeAliases(trigger);
+                    triggers.add(trigger);
                 }
-                result.actions = actions;
+                result.triggers = triggers;
             }
             if (partial.conditions != null && !partial.conditions.isEmpty()) {
                 if (!partial.conditions.isArray()) {
@@ -244,21 +244,21 @@ public class YamlRuleDTO implements ModularDTO<YamlRuleDTO, ObjectMapper, JsonNo
                 }
                 result.conditions = conditions;
             }
-            if (partial.triggers != null && !partial.triggers.isEmpty()) {
-                if (!partial.triggers.isArray()) {
-                    throw new SerializationException("Expected triggers to be an array node");
+            if (partial.actions != null && !partial.actions.isEmpty()) {
+                if (!partial.actions.isArray()) {
+                    throw new SerializationException("Expected actions to be an array node");
                 }
-                List<YamlModuleDTO> triggers = new ArrayList<>(partial.triggers.size());
-                JsonNode triggerNode;
-                YamlModuleDTO trigger;
-                for (Iterator<JsonNode> iterator = partial.triggers.elements(); iterator.hasNext();) {
-                    triggerNode = iterator.next();
-                    trigger = mapper.treeToValue(triggerNode, YamlModuleDTO.class);
-                    trigger.type = ModuleTypeAliases.aliasToType(Trigger.class, trigger.type);
-                    translateMIMETypeAliases(trigger);
-                    triggers.add(trigger);
+                List<YamlActionDTO> actions = new ArrayList<>(partial.actions.size());
+                JsonNode actionNode;
+                YamlActionDTO action;
+                for (Iterator<JsonNode> iterator = partial.actions.elements(); iterator.hasNext();) {
+                    actionNode = iterator.next();
+                    action = mapper.treeToValue(actionNode, YamlActionDTO.class);
+                    action.type = ModuleTypeAliases.aliasToType(Action.class, action.type);
+                    translateMIMETypeAliases(action);
+                    actions.add(action);
                 }
-                result.triggers = triggers;
+                result.actions = actions;
             }
         } catch (JsonProcessingException | IllegalArgumentException e) {
             throw new SerializationException(e.getMessage(), e);
@@ -418,14 +418,14 @@ public class YamlRuleDTO implements ModularDTO<YamlRuleDTO, ObjectMapper, JsonNo
         if (configDescriptions != null) {
             builder.append("configDescriptions=").append(configDescriptions).append(", ");
         }
+        if (triggers != null) {
+            builder.append("triggers=").append(triggers).append(", ");
+        }
         if (conditions != null) {
             builder.append("conditions=").append(conditions).append(", ");
         }
         if (actions != null) {
-            builder.append("actions=").append(actions).append(", ");
-        }
-        if (triggers != null) {
-            builder.append("triggers=").append(triggers);
+            builder.append("actions=").append(actions);
         }
         builder.append("]");
         return builder.toString();
@@ -447,8 +447,8 @@ public class YamlRuleDTO implements ModularDTO<YamlRuleDTO, ObjectMapper, JsonNo
         @JsonAlias({ "configuration" })
         public Map<@NonNull String, @NonNull Object> config;
         public JsonNode configDescriptions;
+        public JsonNode triggers;
         public JsonNode conditions;
         public JsonNode actions;
-        public JsonNode triggers;
     }
 }

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/rules/YamlRuleTemplateDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/rules/YamlRuleTemplateDTO.java
@@ -62,9 +62,9 @@ public class YamlRuleTemplateDTO
     public String description;
     public Visibility visibility;
     public Map<@NonNull String, @NonNull YamlConfigDescriptionParameterDTO> configDescriptions;
+    public List<@NonNull YamlModuleDTO> triggers;
     public List<@NonNull YamlConditionDTO> conditions;
     public List<@NonNull YamlActionDTO> actions;
-    public List<@NonNull YamlModuleDTO> triggers;
 
     /**
      * Creates a new instance.
@@ -182,21 +182,21 @@ public class YamlRuleTemplateDTO
                 result.configDescriptions = configDescriptions;
             }
 
-            if (partial.actions != null && !partial.actions.isEmpty()) {
-                if (!partial.actions.isArray()) {
-                    throw new SerializationException("Expected actions to be an array node");
+            if (partial.triggers != null && !partial.triggers.isEmpty()) {
+                if (!partial.triggers.isArray()) {
+                    throw new SerializationException("Expected triggers to be an array node");
                 }
-                List<YamlActionDTO> actions = new ArrayList<>(partial.actions.size());
-                JsonNode actionNode;
-                YamlActionDTO action;
-                for (Iterator<JsonNode> iterator = partial.actions.elements(); iterator.hasNext();) {
-                    actionNode = iterator.next();
-                    action = mapper.treeToValue(actionNode, YamlActionDTO.class);
-                    action.type = ModuleTypeAliases.aliasToType(Action.class, action.type);
-                    translateMIMETypeAliases(action);
-                    actions.add(action);
+                List<YamlModuleDTO> triggers = new ArrayList<>(partial.triggers.size());
+                JsonNode triggerNode;
+                YamlModuleDTO trigger;
+                for (Iterator<JsonNode> iterator = partial.triggers.elements(); iterator.hasNext();) {
+                    triggerNode = iterator.next();
+                    trigger = mapper.treeToValue(triggerNode, YamlModuleDTO.class);
+                    trigger.type = ModuleTypeAliases.aliasToType(Trigger.class, trigger.type);
+                    translateMIMETypeAliases(trigger);
+                    triggers.add(trigger);
                 }
-                result.actions = actions;
+                result.triggers = triggers;
             }
             if (partial.conditions != null && !partial.conditions.isEmpty()) {
                 if (!partial.conditions.isArray()) {
@@ -214,21 +214,21 @@ public class YamlRuleTemplateDTO
                 }
                 result.conditions = conditions;
             }
-            if (partial.triggers != null && !partial.triggers.isEmpty()) {
-                if (!partial.triggers.isArray()) {
-                    throw new SerializationException("Expected triggers to be an array node");
+            if (partial.actions != null && !partial.actions.isEmpty()) {
+                if (!partial.actions.isArray()) {
+                    throw new SerializationException("Expected actions to be an array node");
                 }
-                List<YamlModuleDTO> triggers = new ArrayList<>(partial.triggers.size());
-                JsonNode triggerNode;
-                YamlModuleDTO trigger;
-                for (Iterator<JsonNode> iterator = partial.triggers.elements(); iterator.hasNext();) {
-                    triggerNode = iterator.next();
-                    trigger = mapper.treeToValue(triggerNode, YamlModuleDTO.class);
-                    trigger.type = ModuleTypeAliases.aliasToType(Trigger.class, trigger.type);
-                    translateMIMETypeAliases(trigger);
-                    triggers.add(trigger);
+                List<YamlActionDTO> actions = new ArrayList<>(partial.actions.size());
+                JsonNode actionNode;
+                YamlActionDTO action;
+                for (Iterator<JsonNode> iterator = partial.actions.elements(); iterator.hasNext();) {
+                    actionNode = iterator.next();
+                    action = mapper.treeToValue(actionNode, YamlActionDTO.class);
+                    action.type = ModuleTypeAliases.aliasToType(Action.class, action.type);
+                    translateMIMETypeAliases(action);
+                    actions.add(action);
                 }
-                result.triggers = triggers;
+                result.actions = actions;
             }
         } catch (JsonProcessingException | IllegalArgumentException e) {
             throw new SerializationException(e.getMessage(), e);
@@ -380,14 +380,14 @@ public class YamlRuleTemplateDTO
         if (configDescriptions != null) {
             builder.append("configDescriptions=").append(configDescriptions).append(", ");
         }
+        if (triggers != null) {
+            builder.append("triggers=").append(triggers).append(", ");
+        }
         if (conditions != null) {
             builder.append("conditions=").append(conditions).append(", ");
         }
         if (actions != null) {
-            builder.append("actions=").append(actions).append(", ");
-        }
-        if (triggers != null) {
-            builder.append("triggers=").append(triggers);
+            builder.append("actions=").append(actions);
         }
         builder.append("]");
         return builder.toString();
@@ -403,8 +403,8 @@ public class YamlRuleTemplateDTO
         public String description;
         public String visibility;
         public JsonNode configDescriptions;
+        public JsonNode triggers;
         public JsonNode conditions;
         public JsonNode actions;
-        public JsonNode triggers;
     }
 }

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/rules/YamlRuleDTOTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/rules/YamlRuleDTOTest.java
@@ -65,7 +65,7 @@ public class YamlRuleDTOTest {
         YamlRuleDTO ruleDTO = new YamlRuleDTO(rule, RuleSerializationOption.INCLUDE_ALL);
         assertNotNull(ruleDTO);
         assertEquals(
-                "YamlRuleDTO [uid=rule1, templateState=no-template, label=Rule 1, tags=[], visibility=VISIBLE, config={}, configDescriptions={number=YamlConfigDescriptionParameterDTO [required=false, type=DECIMAL, readOnly=false, multiple=false, advanced=false, verify=false, limitToOptions=true, ]}, conditions=[YamlConditionDTO [id=condition1, inputs={}, type=type1, config={}]], actions=[YamlActionDTO [id=action1, inputs={}, type=type1, config={}]], triggers=[YamlModuleDTO [id=trigger1, type=type1, config={}]]]",
+                "YamlRuleDTO [uid=rule1, templateState=no-template, label=Rule 1, tags=[], visibility=VISIBLE, config={}, configDescriptions={number=YamlConfigDescriptionParameterDTO [required=false, type=DECIMAL, readOnly=false, multiple=false, advanced=false, verify=false, limitToOptions=true, ]}, triggers=[YamlModuleDTO [id=trigger1, type=type1, config={}]], conditions=[YamlConditionDTO [id=condition1, inputs={}, type=type1, config={}]], actions=[YamlActionDTO [id=action1, inputs={}, type=type1, config={}]]]",
                 ruleDTO.toString());
 
         rule = RuleBuilder.create(rule).withTemplateUID("templateUID").withActions(List.of())
@@ -73,17 +73,17 @@ public class YamlRuleDTOTest {
         ruleDTO = new YamlRuleDTO(rule, RuleSerializationOption.INCLUDE_ALL);
         assertNotNull(ruleDTO);
         assertEquals(
-                "YamlRuleDTO [uid=rule1, template=templateUID, templateState=no-template, label=Rule 1, tags=[], description=Rule description, visibility=VISIBLE, config={}, configDescriptions={number=YamlConfigDescriptionParameterDTO [required=false, type=DECIMAL, readOnly=false, multiple=false, advanced=false, verify=false, limitToOptions=true, ]}, conditions=[YamlConditionDTO [id=condition1, inputs={}, type=type1, config={}]], triggers=[YamlModuleDTO [id=trigger1, type=type1, config={}]]]",
+                "YamlRuleDTO [uid=rule1, template=templateUID, templateState=no-template, label=Rule 1, tags=[], description=Rule description, visibility=VISIBLE, config={}, configDescriptions={number=YamlConfigDescriptionParameterDTO [required=false, type=DECIMAL, readOnly=false, multiple=false, advanced=false, verify=false, limitToOptions=true, ]}, triggers=[YamlModuleDTO [id=trigger1, type=type1, config={}]], conditions=[YamlConditionDTO [id=condition1, inputs={}, type=type1, config={}]], ]",
                 ruleDTO.toString());
         ruleDTO = new YamlRuleDTO(rule, RuleSerializationOption.NORMAL);
         assertNotNull(ruleDTO);
         assertEquals(
-                "YamlRuleDTO [uid=rule1, template=templateUID, label=Rule 1, description=Rule description, conditions=[YamlConditionDTO [id=condition1, type=type1]], triggers=[YamlModuleDTO [id=trigger1, type=type1]]]",
+                "YamlRuleDTO [uid=rule1, template=templateUID, label=Rule 1, description=Rule description, triggers=[YamlModuleDTO [id=trigger1, type=type1]], conditions=[YamlConditionDTO [id=condition1, type=type1]], ]",
                 ruleDTO.toString());
         ruleDTO = new YamlRuleDTO(rule, RuleSerializationOption.STRIP_TEMPLATE);
         assertNotNull(ruleDTO);
         assertEquals(
-                "YamlRuleDTO [uid=rule1, label=Rule 1, description=Rule description, conditions=[YamlConditionDTO [id=condition1, type=type1]], triggers=[YamlModuleDTO [id=trigger1, type=type1]]]",
+                "YamlRuleDTO [uid=rule1, label=Rule 1, description=Rule description, triggers=[YamlModuleDTO [id=trigger1, type=type1]], conditions=[YamlConditionDTO [id=condition1, type=type1]], ]",
                 ruleDTO.toString());
         ruleDTO = new YamlRuleDTO(rule, RuleSerializationOption.STUB_ONLY);
         assertNotNull(ruleDTO);

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/rules/YamlRuleTemplateDTOTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/rules/YamlRuleTemplateDTOTest.java
@@ -69,12 +69,12 @@ public class YamlRuleTemplateDTOTest {
                 RuleTemplateSerializationOption.INCLUDE_ALL);
         assertNotNull(templateDTO);
         assertEquals(
-                "YamlRuleTemplateDTO [uid=template1, label=Foo Template, tags=[test], description=Foo rule template, visibility=VISIBLE, configDescriptions={number=YamlConfigDescriptionParameterDTO [required=false, type=DECIMAL, readOnly=false, multiple=false, advanced=false, verify=false, limitToOptions=true, ]}, conditions=[YamlConditionDTO [id=condition1, inputs={}, type=type1, config={}]], actions=[YamlActionDTO [id=action1, inputs={}, type=type1, config={}]], triggers=[YamlModuleDTO [id=trigger1, type=type1, config={}]]]",
+                "YamlRuleTemplateDTO [uid=template1, label=Foo Template, tags=[test], description=Foo rule template, visibility=VISIBLE, configDescriptions={number=YamlConfigDescriptionParameterDTO [required=false, type=DECIMAL, readOnly=false, multiple=false, advanced=false, verify=false, limitToOptions=true, ]}, triggers=[YamlModuleDTO [id=trigger1, type=type1, config={}]], conditions=[YamlConditionDTO [id=condition1, inputs={}, type=type1, config={}]], actions=[YamlActionDTO [id=action1, inputs={}, type=type1, config={}]]]",
                 templateDTO.toString());
         templateDTO = new YamlRuleTemplateDTO(template, RuleTemplateSerializationOption.NORMAL);
         assertNotNull(templateDTO);
         assertEquals(
-                "YamlRuleTemplateDTO [uid=template1, label=Foo Template, tags=[test], description=Foo rule template, configDescriptions={number=YamlConfigDescriptionParameterDTO [type=DECIMAL, ]}, conditions=[YamlConditionDTO [id=condition1, type=type1]], actions=[YamlActionDTO [id=action1, type=type1]], triggers=[YamlModuleDTO [id=trigger1, type=type1]]]",
+                "YamlRuleTemplateDTO [uid=template1, label=Foo Template, tags=[test], description=Foo rule template, configDescriptions={number=YamlConfigDescriptionParameterDTO [type=DECIMAL, ]}, triggers=[YamlModuleDTO [id=trigger1, type=type1]], conditions=[YamlConditionDTO [id=condition1, type=type1]], actions=[YamlActionDTO [id=action1, type=type1]]]",
                 templateDTO.toString());
     }
 


### PR DESCRIPTION
I never reflected much about the module order when writing the code, but after having written the documentation, I see the need for a consistent order, and one that matches the order in which these are normally dealt with and in their "natural processing order". When serializing rules and rule templates, the order follows the order in the DTO. This makes YAML rule and rule template module order "triggers-conditions-actions" instead of "conditions-actions-triggers".

I recommend backporting to 5.2, to keep the period these will be generated in an "unnatural" order as short as possible.