### PR TITLE
Replace remote‑addon ExpiringCache with explicit refresh to avoid expiry‑induced UI stalls

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
@@ -15,17 +15,16 @@ package org.openhab.core.addon.marketplace;
 import static org.openhab.core.common.ThreadPoolManager.THREAD_POOL_NAME_COMMON;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Dictionary;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -37,7 +36,6 @@ import org.openhab.core.addon.AddonInfo;
 import org.openhab.core.addon.AddonInfoRegistry;
 import org.openhab.core.addon.AddonService;
 import org.openhab.core.addon.AddonType;
-import org.openhab.core.cache.ExpiringCache;
 import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.config.core.ConfigParser;
 import org.openhab.core.events.Event;
@@ -86,15 +84,14 @@ public abstract class AbstractRemoteAddonService implements AddonService {
     protected final BundleVersion coreVersion;
 
     protected final Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").create();
-    protected final Set<MarketplaceAddonHandler> addonHandlers = new HashSet<>();
+    protected final Set<MarketplaceAddonHandler> addonHandlers = new CopyOnWriteArraySet<>();
     protected final Storage<String> installedAddonStorage;
     protected final EventPublisher eventPublisher;
     protected final ConfigurationAdmin configurationAdmin;
-    protected final ExpiringCache<List<Addon>> cachedRemoteAddons = new ExpiringCache<>(Duration.ofMinutes(15),
-            this::getRemoteAddons);
+    protected volatile List<Addon> cachedRemoteAddons = List.of();
     protected final AddonInfoRegistry addonInfoRegistry;
-    protected List<Addon> cachedAddons = List.of();
-    protected List<String> installedAddonIds = List.of();
+    protected volatile List<Addon> cachedAddons = List.of();
+    protected volatile List<String> installedAddonIds = List.of();
 
     private final Logger logger = LoggerFactory.getLogger(AbstractRemoteAddonService.class);
     private final ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool(THREAD_POOL_NAME_COMMON);
@@ -124,10 +121,10 @@ public abstract class AbstractRemoteAddonService implements AddonService {
 
     @Override
     public void refreshSource() {
-        refreshSource(false);
+        refreshSource(true);
     }
 
-    private void refreshSource(boolean installedOnly) {
+    private synchronized void refreshSource(boolean fetchRemoteAddons) {
         if (!addonHandlers.stream().allMatch(MarketplaceAddonHandler::isReady)) {
             logger.debug("Add-on service '{}' tried to refresh source before add-on handlers ready. Exiting.",
                     getClass());
@@ -149,7 +146,7 @@ public abstract class AbstractRemoteAddonService implements AddonService {
             logger.error(
                     "Failed to read JSON database, trying to purge it. You might need to re-install {} from the '{}' service.",
                     installedAddonStorage.getKeys(), getId());
-            refreshSource(installedOnly);
+            refreshSource(fetchRemoteAddons);
             return;
         }
 
@@ -162,12 +159,16 @@ public abstract class AbstractRemoteAddonService implements AddonService {
         List<String> currentAddonIds = addons.stream().map(Addon::getUid).toList();
 
         // get the remote addons
-        if (!installedOnly && remoteEnabled()) {
-            List<Addon> remoteAddons = Objects.requireNonNullElse(cachedRemoteAddons.getValue(), List.of());
-            remoteAddons.stream().filter(a -> !currentAddonIds.contains(a.getUid())).forEach(addon -> {
+        if (remoteEnabled()) {
+            if (fetchRemoteAddons || cachedRemoteAddons.isEmpty()) {
+                cachedRemoteAddons = List.copyOf(getRemoteAddons());
+            }
+            cachedRemoteAddons.stream().filter(a -> !currentAddonIds.contains(a.getUid())).forEach(addon -> {
                 setInstalled(addon);
                 addons.add(addon);
             });
+        } else if (!cachedRemoteAddons.isEmpty()) {
+            cachedRemoteAddons = List.of();
         }
 
         // remove incompatible add-ons if not enabled
@@ -183,10 +184,10 @@ public abstract class AbstractRemoteAddonService implements AddonService {
             }
         }
 
-        cachedAddons = addons;
+        cachedAddons = List.copyOf(addons);
         this.installedAddonIds = currentAddonIds;
 
-        if (!installedOnly && !missingAddons.isEmpty()) {
+        if (!missingAddons.isEmpty()) {
             logger.info("Re-installing missing add-ons from remote repository: {}", missingAddons);
             scheduler.execute(() -> missingAddons.forEach(this::install));
         }
@@ -232,12 +233,6 @@ public abstract class AbstractRemoteAddonService implements AddonService {
     }
 
     @Override
-    public List<Addon> getAddons(@Nullable Locale locale, boolean installedOnly) {
-        refreshSource(installedOnly);
-        return cachedAddons;
-    }
-
-    @Override
     public List<AddonType> getTypes(@Nullable Locale locale) {
         return AddonType.DEFAULT_TYPES;
     }
@@ -256,8 +251,7 @@ public abstract class AbstractRemoteAddonService implements AddonService {
                         handler.install(addon);
                         addon.setInstalled(true);
                         installedAddonStorage.put(id, gson.toJson(addon));
-                        cachedRemoteAddons.invalidateValue();
-                        refreshSource();
+                        refreshSource(false);
                         postInstalledEvent(addon.getUid());
                     } catch (MarketplaceHandlerException e) {
                         postFailureEvent(addon.getUid(), e.getMessage());
@@ -284,8 +278,7 @@ public abstract class AbstractRemoteAddonService implements AddonService {
                     try {
                         handler.uninstall(addon);
                         installedAddonStorage.remove(id);
-                        cachedRemoteAddons.invalidateValue();
-                        refreshSource();
+                        refreshSource(false);
                         postUninstalledEvent(addon.getUid());
                     } catch (MarketplaceHandlerException e) {
                         postFailureEvent(addon.getUid(), e.getMessage());

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
@@ -126,7 +126,6 @@ public class CommunityMarketplaceAddonService extends AbstractRemoteAddonService
             this.showUnpublished = ConfigParser.valueAsOrElse(config.get(CONFIG_SHOW_UNPUBLISHED_ENTRIES_KEY),
                     Boolean.class, false);
             this.enabled = ConfigParser.valueAsOrElse(config.get(CONFIG_ENABLED_KEY), Boolean.class, true);
-            cachedRemoteAddons.invalidateValue();
             refreshSource();
         }
     }

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
@@ -95,7 +95,6 @@ public class JsonAddonService extends AbstractRemoteAddonService {
             String urls = ConfigParser.valueAsOrElse(config.get(CONFIG_URLS), String.class, "");
             addonServiceUrls = Arrays.asList(urls.split("\\|")).stream().filter(this::isValidUrl).toList();
             showUnstable = ConfigParser.valueAsOrElse(config.get(CONFIG_SHOW_UNSTABLE), Boolean.class, false);
-            cachedRemoteAddons.invalidateValue();
             refreshSource();
         }
     }

--- a/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonServiceTest.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonServiceTest.java
@@ -128,7 +128,7 @@ public class AbstractRemoteAddonServiceTest {
     }
 
     @Test
-    public void testInstalledAddonIsStillPresentAfterRemoteIsDisabledOrMissing() {
+    public void testInstalledAddonIsStillPresentAfterRemoteIsDisabledOrMissingAfterRefresh() {
         addonService.setInstalled(TEST_ADDON);
         addonService.addToStorage(TEST_ADDON);
 
@@ -139,22 +139,13 @@ public class AbstractRemoteAddonServiceTest {
         // disable remote repo
         properties.put(CONFIG_REMOTE_ENABLED, false);
 
+        // force refresh after changing settings
+        addonService.refreshSource();
+
         // check only the installed addon is present
         addons = addonService.getAddons(null);
         assertThat(addons, hasSize(1));
         assertThat(addons.getFirst().getUid(), is(getFullAddonId(TEST_ADDON)));
-    }
-
-    @Test
-    public void testInstalledOnlyAddonsDoNotTriggerRemoteLookup() {
-        addonService.setInstalled(TEST_ADDON);
-        addonService.addToStorage(TEST_ADDON);
-
-        List<Addon> addons = addonService.getAddons(null, true);
-        assertThat(addons, hasSize(1));
-        assertThat(addons.getFirst().getUid(), is(getFullAddonId(TEST_ADDON)));
-        assertThat(addons.getFirst().isInstalled(), is(true));
-        assertThat(addonService.getRemoteCalls(), is(0));
     }
 
     @Test

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonService.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonService.java
@@ -64,22 +64,6 @@ public interface AddonService {
     List<Addon> getAddons(@Nullable Locale locale);
 
     /**
-     * Retrieves add-ons, optionally restricted to installed ones only.
-     *
-     * Implementations that can avoid remote lookups when {@code installedOnly} is {@code true} should do so.
-     *
-     * @param locale the locale to use for the result
-     * @param installedOnly {@code true} to return only installed add-ons
-     * @return the localized add-ons
-     */
-    default List<Addon> getAddons(@Nullable Locale locale, boolean installedOnly) {
-        if (installedOnly) {
-            return getAddons(locale).stream().filter(Addon::isInstalled).toList();
-        }
-        return getAddons(locale);
-    }
-
-    /**
      * Retrieves the add-on for the given id.
      *
      * @param id the id of the add-on

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
@@ -156,22 +156,35 @@ public class AddonResource implements RESTResource {
     public Response getAddon(
             @HeaderParam("Accept-Language") @Parameter(description = "language") @Nullable String language,
             @QueryParam("serviceId") @Parameter(description = "service ID") @Nullable String serviceId,
-            @QueryParam("installedOnly") @Parameter(description = "true to return only installed add-ons") @Nullable Boolean installedOnly) {
+            @QueryParam("installedOnly") @Parameter(description = "true to return only installed add-ons") @Nullable Boolean installedOnly,
+            @QueryParam("refresh") @Parameter(description = "true to refresh add-ons before returning them") @Nullable Boolean refresh) {
         logger.debug("Received HTTP GET request at '{}'", uriInfo.getPath());
 
         final Locale locale = localeService.getLocale(language);
+        boolean forceRefresh = Boolean.TRUE.equals(refresh);
 
+        Stream<Addon> addons;
         if ("all".equals(serviceId)) {
-            return Response.ok(new Stream2JSONInputStream(getAllAddons(locale, Boolean.TRUE.equals(installedOnly))))
-                    .build();
+            if (forceRefresh) {
+                addonServices.forEach(AddonService::refreshSource);
+            }
+            addons = getAllAddons(locale);
         } else {
             AddonService addonService = (serviceId != null) ? getServiceById(serviceId) : getDefaultService();
             if (addonService == null) {
                 return Response.status(HttpStatus.NOT_FOUND_404).build();
             }
-            return Response.ok(new Stream2JSONInputStream(
-                    addonService.getAddons(locale, Boolean.TRUE.equals(installedOnly)).stream())).build();
+            if (forceRefresh) {
+                addonService.refreshSource();
+            }
+            addons = addonService.getAddons(locale).stream();
         }
+
+        if (Boolean.TRUE.equals(installedOnly)) {
+            addons = addons.filter(Addon::isInstalled);
+        }
+
+        return Response.ok(new Stream2JSONInputStream(addons)).build();
     }
 
     @GET
@@ -416,8 +429,8 @@ public class AddonResource implements RESTResource {
                 .findFirst().orElse(addonServices.stream().findFirst().orElse(null));
     }
 
-    private Stream<Addon> getAllAddons(Locale locale, boolean installedOnly) {
-        return addonServices.stream().map(s -> s.getAddons(locale, installedOnly)).flatMap(Collection::stream);
+    private Stream<Addon> getAllAddons(Locale locale) {
+        return addonServices.stream().map(s -> s.getAddons(locale)).flatMap(Collection::stream);
     }
 
     private Set<AddonType> getAllAddonTypes(Locale locale) {


### PR DESCRIPTION
The automatic 15‑minute cache expiry occasionally caused slow or stalled marketplace addon loads. Users can now request a refresh on demand, ensuring predictable behaviour and consistently responsive UI performance.

