### PR TITLE
Fix potential NPE in ScriptTransformationServiceFactory

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationServiceFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationServiceFactory.java
@@ -90,8 +90,11 @@ public class ScriptTransformationServiceFactory {
         }
     }
 
-    private void unregisterService(ComponentInstance<ScriptTransformationService> instance) {
-        instance.getInstance().deactivate();
+    private @NonNullByDefault({}) void unregisterService(ComponentInstance<ScriptTransformationService> instance) {
+        ScriptTransformationService service = instance.getInstance();
+        if (service != null) {
+            service.deactivate();
+        }
         instance.dispose();
     }
 }


### PR DESCRIPTION
The annotations claim that `getInstance()` is `@NonNull`, but that's in fact wrong. I've seen this fail because it *is* `null`, and the Javadoc also confirms that it can be `null`.