### PR TITLE
Fix YAML Thing TEXT configuration parameter processing to support list

### DIFF
--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlThingProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlThingProvider.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -591,61 +592,84 @@ public class YamlThingProvider extends AbstractProvider<Thing>
 
     private Configuration processThingConfiguration(ThingTypeUID thingTypeUID, ThingUID thingUID,
             Configuration configuration) {
-        Set<String> thingStringParams = !configuration.keySet().isEmpty()
-                ? getThingConfigStringParameters(thingTypeUID, thingUID)
+        Set<String> thingTextParams = !configuration.keySet().isEmpty()
+                ? getThingConfigTextParameters(thingTypeUID, thingUID)
                 : Set.of();
-        return processConfiguration(thingUID, configuration, thingStringParams);
+        return processConfiguration(thingUID, configuration, thingTextParams);
     }
 
     private Configuration processChannelConfiguration(@Nullable ChannelTypeUID channelTypeUID, ChannelUID channelUID,
             Configuration configuration) {
-        Set<String> channelStringParams = !configuration.keySet().isEmpty()
-                ? getChannelConfigStringParameters(channelTypeUID, channelUID)
+        Set<String> channelTextParams = !configuration.keySet().isEmpty()
+                ? getChannelConfigTextParameters(channelTypeUID, channelUID)
                 : Set.of();
-        return processConfiguration(channelUID, configuration, channelStringParams);
+        return processConfiguration(channelUID, configuration, channelTextParams);
     }
 
