### PR TITLE
Add rule start level condition

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/factory/CoreModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/factory/CoreModuleHandlerFactory.java
@@ -37,6 +37,7 @@ import org.openhab.core.automation.internal.module.handler.ItemStateTriggerHandl
 import org.openhab.core.automation.internal.module.handler.ItemStateUpdateActionHandler;
 import org.openhab.core.automation.internal.module.handler.RuleEnablementActionHandler;
 import org.openhab.core.automation.internal.module.handler.RunRuleActionHandler;
+import org.openhab.core.automation.internal.module.handler.SystemConditionHandler;
 import org.openhab.core.automation.internal.module.handler.SystemTriggerHandler;
 import org.openhab.core.automation.internal.module.handler.ThingStatusConditionHandler;
 import org.openhab.core.automation.internal.module.handler.ThingStatusTriggerHandler;
@@ -75,7 +76,8 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory implement
             ItemStateUpdateActionHandler.ITEM_STATE_UPDATE_ACTION, GenericEventTriggerHandler.MODULE_TYPE_ID,
             ChannelEventTriggerHandler.MODULE_TYPE_ID, GenericEventConditionHandler.MODULETYPE_ID,
             GenericEventConditionHandler.MODULETYPE_ID, CompareConditionHandler.MODULE_TYPE,
-            SystemTriggerHandler.STARTLEVEL_MODULE_TYPE_ID, RuleEnablementActionHandler.UID, RunRuleActionHandler.UID);
+            SystemConditionHandler.STARTLEVEL_MODULE_TYPE_ID, SystemTriggerHandler.STARTLEVEL_MODULE_TYPE_ID,
+            RuleEnablementActionHandler.UID, RunRuleActionHandler.UID);
 
     private final ThingRegistry thingRegistry;
     private final ItemRegistry itemRegistry;
