### PR TITLE
Set system property to run GraalVM Truffle on unsupported platforms

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/Activator.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/Activator.java
@@ -38,6 +38,10 @@ public final class Activator implements BundleActivator {
     @Override
     public void start(@Nullable BundleContext bc) throws Exception {
         logger.info("Starting openHAB {} ({})", OpenHAB.getVersion(), OpenHAB.buildString());
+
+        // Enable GraalVM Truffle to run on unsupported platforms, e.g., BSD
+        System.setProperty("polyglot.engine.allowUnsupportedPlatform", "true");
+
         ServiceReference<ConfigurationAdmin> ref;
         if (bc != null && (ref = bc.getServiceReference(ConfigurationAdmin.class)) != null) {
             ConfigurationAdmin ca = bc.getService(ref);


### PR DESCRIPTION
Refs https://github.com/openhab/openhab-addons/issues/19276.