-    private Configuration processConfiguration(UID uid, Configuration configuration, Set<String> stringParameters) {
-        Map<String, Object> params = new HashMap<>();
-
-        configuration.keySet().forEach(name -> {
-            Object valueIn = configuration.get(name);
-            Object valueOut = valueIn;
-            // For configuration parameter of type text only
-            if (stringParameters.contains(name)) {
-                if (valueIn != null && !(valueIn instanceof String)) {
-                    logger.info(
-                            "\"{}\": the value of the configuration TEXT parameter \"{}\" is not interpreted as a string and will be automatically converted. Enclose your value in double quotes to prevent conversion.",
-                            uid, name);
+    private Object processSingleTextParam(UID uid, String name, Object param) {
+        if (param instanceof Number || param instanceof Boolean) {
+            logger.info(
+                    "\"{}\": the value of TEXT configuration parameter \"{}\" has been interpreted as a {}, and will "
+                            + "be converted to a string. Enclose your value in double quotes to prevent conversion.",
+                    uid, name, param instanceof Boolean ? "boolean" : "number");
+            // if the value in YAML is an unquoted number, the value resulting of the parsing can then be
+            // of type BigDecimal or BigInteger.
+            // If the value is of type BigDecimal, we convert it into a String. If there is no decimal,
+            // we convert it to an integer and return a String from that integer.
+            // - Value 1 in YAML is converted into String "1"
+            // - Value 1.0 in YAML is converted into String "1"
+            // - Value 1.5 in YAML is converted into String "1.5"
+            // If the value is not of type BigDecimal, it is kept unchanged. Conversion to a String will
+            // be applied at a next step during configuration normalization.
+            if (param instanceof BigDecimal bigDecimalValue) {
+                try {
+                    Object result = bigDecimalValue.stripTrailingZeros().scale() <= 0
+                            ? String.valueOf(bigDecimalValue.toBigIntegerExact().longValue())
+                            : bigDecimalValue.toString();
+                    logger.trace("config param {}: {} ({}) converted into {} ({})", name, param,
+                            param.getClass().getSimpleName(), result, result.getClass().getSimpleName());
+                    return result;
+                } catch (ArithmeticException e) {
+                    // Ignore error and return the original value
                 }
-                // if the value in YAML is an unquoted number, the value resulting of the parsing can then be
-                // of type BigDecimal or BigInteger.
-                // If the value is of type BigDecimal, we convert it into a String. If there is no decimal,
-                // we convert it to an integer and return a String from that integer.
-                // - Value 1 in YAML is converted into String "1"
-                // - Value 1.0 in YAML is converted into String "1"
-                // - Value 1.5 in YAML is converted into String "1.5"
-                // If the value is not of type BigDecimal, it is kept unchanged. Conversion to a String will
-                // be applied at a next step during configuration normalization.
-                if (valueIn instanceof BigDecimal bigDecimalValue) {
-                    try {
-                        valueOut = bigDecimalValue.stripTrailingZeros().scale() <= 0
-                                ? String.valueOf(bigDecimalValue.toBigIntegerExact().longValue())
-                                : bigDecimalValue.toString();
-                        logger.trace("config param {}: {} ({}) converted into {} ({})", name, valueIn,
-                                valueIn.getClass().getSimpleName(), valueOut, valueOut.getClass().getSimpleName());
-                    } catch (ArithmeticException e) {
-                        // Ignore error and return the original value
+            } else if (param instanceof Boolean bool) {
+                return bool.booleanValue() ? "true" : "false";
+            }
+        }
+        return param;
+    }
+
+    private Configuration processConfiguration(UID uid, Configuration configuration, Set<String> textParameters) {
+        Map<String, Object> params = new HashMap<>();
+        Object value;
+        String name;
+        for (Entry<String, Object> entry : configuration.getProperties().entrySet()) {
+            name = entry.getKey();
+            value = entry.getValue();
+            if (textParameters.contains(name)) {
+                if (value instanceof Iterable<?> iterable) {
+                    List<Object> elements = new ArrayList<>();
+                    for (Object element : iterable) {
+                        elements.add(processSingleTextParam(uid, name, element));
                     }
+                    value = elements;
+                } else if (value instanceof Object && value.getClass().isArray()) {
+                    List<Object> elements = new ArrayList<>();
+                    for (Object element : Arrays.asList((Object[]) value)) {
+                        elements.add(processSingleTextParam(uid, name, element));
+                    }
+                    value = elements;
+                } else {
+                    value = processSingleTextParam(uid, name, value);
                 }
             }
-            params.put(name, valueOut);
-        });
+            params.put(name, value);
+        }
 
         return new Configuration(params);
     }
 
-    private Set<String> getThingConfigStringParameters(ThingTypeUID thingTypeUID, ThingUID thingUID) {
+    private Set<String> getThingConfigTextParameters(ThingTypeUID thingTypeUID, ThingUID thingUID) {
         Set<String> params = new HashSet<>();
 
         ThingType thingType = thingTypeRegistry.getThingType(thingTypeUID);
@@ -655,10 +679,10 @@ public class YamlThingProvider extends AbstractProvider<Thing>
 
         URI descURI = thingType.getConfigDescriptionURI();
         if (descURI != null) {
-            params.addAll(getStringParameters(descURI));
+            params.addAll(getTextParameters(descURI));
         }
         try {
-            params.addAll(getStringParameters(new URI("thing:" + thingUID)));
+            params.addAll(getTextParameters(new URI("thing:" + thingUID)));
         } catch (URISyntaxException e) {
             // Ignore exception, this will never happen with a valid thing UID
         }
@@ -666,8 +690,7 @@ public class YamlThingProvider extends AbstractProvider<Thing>
         return params;
     }
 
-    private Set<String> getChannelConfigStringParameters(@Nullable ChannelTypeUID channelTypeUID,
-            ChannelUID channelUID) {
+    private Set<String> getChannelConfigTextParameters(@Nullable ChannelTypeUID channelTypeUID, ChannelUID channelUID) {
         Set<String> params = new HashSet<>();
 
         ChannelType channelType = channelTypeUID == null ? null : channelTypeRegistry.getChannelType(channelTypeUID);
@@ -677,10 +700,10 @@ public class YamlThingProvider extends AbstractProvider<Thing>
 
         URI descURI = channelType.getConfigDescriptionURI();
         if (descURI != null) {
-            params.addAll(getStringParameters(descURI));
+            params.addAll(getTextParameters(descURI));
         }
         try {
-            params.addAll(getStringParameters(new URI("channel:" + channelUID)));
+            params.addAll(getTextParameters(new URI("channel:" + channelUID)));
         } catch (URISyntaxException e) {
             // Ignore exception, this will never happen with a valid channel UID
         }
@@ -688,7 +711,7 @@ public class YamlThingProvider extends AbstractProvider<Thing>
         return params;
     }
 
-    private Set<String> getStringParameters(URI uri) {
+    private Set<String> getTextParameters(URI uri) {
         Set<String> params = new HashSet<>();
         ConfigDescription configDescription = configDescriptionRegistry.getConfigDescription(uri);
         if (configDescription != null) {

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlThingProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlThingProvider.java
@@ -14,11 +14,11 @@ package org.openhab.core.model.yaml.internal.things;
 
 import static org.openhab.core.model.yaml.YamlModelUtils.isIsolatedModel;
 
+import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -655,8 +655,9 @@ public class YamlThingProvider extends AbstractProvider<Thing>
                     value = elements;
                 } else if (value instanceof Object && value.getClass().isArray()) {
                     List<Object> elements = new ArrayList<>();
-                    for (Object element : Arrays.asList((Object[]) value)) {
-                        elements.add(processSingleTextParam(uid, name, element));
+                    int length = Array.getLength(value);
+                    for (int i = 0; i < length; i++) {
+                        elements.add(processSingleTextParam(uid, name, Array.get(value, i)));
                     }
                     value = elements;
                 } else {

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/things/YamlThingProviderTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/things/YamlThingProviderTest.java
@@ -520,10 +520,10 @@ public class YamlThingProviderTest {
         Files.copy(SOURCE_PATH.resolve("thingWithNumberInTextParam.yaml"), fullModelPath);
         modelRepository.processWatchEvent(WatchService.Kind.CREATE, fullModelPath);
 
-        Collection<Thing> things = thingProvider.getAllFromModel(MODEL_NAME);
+        List<Thing> things = new ArrayList<>(thingProvider.getAllFromModel(MODEL_NAME));
+        things.sort((o1, o2) -> o1.getUID().toString().compareTo(o2.getUID().toString()));
         assertThat(things, hasSize(2));
-        Iterator<Thing> it = things.iterator();
-        Thing thing = it.next();
+        Thing thing = things.get(0);
         assertEquals(NTP_THING_UID, thing.getUID());
 
         assertThat(thing.getConfiguration().keySet(),
@@ -542,7 +542,7 @@ public class YamlThingProviderTest {
         assertThat(channel.getConfiguration().keySet(), contains("DateTimeFormat"));
         assertEquals("123.45", channel.getConfiguration().get("DateTimeFormat"));
 
-        thing = it.next();
+        thing = things.get(1);
         assertEquals(NTP_THING_UID2, thing.getUID());
 
         assertThat(thing.getConfiguration().keySet(),

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/things/YamlThingProviderTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/things/YamlThingProviderTest.java
@@ -129,6 +129,7 @@ public class YamlThingProviderTest {
     private static final String DEFAULT_DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss z";
 
     private static final ThingUID NTP_THING_UID = new ThingUID(NTP_THING_TYPE_UID, "local");
+    private static final ThingUID NTP_THING_UID2 = new ThingUID(NTP_THING_TYPE_UID, "local2");
 
     private @Mock @NonNullByDefault({}) WatchService watchServiceMock;
     private @Mock @NonNullByDefault({}) ReadyService readyServiceMock;
@@ -520,8 +521,9 @@ public class YamlThingProviderTest {
         modelRepository.processWatchEvent(WatchService.Kind.CREATE, fullModelPath);
 
         Collection<Thing> things = thingProvider.getAllFromModel(MODEL_NAME);
-        assertThat(things, hasSize(1));
-        Thing thing = things.iterator().next();
+        assertThat(things, hasSize(2));
+        Iterator<Thing> it = things.iterator();
+        Thing thing = it.next();
         assertEquals(NTP_THING_UID, thing.getUID());
 
         assertThat(thing.getConfiguration().keySet(),
@@ -530,15 +532,34 @@ public class YamlThingProviderTest {
         assertEquals("12.3", thing.getConfiguration().get("timeZone"));
 
         assertEquals(2, thing.getChannels().size());
-        Iterator<Channel> it = thing.getChannels().iterator();
-        Channel channel = it.next();
+        Iterator<Channel> chIt = thing.getChannels().iterator();
+        Channel channel = chIt.next();
         assertEquals(new ChannelUID(NTP_THING_UID, "string"), channel.getUID());
         assertThat(channel.getConfiguration().keySet(), contains("DateTimeFormat"));
         assertEquals("100", channel.getConfiguration().get("DateTimeFormat"));
-        channel = it.next();
+        channel = chIt.next();
         assertEquals(new ChannelUID(NTP_THING_UID, "date-only-string"), channel.getUID());
         assertThat(channel.getConfiguration().keySet(), contains("DateTimeFormat"));
         assertEquals("123.45", channel.getConfiguration().get("DateTimeFormat"));
+
+        thing = it.next();
+        assertEquals(NTP_THING_UID2, thing.getUID());
+
+        assertThat(thing.getConfiguration().keySet(),
+                containsInAnyOrder("hostname", "timeZone", "refreshInterval", "refreshNtp", "serverPort"));
+        assertEquals("false", thing.getConfiguration().get("hostname"));
+        assertEquals("12.3", thing.getConfiguration().get("timeZone"));
+
+        assertEquals(2, thing.getChannels().size());
+        chIt = thing.getChannels().iterator();
+        channel = chIt.next();
+        assertEquals(new ChannelUID(NTP_THING_UID2, "string"), channel.getUID());
+        assertThat(channel.getConfiguration().keySet(), contains("DateTimeFormat"));
+        assertEquals("100", channel.getConfiguration().get("DateTimeFormat"));
+        channel = chIt.next();
+        assertEquals(new ChannelUID(NTP_THING_UID2, "date-only-string"), channel.getUID());
+        assertThat(channel.getConfiguration().keySet(), contains("DateTimeFormat"));
+        assertEquals("true", channel.getConfiguration().get("DateTimeFormat"));
     }
 
     @Test

--- a/bundles/org.openhab.core.model.yaml/src/test/resources/model/things/thingWithNumberInTextParam.yaml
+++ b/bundles/org.openhab.core.model.yaml/src/test/resources/model/things/thingWithNumberInTextParam.yaml
@@ -13,3 +13,16 @@ things:
         type: string-channel
         config:
           DateTimeFormat: 123.45
+  ntp:ntp:local2:
+    config:
+      hostname: false
+      timeZone: 12.3
+    channels:
+      string:
+        type: string-channel
+        config:
+          DateTimeFormat: 100
+      date-only-string:
+        type: string-channel
+        config:
+          DateTimeFormat: true


### PR DESCRIPTION
This is a bugfix turned somewhat into a refactoring.

The problem has come up on the forum [here](https://community.openhab.org/t/configuration-text-parameter-transformationpattern/169729) and [here](https://community.openhab.org/t/yaml-thing-provider-string-conversion-info-message/169664).

Extra logic has been put into `YamlThingProvider` to avoid some common situations where unquoted numbers for `TEXT` configuration parameters will fail because they are deserialized as `Number`, not `String`. Only `BigDecimal` will actually be converted to a string, the rest will fall back on the `toString()` call in the parameter normalization. But, a "warning message" will be logged if the deserialized value isn't a `String`, for example `“mqtt:topic:f06f8352c2:Switches:Garage_Lights_n”: the value of the configuration TEXT parameter “transformationPattern” is not interpreted as a string and will be automatically converted. Enclose your value in double quotes to prevent conversion.`.

The message is basically misplaced because the reason it's not a `String` isn't that it's a `Number` (which is the assumption), but that it's a `List`. It is a `List` because the parameter description defines that `multiple = true`. So, the whole thing is very confusing to users who think they need to quote something, but can't understand what (quoting an array element won't make a difference).

There is a similar situation with boolean values that isn't handled.

I've changed all this in this PR. The processing now correctly "warns" if there's an unquoted number or boolean in a `TEXT` parameter, converting as necessary, while also handling collections and arrays (I don't think arrays can occur because I think YAML always deserializes to `List`s, but it can't hurt to handle it if one should appear). It will iterate through collections/arrays and process each parameter.

I've added the boolean case to the tests, but not the collection/array case, because I couldn't think of a `ThingType` that has a `TEXT` parameter type with multiple entries, except for the MQTT types that I know way too little about to use. I have tested it manually and verified that it does work though.

@lolodomo I guess you want to take a look at this.