### PR TITLE
Fix chart not being rendered if item has no label

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/DefaultChartProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/DefaultChartProvider.java
@@ -328,7 +328,7 @@ public class DefaultChartProvider implements ChartProvider {
 
         // Get the item label
         String label = itemUIRegistry.getLabel(item.getName());
-        if (label == null) {
+        if (label == null || label.isEmpty()) {
             label = item.getName();
         } else if (label.contains("[") && label.contains("]")) {
             label = label.substring(0, label.indexOf('['));


### PR DESCRIPTION
XCharts is unhappy about an empty series name (see [1]), so use the item name in that case.

Originally reported in https://github.com/openhab/openhab-android/issues/3983

[1] https://github.com/knowm/XChart/blob/5ae95dbafa68cf246d6df105a3e7a6f2361bf6c9/xchart/src/main/java/org/knowm/xchart/internal/series/Series.java#L31