@@ -143,6 +145,8 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory implement
                 return new GenericEventConditionHandler(condition);
             } else if (CompareConditionHandler.MODULE_TYPE.equals(moduleTypeUID)) {
                 return new CompareConditionHandler(condition);
+            } else if (SystemConditionHandler.STARTLEVEL_MODULE_TYPE_ID.equals(moduleTypeUID)) {
+                return new SystemConditionHandler(condition, startLevelService);
             }
         } else if (module instanceof Action action) {
             // Handle actions

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/factory/CoreModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/factory/CoreModuleHandlerFactory.java
@@ -75,9 +75,8 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory implement
             ItemStateConditionHandler.ITEM_STATE_CONDITION, ItemCommandActionHandler.ITEM_COMMAND_ACTION,
             ItemStateUpdateActionHandler.ITEM_STATE_UPDATE_ACTION, GenericEventTriggerHandler.MODULE_TYPE_ID,
             ChannelEventTriggerHandler.MODULE_TYPE_ID, GenericEventConditionHandler.MODULETYPE_ID,
-            GenericEventConditionHandler.MODULETYPE_ID, CompareConditionHandler.MODULE_TYPE,
-            SystemConditionHandler.STARTLEVEL_MODULE_TYPE_ID, SystemTriggerHandler.STARTLEVEL_MODULE_TYPE_ID,
-            RuleEnablementActionHandler.UID, RunRuleActionHandler.UID);
+            CompareConditionHandler.MODULE_TYPE, SystemConditionHandler.STARTLEVEL_MODULE_TYPE_ID,
+            SystemTriggerHandler.STARTLEVEL_MODULE_TYPE_ID, RuleEnablementActionHandler.UID, RunRuleActionHandler.UID);
 
     private final ThingRegistry thingRegistry;
     private final ItemRegistry itemRegistry;

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/SystemConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/SystemConditionHandler.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.internal.module.handler;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.automation.Condition;
+import org.openhab.core.automation.handler.BaseConditionModuleHandler;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.service.StartLevelService;
+
+/**
+ * This is a ModuleHandler implementation for system state conditions.
+ *
+ * @author Ravi Nadahar - Initial contribution
+ */
+@NonNullByDefault
+public class SystemConditionHandler extends BaseConditionModuleHandler {
+
+    public static final String STARTLEVEL_MODULE_TYPE_ID = "core.SystemStartlevelCondition";
+    public static final String CFG_MIN_STARTLEVEL = "minStartlevel";
+
+    /**
+     * The minimum startlevel.
+     */
+    private final int minStartlevel;
+    private final StartLevelService startLevelService;
+
+    public SystemConditionHandler(Condition condition, StartLevelService startLevelService) {
+        super(condition);
+        this.startLevelService = startLevelService;
+        Configuration configuration = module.getConfiguration();
+        this.minStartlevel = ((Number) configuration.get(CFG_MIN_STARTLEVEL)).intValue();
+    }
+
+    @Override
+    public boolean isSatisfied(Map<String, Object> inputs) {
+        return startLevelService.getStartLevel() >= minStartlevel;
+    }
+}

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/SystemConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/SystemConditionHandler.java
@@ -37,11 +37,23 @@ public class SystemConditionHandler extends BaseConditionModuleHandler {
     private final int minStartlevel;
     private final StartLevelService startLevelService;
 
-    public SystemConditionHandler(Condition condition, StartLevelService startLevelService) {
+    /**
+     * Creates a new system start level condition instance.
+     *
+     * @param condition the {@link Condition} module instance.
+     * @param startLevelService the {@link StartLevelService} to use.
+     * @throws IllegalArgumentException If {@value #CFG_MIN_STARTLEVEL} isn't a valid integer.
+     */
+    public SystemConditionHandler(Condition condition, StartLevelService startLevelService)
+            throws IllegalArgumentException {
         super(condition);
         this.startLevelService = startLevelService;
-        Configuration configuration = module.getConfiguration();
-        this.minStartlevel = ((Number) configuration.get(CFG_MIN_STARTLEVEL)).intValue();
+        try {
+            Configuration configuration = module.getConfiguration();
+            this.minStartlevel = ((Number) configuration.get(CFG_MIN_STARTLEVEL)).intValue();
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException("'" + CFG_MIN_STARTLEVEL + "' parameter must be an integer value.", e);
+        }
     }
 
     @Override

--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/StartlevelCondition.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/StartlevelCondition.json
@@ -1,0 +1,41 @@
+{
+	"conditions": [
+		{
+			"uid": "core.SystemStartlevelCondition",
+			"label": "a system start level has been reached",
+			"description": "Checks if the specified system start level has been reached.",
+			"configDescriptions": [
+				{
+					"name": "minStartlevel",
+					"type": "INTEGER",
+					"label": "Minimum Start Level",
+					"description": "Returns true if the system has reached this start level.",
+					"required": true,
+					"default": 80,
+					"options": [
+						{
+							"label": "40 - Rules loaded",
+							"value": 40
+						},
+						{
+							"label": "50 - Rule engine started",
+							"value": 50
+						},
+						{
+							"label": "70 - User interfaces started",
+							"value": 70
+						},
+						{
+							"label": "80 - Things initialized",
+							"value": 80
+						},
+						{
+							"label": "100 - Startup complete",
+							"value": 100
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/i18n/automation.properties
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/i18n/automation.properties
@@ -275,6 +275,18 @@ module-type.core.RunRuleAction.config.considerConditions.description = Specifies
 module-type.core.RunRuleAction.config.considerConditions.option.true = Yes
 module-type.core.RunRuleAction.config.considerConditions.option.false = No
 
+# core.SystemStartlevelCondition
+
+module-type.core.SystemStartlevelCondition.label = a system start level has been reached
+module-type.core.SystemStartlevelCondition.description = Checks if the specified system start level has been reached.
+module-type.core.SystemStartlevelCondition.config.minStartlevel.label = Minimum Start Level
+module-type.core.SystemStartlevelCondition.config.minStartlevel.description = Returns true if the system has reached this start level.
+module-type.core.SystemStartlevelCondition.config.minStartlevel.option.40 = 40 - Rules loaded
+module-type.core.SystemStartlevelCondition.config.minStartlevel.option.50 = 50 - Rule engine started
+module-type.core.SystemStartlevelCondition.config.minStartlevel.option.70 = 70 - User interfaces started
+module-type.core.SystemStartlevelCondition.config.minStartlevel.option.80 = 80 - Things initialized
+module-type.core.SystemStartlevelCondition.config.minStartlevel.option.100 = 100 - Startup complete
+
 # core.SystemStartlevelTrigger
 
 module-type.core.SystemStartlevelTrigger.label = a system start level is reached

--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
@@ -50,6 +50,7 @@ import org.openhab.core.automation.internal.module.handler.IntervalConditionHand
 import org.openhab.core.automation.internal.module.handler.ItemCommandTriggerHandler;
 import org.openhab.core.automation.internal.module.handler.ItemStateConditionHandler;
 import org.openhab.core.automation.internal.module.handler.ItemStateTriggerHandler;
+import org.openhab.core.automation.internal.module.handler.SystemConditionHandler;
 import org.openhab.core.automation.internal.module.handler.SystemTriggerHandler;
 import org.openhab.core.automation.internal.module.handler.ThingStatusConditionHandler;
 import org.openhab.core.automation.internal.module.handler.ThingStatusTriggerHandler;
@@ -83,6 +84,7 @@ import org.openhab.core.model.rule.rules.ItemStateCondition;
 import org.openhab.core.model.rule.rules.RuleModel;
 import org.openhab.core.model.rule.rules.SystemOnShutdownTrigger;
 import org.openhab.core.model.rule.rules.SystemOnStartupTrigger;
+import org.openhab.core.model.rule.rules.SystemStartlevelCondition;
 import org.openhab.core.model.rule.rules.SystemStartlevelTrigger;
 import org.openhab.core.model.rule.rules.ThingStateChangedEventTrigger;
 import org.openhab.core.model.rule.rules.ThingStateUpdateEventTrigger;
@@ -613,6 +615,11 @@ public class DSLRuleProvider
                 cfg.put(IntervalConditionHandler.CFG_MIN_INTERVAL, intervalCond.getInterval());
                 yield ConditionBuilder.create().withId(Integer.toString(triggerId++))
                         .withTypeUID(IntervalConditionHandler.MODULE_TYPE_ID).withConfiguration(cfg).build();
+            }
+            case SystemStartlevelCondition startlevelCond -> {
+                cfg.put(SystemConditionHandler.CFG_MIN_STARTLEVEL, startlevelCond.getLevel());
+                yield ConditionBuilder.create().withId(Integer.toString(triggerId++))
+                        .withTypeUID(SystemConditionHandler.STARTLEVEL_MODULE_TYPE_ID).withConfiguration(cfg).build();
             }
             case ThingStatusCondition tsCond -> {
                 cfg.put(ThingStatusConditionHandler.CFG_THING_UID, tsCond.getThing());

--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/converter/DslRuleConverter.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/converter/DslRuleConverter.java
@@ -58,6 +58,7 @@ import org.openhab.core.automation.internal.module.handler.IntervalConditionHand
 import org.openhab.core.automation.internal.module.handler.ItemCommandTriggerHandler;
 import org.openhab.core.automation.internal.module.handler.ItemStateConditionHandler;
 import org.openhab.core.automation.internal.module.handler.ItemStateTriggerHandler;
+import org.openhab.core.automation.internal.module.handler.SystemConditionHandler;
 import org.openhab.core.automation.internal.module.handler.SystemTriggerHandler;
 import org.openhab.core.automation.internal.module.handler.ThingStatusConditionHandler;
 import org.openhab.core.automation.internal.module.handler.ThingStatusTriggerHandler;
@@ -85,6 +86,7 @@ import org.openhab.core.model.rule.rules.IntervalCondition;
 import org.openhab.core.model.rule.rules.ItemStateCondition;
 import org.openhab.core.model.rule.rules.RuleModel;
 import org.openhab.core.model.rule.rules.RulesFactory;
+import org.openhab.core.model.rule.rules.SystemStartlevelCondition;
 import org.openhab.core.model.rule.rules.SystemStartlevelTrigger;
 import org.openhab.core.model.rule.rules.ThingStateChangedEventTrigger;
 import org.openhab.core.model.rule.rules.ThingStateUpdateEventTrigger;
@@ -774,6 +776,15 @@ public class DslRuleConverter implements RuleSerializer, RuleParser {
                     throw new SerializationException("Invalid condition: " + condition);
                 }
                 return ivCond;
+            case SystemConditionHandler.STARTLEVEL_MODULE_TYPE_ID:
+                SystemStartlevelCondition slCond = factory.createSystemStartlevelCondition();
+                value = condition.getConfiguration().get(SystemConditionHandler.CFG_MIN_STARTLEVEL);
+                if (value instanceof Number startlevel) {
+                    slCond.setLevel(startlevel.intValue());
+                } else {
+                    throw new SerializationException("Invalid condition: " + condition);
+                }
+                return slCond;
             case ThingStatusConditionHandler.THING_STATUS_CONDITION:
                 ThingStatusCondition tsCond = factory.createThingStatusCondition();
                 value = condition.getConfiguration().get(ThingStatusConditionHandler.CFG_THING_UID);

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/Rules.xtext
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/Rules.xtext
@@ -107,6 +107,7 @@ Condition:
 	HolidayCondition |
 	InDaysetCondition |
 	IntervalCondition |
+	SystemStartlevelCondition |
 	ThingStatusCondition |
 	ItemStateCondition
 ;
@@ -133,6 +134,10 @@ InDaysetCondition:
 
 IntervalCondition:
 	interval=INT 'ms' 'between' 'executions'
+;
+
+SystemStartlevelCondition:
+	'System' 'start level is at least' level=INT
 ;
 
 ThingStatusCondition:

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/rules/ModuleTypeAliases.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/rules/ModuleTypeAliases.java
@@ -37,6 +37,7 @@ import org.openhab.core.automation.internal.module.handler.ItemStateTriggerHandl
 import org.openhab.core.automation.internal.module.handler.ItemStateUpdateActionHandler;
 import org.openhab.core.automation.internal.module.handler.RuleEnablementActionHandler;
 import org.openhab.core.automation.internal.module.handler.RunRuleActionHandler;
+import org.openhab.core.automation.internal.module.handler.SystemConditionHandler;
 import org.openhab.core.automation.internal.module.handler.SystemTriggerHandler;
 import org.openhab.core.automation.internal.module.handler.ThingStatusConditionHandler;
 import org.openhab.core.automation.internal.module.handler.ThingStatusTriggerHandler;
@@ -73,6 +74,7 @@ public class ModuleTypeAliases {
                 { "C", "Dayset", EphemerisConditionHandler.DAYSET_MODULE_TYPE_ID }, //
                 { "C", "Holiday", EphemerisConditionHandler.HOLIDAY_MODULE_TYPE_ID }, //
                 { "C", "Interval", IntervalConditionHandler.MODULE_TYPE_ID }, //
+                { "C", "StartLevel", SystemConditionHandler.STARTLEVEL_MODULE_TYPE_ID }, //
                 { "C", "ItemState", ItemStateConditionHandler.ITEM_STATE_CONDITION }, //
                 { "C", "NotHoliday", EphemerisConditionHandler.NOT_HOLIDAY_MODULE_TYPE_ID }, //
                 { "C", "Script", ScriptConditionHandler.TYPE_ID }, //

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/rules/ModuleTypeAliasesTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/rules/ModuleTypeAliasesTest.java
@@ -45,6 +45,7 @@ public class ModuleTypeAliasesTest {
         assertThat(ModuleTypeAliases.aliasToType(Condition.class, "Dayset"), is("ephemeris.DaysetCondition"));
         assertThat(ModuleTypeAliases.aliasToType(Condition.class, "Holiday"), is("ephemeris.HolidayCondition"));
         assertThat(ModuleTypeAliases.aliasToType(Condition.class, "Interval"), is("timer.IntervalCondition"));
+        assertThat(ModuleTypeAliases.aliasToType(Condition.class, "StartLevel"), is("core.SystemStartlevelCondition"));
         assertThat(ModuleTypeAliases.aliasToType(Condition.class, "ItemState"), is("core.ItemStateCondition"));
         assertThat(ModuleTypeAliases.aliasToType(Condition.class, "NotHoliday"), is("ephemeris.NotHolidayCondition"));
         assertThat(ModuleTypeAliases.aliasToType(Condition.class, "Script"), is("script.ScriptCondition"));
@@ -84,6 +85,7 @@ public class ModuleTypeAliasesTest {
         assertThat(ModuleTypeAliases.typeToAlias(Condition.class, "ephemeris.DaysetCondition"), is("Dayset"));
         assertThat(ModuleTypeAliases.typeToAlias(Condition.class, "ephemeris.HolidayCondition"), is("Holiday"));
         assertThat(ModuleTypeAliases.typeToAlias(Condition.class, "timer.IntervalCondition"), is("Interval"));
+        assertThat(ModuleTypeAliases.typeToAlias(Condition.class, "core.SystemStartlevelCondition"), is("StartLevel"));
         assertThat(ModuleTypeAliases.typeToAlias(Condition.class, "core.ItemStateCondition"), is("ItemState"));
         assertThat(ModuleTypeAliases.typeToAlias(Condition.class, "ephemeris.NotHolidayCondition"), is("NotHoliday"));
         assertThat(ModuleTypeAliases.typeToAlias(Condition.class, "script.ScriptCondition"), is("Script"));

--- a/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/handler/SystemConditionHandlerTest.java
+++ b/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/handler/SystemConditionHandlerTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.internal.module.handler;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.automation.Action;
+import org.openhab.core.automation.Condition;
+import org.openhab.core.automation.Rule;
+import org.openhab.core.automation.RuleManager;
+import org.openhab.core.automation.RuleRegistry;
+import org.openhab.core.automation.RuleStatus;
+import org.openhab.core.automation.RuleStatusInfo;
+import org.openhab.core.automation.Trigger;
+import org.openhab.core.automation.internal.RuleEngineImpl;
+import org.openhab.core.automation.internal.module.factory.CoreModuleHandlerFactory;
+import org.openhab.core.automation.type.ModuleTypeRegistry;
+import org.openhab.core.automation.util.ModuleBuilder;
+import org.openhab.core.automation.util.RuleBuilder;
+import org.openhab.core.common.registry.ProviderChangeListener;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.events.Event;
+import org.openhab.core.events.EventPublisher;
+import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.i18n.TimeZoneProvider;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemProvider;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.events.ItemCommandEvent;
+import org.openhab.core.items.events.ItemEventFactory;
+import org.openhab.core.library.items.SwitchItem;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.service.ReadyMarker;
+import org.openhab.core.service.StartLevelService;
+import org.openhab.core.test.java.JavaOSGiTest;
+import org.openhab.core.test.storage.VolatileStorageService;
+import org.openhab.core.thing.ThingRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This tests the system conditions.
+ *
+ * @author Ravi Nadahar - Initial contribution
+ */
+@NonNullByDefault
+public class SystemConditionHandlerTest extends JavaOSGiTest {
+    private final Logger logger = LoggerFactory.getLogger(SystemConditionHandlerTest.class);
+    private VolatileStorageService volatileStorageService = new VolatileStorageService();
+    private @NonNullByDefault({}) RuleRegistry ruleRegistry;
+    private @NonNullByDefault({}) RuleManager ruleEngine;
+    private @Nullable Event itemEvent;
+    private @NonNullByDefault({}) StartLevelService startLevelService;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        startLevelService = mock(StartLevelService.class);
+        when(startLevelService.getStartLevel()).thenReturn(100);
+        registerService(startLevelService, StartLevelService.class.getName());
+        EventPublisher eventPublisher = Objects.requireNonNull(getService(EventPublisher.class));
+        ThingRegistry thingRegistry = Objects.requireNonNull(getService(ThingRegistry.class));
+        ItemRegistry itemRegistry = Objects.requireNonNull(getService(ItemRegistry.class));
+        CoreModuleHandlerFactory coreModuleHandlerFactory = new CoreModuleHandlerFactory(getBundleContext(),
+                eventPublisher, thingRegistry, itemRegistry, mock(TimeZoneProvider.class), startLevelService);
+        registerService(coreModuleHandlerFactory);
+
+        ItemProvider itemProvider = new ItemProvider() {
+            @Override
+            public void addProviderChangeListener(ProviderChangeListener<Item> listener) {
+            }
+
+            @Override
+            public Collection<Item> getAll() {
+                return List.of(new SwitchItem("TriggeredItem"), new SwitchItem("SwitchedItem"));
+            }
+
+            @Override
+            public void removeProviderChangeListener(ProviderChangeListener<Item> listener) {
+            }
+        };
+        registerService(itemProvider);
+        registerService(volatileStorageService);
+        waitForAssert(() -> {
+            ruleRegistry = getService(RuleRegistry.class);
+            assertThat(ruleRegistry, is(notNullValue()));
+        }, 3000, 100);
+        waitForAssert(() -> {
+            ruleEngine = getService(RuleManager.class);
+            assertThat(ruleEngine, is(notNullValue()));
+        }, 3000, 100);
+
+        RuleEngineImpl ruleEngine = Objects.requireNonNull((RuleEngineImpl) getService(RuleManager.class));
+        ruleEngine.onReadyMarkerAdded(new ReadyMarker("", ""));
+        waitForAssert(() -> assertTrue(ruleEngine.isStarted()));
+    }
+
+    @Test
+    public void assertThatConditionWorks() throws InterruptedException {
+        SystemConditionHandler handler = getSystemConditionHandler(BigDecimal.valueOf(40));
+        when(startLevelService.getStartLevel()).thenReturn(20);
+        assertThat(handler.isSatisfied(Map.of()), is(false));
+        when(startLevelService.getStartLevel()).thenReturn(39);
+        assertThat(handler.isSatisfied(Map.of()), is(false));
+        when(startLevelService.getStartLevel()).thenReturn(40);
+        assertThat(handler.isSatisfied(Map.of()), is(true));
+    }
+
+    @Test
+    public void assertThatConditionWorksInRule() throws Exception {
+        String testItemName1 = "TriggeredItem";
+        String testItemName2 = "SwitchedItem";
+
+        // Create Rule
+        logger.info("Create rule");
+        Configuration triggerConfig = new Configuration(Map.of("itemName", testItemName1));
+        List<Trigger> triggers = List.of(ModuleBuilder.createTrigger().withId("MyTrigger")
+                .withTypeUID(ItemStateTriggerHandler.UPDATE_MODULE_TYPE_ID).withConfiguration(triggerConfig).build());
+
+        List<Condition> conditions = List.of(getStartlevelCondition(BigDecimal.valueOf(60)));
+
+        Map<String, Object> cfgEntries = new HashMap<>();
+        cfgEntries.put("itemName", testItemName2);
+        cfgEntries.put("command", "ON");
+        Configuration actionConfig = new Configuration(cfgEntries);
+        List<Action> actions = List.of(ModuleBuilder.createAction().withId("MyItemPostCommandAction")
+                .withTypeUID(ItemCommandActionHandler.ITEM_COMMAND_ACTION).withConfiguration(actionConfig).build());
+
+        // Prepare the execution
+        EventPublisher eventPublisher = getService(EventPublisher.class);
+        assertNotNull(eventPublisher);
+        when(startLevelService.getStartLevel()).thenReturn(80);
+
+        EventSubscriber itemEventHandler = new EventSubscriber() {
+
+            @Override
+            public Set<String> getSubscribedEventTypes() {
+                return Set.of(ItemCommandEvent.TYPE);
+            }
+
+            @Override
+            public void receive(Event event) {
+                logger.info("Event: {}", event.getTopic());
+                if (event.getTopic().contains(testItemName2)) {
+                    SystemConditionHandlerTest.this.itemEvent = event;
+                }
+            }
+        };
+        registerService(itemEventHandler);
+
+        Rule rule = RuleBuilder.create("MyRule" + new Random().nextInt()).withTriggers(triggers)
+                .withConditions(conditions).withActions(actions).withName("MyConditionTestRule").build();
+        logger.info("Rule created: {}", rule.getUID());
+
+        logger.info("Add rule");
+        ruleRegistry.add(rule);
+        logger.info("Rule added");
+
+        logger.info("Enable rule and wait for idle status");
+        ruleEngine.setEnabled(rule.getUID(), true);
+        waitForAssert(() -> {
+            RuleStatusInfo ruleStatus = ruleEngine.getStatusInfo(rule.getUID());
+            if (ruleStatus == null) {
+                fail("Failed to get rule status");
+            } else {
+                assertThat(ruleStatus.getStatus(), is(RuleStatus.IDLE));
+            }
+        });
+        logger.info("Rule is enabled and idle");
+
+        logger.info("Send and wait for item state is ON");
+        eventPublisher.post(ItemEventFactory.createStateUpdatedEvent(testItemName1, OnOffType.ON, null));
+
+        waitForAssert(() -> {
+            assertThat(itemEvent, is(notNullValue()));
+            if (itemEvent instanceof ItemCommandEvent event) {
+                assertThat(event.getItemCommand(), is(OnOffType.ON));
+            } else {
+                fail("itemEvent is " + itemEvent);
+            }
+        });
+
+        when(startLevelService.getStartLevel()).thenReturn(60);
+        // Send another event to check if the condition is still satisfied
+        itemEvent = null; // reset it
+        eventPublisher.post(ItemEventFactory.createStateUpdatedEvent(testItemName1, OnOffType.ON, null));
+
+        waitForAssert(() -> {
+            assertThat(itemEvent, is(notNullValue()));
+            if (itemEvent instanceof ItemCommandEvent event) {
+                assertThat(event.getItemCommand(), is(OnOffType.ON));
+            } else {
+                fail("itemEvent is " + itemEvent);
+            }
+        });
+        logger.info("item state is ON");
+
+        // Make the condition fail
+        Rule rule2 = RuleBuilder.create(rule)
+                .withConditions(ModuleBuilder.createCondition(rule.getConditions().getFirst())
+                        .withConfiguration(getStartlevelConfiguration(BigDecimal.valueOf(100))).build())
+                .build();
+        ruleRegistry.update(rule2);
+
+        // Prepare the execution
+        itemEvent = null;
+        eventPublisher.post(ItemEventFactory.createStateUpdatedEvent(testItemName1, OnOffType.ON, null));
+
+        // Give it some time to act
+        Thread.sleep(300L);
+        assertThat(itemEvent, is(nullValue()));
+    }
+
+    @Test
+    public void checkIfModuleTypeIsRegistered() {
+        ModuleTypeRegistry mtr = getService(ModuleTypeRegistry.class);
+        if (mtr != null) {
+            waitForAssert(() -> {
+                assertThat(mtr.get(SystemConditionHandler.STARTLEVEL_MODULE_TYPE_ID), is(notNullValue()));
+            }, 3000, 100);
+        } else {
+            fail("Failed to get ModuleTypeRegistry instance");
+        }
+    }
+
+    private SystemConditionHandler getSystemConditionHandler(BigDecimal minStartlevel) {
+        return new SystemConditionHandler(getStartlevelCondition(minStartlevel), startLevelService);
+    }
+
+    private Condition getStartlevelCondition(BigDecimal minStartlevel) {
+        Configuration config = getStartlevelConfiguration(minStartlevel);
+        return ModuleBuilder.createCondition().withId("testStartlevelCondition")
+                .withTypeUID(SystemConditionHandler.STARTLEVEL_MODULE_TYPE_ID).withConfiguration(config).build();
+    }
+
+    private Configuration getStartlevelConfiguration(BigDecimal minStartlevel) {
+        return new Configuration(Map.of(SystemConditionHandler.CFG_MIN_STARTLEVEL, minStartlevel));
+    }
+}

--- a/itests/org.openhab.core.model.rule.tests/src/main/java/org/openhab/core/model/rule/runtime/DSLRuleProviderTest.java
+++ b/itests/org.openhab.core.model.rule.tests/src/main/java/org/openhab/core/model/rule/runtime/DSLRuleProviderTest.java
@@ -43,6 +43,7 @@ import org.openhab.core.automation.internal.module.handler.IntervalConditionHand
 import org.openhab.core.automation.internal.module.handler.ItemCommandTriggerHandler;
 import org.openhab.core.automation.internal.module.handler.ItemStateConditionHandler;
 import org.openhab.core.automation.internal.module.handler.ItemStateTriggerHandler;
+import org.openhab.core.automation.internal.module.handler.SystemConditionHandler;
 import org.openhab.core.automation.internal.module.handler.SystemTriggerHandler;
 import org.openhab.core.automation.internal.module.handler.ThingStatusConditionHandler;
 import org.openhab.core.automation.internal.module.handler.ThingStatusTriggerHandler;
@@ -314,7 +315,8 @@ public class DSLRuleProviderTest extends JavaOSGiTest {
                 "   Item X ON and\n" + //
                 "   Item Y != 0 and\n" + //
                 "   Item Z > 5.25 and\n" + //
-                "   15000 ms between executions\n" + //
+                "   15000 ms between executions and\n" + //
+                "   System start level is at least 70\n" + //
                 "then\n" + //
                 "   logInfo('Test', 'Test')\n" + //
                 "end\n\n";
@@ -331,7 +333,7 @@ public class DSLRuleProviderTest extends JavaOSGiTest {
 
         assertThat(rule.getUID(), is("dslruletest-1"));
         assertThat(rule.getName(), is("RuleWithAllConditions"));
-        assertThat(rule.getConditions().size(), is(14));
+        assertThat(rule.getConditions().size(), is(15));
 
         assertThat(rule.getConditions().getFirst().getTypeUID(), is(TimeOfDayConditionHandler.MODULE_TYPE_ID));
         assertThat(rule.getConditions().getFirst().getConfiguration().get(TimeOfDayConditionHandler.CFG_START_TIME),
@@ -400,6 +402,10 @@ public class DSLRuleProviderTest extends JavaOSGiTest {
         assertThat(rule.getConditions().get(13).getTypeUID(), is(IntervalConditionHandler.MODULE_TYPE_ID));
         assertThat(rule.getConditions().get(13).getConfiguration().get(IntervalConditionHandler.CFG_MIN_INTERVAL),
                 is(new BigDecimal(15000)));
+
+        assertThat(rule.getConditions().get(14).getTypeUID(), is(SystemConditionHandler.STARTLEVEL_MODULE_TYPE_ID));
+        assertThat(rule.getConditions().get(14).getConfiguration().get(SystemConditionHandler.CFG_MIN_STARTLEVEL),
+                is(new BigDecimal(70)));
     }
 
     @Test


### PR DESCRIPTION
When reading through user reports, I've seen the challenge of rules that start to trigger too soon during startup come up several times. People have to resort to using proxy Items that are set when the system is fully up that prevents the rule from running etc.

I figured that it should be pretty easy to make a condition that requires that a certain start level has been reached before the rule will run, and this is it. Note: This shouldn't be confused with the start level trigger, which triggers a rule when a certain start level is reached. This condition doesn't trigger anything, but it prevents rules triggered by other events or for example a timer, from running prematurely.