### PR TITLE
Fix chart not being rendered if item has a label with state only

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/DefaultChartProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/DefaultChartProvider.java
@@ -328,10 +328,11 @@ public class DefaultChartProvider implements ChartProvider {
 
         // Get the item label
         String label = itemUIRegistry.getLabel(item.getName());
+        if (label != null && label.contains("[") && label.contains("]")) {
+            label = label.substring(0, label.indexOf('['));
+        }
         if (label == null || label.isEmpty()) {
             label = item.getName();
-        } else if (label.contains("[") && label.contains("]")) {
-            label = label.substring(0, label.indexOf('['));
         }
 
         Iterable<HistoricItem> result;


### PR DESCRIPTION
XCharts is unhappy about an empty series name. #5722 fixed the case where the label is empty to begin with, but omitted the case where the item label consists only of state (e.g. "[0 %]"). Extend the item name fallback to that case as well.
