### PR TITLE
Prevent ClassCastException in XmlThingTypeProvider

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ThingXmlConfigDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ThingXmlConfigDescriptionProvider.java
@@ -26,7 +26,8 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Simon Kaufmann - Initial contribution
  */
-@Component(service = ConfigDescriptionProvider.class, immediate = true, property = { "openhab.scope=core.xml.thing" })
+@Component(service = { ConfigDescriptionProvider.class,
+        ThingXmlConfigDescriptionProvider.class }, immediate = true, property = { "openhab.scope=core.xml.thing" })
 @NonNullByDefault
 public class ThingXmlConfigDescriptionProvider extends AbstractXmlConfigDescriptionProvider {
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/XmlChannelGroupTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/XmlChannelGroupTypeProvider.java
@@ -35,7 +35,8 @@ import org.osgi.service.component.annotations.Reference;
  * @author Christoph Weitkamp - factored out common aspects into ThingTypeI18nLocalizationService
  */
 @NonNullByDefault
-@Component(property = { "openhab.scope=core.xml.channelGroups" })
+@Component(service = { ChannelGroupTypeProvider.class, XmlChannelGroupTypeProvider.class }, property = {
+        "openhab.scope=core.xml.channelGroups" })
 public class XmlChannelGroupTypeProvider extends AbstractXmlBasedProvider<UID, ChannelGroupType>
         implements ChannelGroupTypeProvider {
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/XmlChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/XmlChannelTypeProvider.java
@@ -38,7 +38,8 @@ import org.osgi.service.component.annotations.Reference;
  * @author Christoph Weitkamp - factored out common aspects into ThingTypeI18nLocalizationService
  */
 @NonNullByDefault
-@Component(property = { "openhab.scope=core.xml.channels" })
+@Component(service = { ChannelTypeProvider.class, XmlChannelTypeProvider.class }, property = {
+        "openhab.scope=core.xml.channels" })
 public class XmlChannelTypeProvider extends AbstractXmlBasedProvider<UID, ChannelType> implements ChannelTypeProvider {
 
     private final ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService;

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/XmlThingTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/XmlThingTypeProvider.java
@@ -21,9 +21,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.ThreadPoolManager;
-import org.openhab.core.config.core.ConfigDescriptionProvider;
 import org.openhab.core.config.core.xml.AbstractXmlBasedProvider;
-import org.openhab.core.config.core.xml.AbstractXmlConfigDescriptionProvider;
 import org.openhab.core.config.core.xml.osgi.XmlDocumentBundleTracker;
 import org.openhab.core.config.core.xml.osgi.XmlDocumentProvider;
 import org.openhab.core.config.core.xml.osgi.XmlDocumentProviderFactory;
@@ -33,8 +31,6 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.UID;
 import org.openhab.core.thing.binding.ThingTypeProvider;
 import org.openhab.core.thing.i18n.ThingTypeI18nLocalizationService;
-import org.openhab.core.thing.type.ChannelGroupTypeProvider;
-import org.openhab.core.thing.type.ChannelTypeProvider;
 import org.openhab.core.thing.type.ThingType;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -66,7 +62,7 @@ public class XmlThingTypeProvider extends AbstractXmlBasedProvider<UID, ThingTyp
     private final ThingTypeI18nLocalizationService thingTypeI18nLocalizationService;
     private final XmlChannelTypeProvider channelTypeProvider;
     private final XmlChannelGroupTypeProvider channelGroupTypeProvider;
-    private final AbstractXmlConfigDescriptionProvider configDescriptionProvider;
+    private final ThingXmlConfigDescriptionProvider configDescriptionProvider;
     private @Nullable XmlDocumentBundleTracker<List<?>> thingTypeTracker;
     private final ReadyService readyService;
     private final ScheduledExecutorService scheduler = ThreadPoolManager
@@ -75,14 +71,14 @@ public class XmlThingTypeProvider extends AbstractXmlBasedProvider<UID, ThingTyp
 
     @Activate
     public XmlThingTypeProvider(
-            final @Reference(target = "(openhab.scope=core.xml.channelGroups)") ChannelGroupTypeProvider channelGroupTypeProvider,
-            final @Reference(target = "(openhab.scope=core.xml.channels)") ChannelTypeProvider channelTypeProvider,
-            final @Reference(target = "(openhab.scope=core.xml.thing)") ConfigDescriptionProvider configDescriptionProvider,
+            final @Reference(target = "(openhab.scope=core.xml.channelGroups)") XmlChannelGroupTypeProvider channelGroupTypeProvider,
+            final @Reference(target = "(openhab.scope=core.xml.channels)") XmlChannelTypeProvider channelTypeProvider,
+            final @Reference(target = "(openhab.scope=core.xml.thing)") ThingXmlConfigDescriptionProvider configDescriptionProvider,
             final @Reference ReadyService readyService,
             final @Reference ThingTypeI18nLocalizationService thingTypeI18nLocalizationService) {
-        this.channelGroupTypeProvider = (XmlChannelGroupTypeProvider) channelGroupTypeProvider;
-        this.channelTypeProvider = (XmlChannelTypeProvider) channelTypeProvider;
-        this.configDescriptionProvider = (AbstractXmlConfigDescriptionProvider) configDescriptionProvider;
+        this.channelGroupTypeProvider = channelGroupTypeProvider;
+        this.channelTypeProvider = channelTypeProvider;
+        this.configDescriptionProvider = configDescriptionProvider;
         this.readyService = readyService;
         this.thingTypeI18nLocalizationService = thingTypeI18nLocalizationService;
     }


### PR DESCRIPTION
This isn't a very common thing to fail, but I've seen it fail. Usually, only the intended implementation use the specific property value that is required. But, add-ons also implements these classes, and if one specifies the same property, one of those instances might be provided by OSGi, and as a result, the casting fails.

Since the goal here seems to be to get the components from the same package, I think it's "cleaner" and safer to actually request the correct type, and avoid the casting altogether.
