### PR TITLE
[DSL] Add more commands/abilities to DSL scripts/rules

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/lib/RuleExtensions.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/lib/RuleExtensions.java
@@ -13,6 +13,7 @@
 package org.openhab.core.model.script.lib;
 
 import java.util.Map;
+import java.util.concurrent.Future;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -93,6 +94,77 @@ public class RuleExtensions {
     public static Map<String, @Nullable Object> run(Rule rule, boolean considerConditions,
             @Nullable Map<String, @Nullable Object> context) {
         return Rules.runRule(rule.getUID(), considerConditions, context);
+    }
+
+    /**
+     * Run the specified rule asynchronously.
+     *
+     * @param rule the {@link Rule} to run.
+     * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
+     * @throws IllegalArgumentException If the specified rule isn't registered.
+     * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     */
+    public static Future<Map<String, @Nullable Object>> runAsync(Rule rule) {
+        return Rules.runAsync(rule.getUID());
+    }
+
+    /**
+     * Run the specified rule asynchronously, while optionally taking conditions into account.
+     *
+     * @param rule the {@link Rule} to run.
+     * @param considerConditions {@code true} to not run the rule if its conditions don't qualify.
+     * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
+     * @throws IllegalArgumentException If the specified rule isn't registered.
+     * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     */
+    public static Future<Map<String, @Nullable Object>> runAsync(Rule rule, boolean considerConditions) {
+        return Rules.runAsync(rule.getUID(), considerConditions);
+    }
+
+    /**
+     * Run the specified rule asynchronously, with the specified context.
+     *
+     * @param rule the {@link Rule} to run.
+     * @param context the {@link Map} of {@link String} and {@link Object} pairs that constitutes the context.
+     * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
+     * @throws IllegalArgumentException If the specified rule isn't registered.
+     * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     */
+    public static Future<Map<String, @Nullable Object>> runAsync(Rule rule, Map<String, @Nullable Object> context) {
+        return Rules.runAsync(rule.getUID(), context);
+    }
+
+    /**
+     * Run the specified rule asynchronously, with the specified context, while optionally taking conditions into
+     * account.
+     *
+     * @param rule the {@link Rule} to run.
+     * @param considerConditions {@code true} to not run the rule if its conditions don't qualify.
+     * @param context the pairs of {@link String}s and {@link Object}s that constitutes the context. Must be in pairs,
+     *            the first is the key, the second is the value.
+     * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
+     * @throws IllegalArgumentException If the specified rule isn't registered.
+     * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     */
+    public static Future<Map<String, @Nullable Object>> runAsync(Rule rule, boolean considerConditions,
+            Object... context) {
+        return Rules.runAsync(rule.getUID(), considerConditions, context);
+    }
+
+    /**
+     * Run the specified rule asynchronously, with the specified context, while optionally taking conditions into
+     * account.
+     *
+     * @param rule the {@link Rule} to run.
+     * @param considerConditions {@code true} to not run the rule if its conditions don't qualify.
+     * @param context the {@link Map} of {@link String} and {@link Object} pairs that constitutes the context.
+     * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
+     * @throws IllegalArgumentException If the specified rule isn't registered.
+     * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     */
+    public static Future<Map<String, @Nullable Object>> runAsync(Rule rule, boolean considerConditions,
+            @Nullable Map<String, @Nullable Object> context) {
+        return Rules.runAsync(rule.getUID(), considerConditions, context);
     }
 
     /**

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/lib/RuleExtensions.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/lib/RuleExtensions.java
@@ -103,6 +103,8 @@ public class RuleExtensions {
      * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
      * @throws IllegalArgumentException If the specified rule isn't registered.
      * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     * @throws UnsupportedOperationException If asynchronous execution isn't supported by the active
+     *             {@link RuleManager}.
      */
     public static Future<Map<String, @Nullable Object>> runAsync(Rule rule) {
         return Rules.runAsync(rule.getUID());
@@ -116,6 +118,8 @@ public class RuleExtensions {
      * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
      * @throws IllegalArgumentException If the specified rule isn't registered.
      * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     * @throws UnsupportedOperationException If asynchronous execution isn't supported by the active
+     *             {@link RuleManager}.
      */
     public static Future<Map<String, @Nullable Object>> runAsync(Rule rule, boolean considerConditions) {
         return Rules.runAsync(rule.getUID(), considerConditions);
@@ -129,6 +133,8 @@ public class RuleExtensions {
      * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
      * @throws IllegalArgumentException If the specified rule isn't registered.
      * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     * @throws UnsupportedOperationException If asynchronous execution isn't supported by the active
+     *             {@link RuleManager}.
      */
     public static Future<Map<String, @Nullable Object>> runAsync(Rule rule, Map<String, @Nullable Object> context) {
         return Rules.runAsync(rule.getUID(), context);
@@ -145,6 +151,8 @@ public class RuleExtensions {
      * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
      * @throws IllegalArgumentException If the specified rule isn't registered.
      * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     * @throws UnsupportedOperationException If asynchronous execution isn't supported by the active
+     *             {@link RuleManager}.
      */
     public static Future<Map<String, @Nullable Object>> runAsync(Rule rule, boolean considerConditions,
             Object... context) {
@@ -161,6 +169,8 @@ public class RuleExtensions {
      * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
      * @throws IllegalArgumentException If the specified rule isn't registered.
      * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     * @throws UnsupportedOperationException If asynchronous execution isn't supported by the active
+     *             {@link RuleManager}.
      */
     public static Future<Map<String, @Nullable Object>> runAsync(Rule rule, boolean considerConditions,
             @Nullable Map<String, @Nullable Object> context) {

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/lib/Rules.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/lib/Rules.java
@@ -13,6 +13,7 @@
 package org.openhab.core.model.script.lib;
 
 import java.util.Map;
+import java.util.concurrent.Future;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -142,6 +143,113 @@ public class Rules {
             throw new IllegalArgumentException("Rule with UID '" + ruleUid + "' doesn't exist");
         }
         return ruleManager.runNow(ruleUid, considerConditions, context);
+    }
+
+    /**
+     * Run the rule with the specified UID asynchronously.
+     *
+     * @param ruleUid the UID of the rule to run.
+     * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
+     * @throws IllegalArgumentException If a rule with the specified UID doesn't exist.
+     * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     */
+    public static Future<Map<String, @Nullable Object>> runAsync(String ruleUid) {
+        RuleManager ruleManager = ScriptServiceUtil.getRuleManager();
+        if (ruleManager == null) {
+            throw new IllegalStateException("RuleManager doesn't exist");
+        }
+        if (ruleManager.getStatus(ruleUid) == null) {
+            throw new IllegalArgumentException("Rule with UID '" + ruleUid + "' doesn't exist");
+        }
+        return ruleManager.runAsync(ruleUid);
+    }
+
+    /**
+     * Run the rule with the specified UID asynchronously while optionally taking conditions into account.
+     *
+     * @param ruleUid the UID of the rule to run.
+     * @param considerConditions {@code true} to not run the rule if its conditions don't qualify.
+     * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
+     * @throws IllegalArgumentException If a rule with the specified UID doesn't exist.
+     * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     */
+    public static Future<Map<String, @Nullable Object>> runAsync(String ruleUid, boolean considerConditions) {
+        RuleManager ruleManager = ScriptServiceUtil.getRuleManager();
+        if (ruleManager == null) {
+            throw new IllegalStateException("RuleManager doesn't exist");
+        }
+        if (ruleManager.getStatus(ruleUid) == null) {
+            throw new IllegalArgumentException("Rule with UID '" + ruleUid + "' doesn't exist");
+        }
+        return ruleManager.runAsync(ruleUid, considerConditions, null);
+    }
+
+    /**
+     * Run the rule with the specified UID asynchronously, with the specified context.
+     *
+     * @param ruleUid the UID of the rule to run.
+     * @param context the {@link Map} of {@link String} and {@link Object} pairs that constitutes the context.
+     * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
+     * @throws IllegalArgumentException If a rule with the specified UID doesn't exist.
+     * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     */
+    public static Future<Map<String, @Nullable Object>> runAsync(String ruleUid,
+            Map<String, @Nullable Object> context) {
+        RuleManager ruleManager = ScriptServiceUtil.getRuleManager();
+        if (ruleManager == null) {
+            throw new IllegalStateException("RuleManager doesn't exist");
+        }
+        if (ruleManager.getStatus(ruleUid) == null) {
+            throw new IllegalArgumentException("Rule with UID '" + ruleUid + "' doesn't exist");
+        }
+        return ruleManager.runAsync(ruleUid, false, context);
+    }
+
+    /**
+     * Run the rule with the specified UID asynchronously, with the specified context, while optionally taking
+     * conditions into account.
+     *
+     * @param ruleUid the UID of the rule to run.
+     * @param considerConditions {@code true} to not run the rule if its conditions don't qualify.
+     * @param context the pairs of {@link String}s and {@link Object}s that constitutes the context. Must be in pairs,
+     *            the first is the key, the second is the value.
+     * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
+     * @throws IllegalArgumentException If a rule with the specified UID doesn't exist.
+     * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     */
+    public static Future<Map<String, @Nullable Object>> runAsync(String ruleUid, boolean considerConditions,
+            Object... context) {
+        RuleManager ruleManager = ScriptServiceUtil.getRuleManager();
+        if (ruleManager == null) {
+            throw new IllegalStateException("RuleManager doesn't exist");
+        }
+        if (ruleManager.getStatus(ruleUid) == null) {
+            throw new IllegalArgumentException("Rule with UID '" + ruleUid + "' doesn't exist");
+        }
+        return ruleManager.runAsync(ruleUid, considerConditions, Utils.parseObjectArrayNullableValues(context));
+    }
+
+    /**
+     * Run the rule with the specified UID asynchronously, with the specified context, while optionally taking
+     * conditions into account.
+     *
+     * @param ruleUid the UID of the rule to run.
+     * @param considerConditions {@code true} to not run the rule if its conditions don't qualify.
+     * @param context the {@link Map} of {@link String} and {@link Object} pairs that constitutes the context.
+     * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
+     * @throws IllegalArgumentException If a rule with the specified UID doesn't exist.
+     * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     */
+    public static Future<Map<String, @Nullable Object>> runAsync(String ruleUid, boolean considerConditions,
+            @Nullable Map<String, @Nullable Object> context) {
+        RuleManager ruleManager = ScriptServiceUtil.getRuleManager();
+        if (ruleManager == null) {
+            throw new IllegalStateException("RuleManager doesn't exist");
+        }
+        if (ruleManager.getStatus(ruleUid) == null) {
+            throw new IllegalArgumentException("Rule with UID '" + ruleUid + "' doesn't exist");
+        }
+        return ruleManager.runAsync(ruleUid, considerConditions, context);
     }
 
     /**

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/lib/Rules.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/lib/Rules.java
@@ -152,6 +152,8 @@ public class Rules {
      * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
      * @throws IllegalArgumentException If a rule with the specified UID doesn't exist.
      * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     * @throws UnsupportedOperationException If asynchronous execution isn't supported by the active
+     *             {@link RuleManager}.
      */
     public static Future<Map<String, @Nullable Object>> runAsync(String ruleUid) {
         RuleManager ruleManager = ScriptServiceUtil.getRuleManager();
@@ -172,6 +174,8 @@ public class Rules {
      * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
      * @throws IllegalArgumentException If a rule with the specified UID doesn't exist.
      * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     * @throws UnsupportedOperationException If asynchronous execution isn't supported by the active
+     *             {@link RuleManager}.
      */
     public static Future<Map<String, @Nullable Object>> runAsync(String ruleUid, boolean considerConditions) {
         RuleManager ruleManager = ScriptServiceUtil.getRuleManager();
@@ -192,6 +196,8 @@ public class Rules {
      * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
      * @throws IllegalArgumentException If a rule with the specified UID doesn't exist.
      * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     * @throws UnsupportedOperationException If asynchronous execution isn't supported by the active
+     *             {@link RuleManager}.
      */
     public static Future<Map<String, @Nullable Object>> runAsync(String ruleUid,
             Map<String, @Nullable Object> context) {
@@ -216,6 +222,8 @@ public class Rules {
      * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
      * @throws IllegalArgumentException If a rule with the specified UID doesn't exist.
      * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     * @throws UnsupportedOperationException If asynchronous execution isn't supported by the active
+     *             {@link RuleManager}.
      */
     public static Future<Map<String, @Nullable Object>> runAsync(String ruleUid, boolean considerConditions,
             Object... context) {
@@ -239,6 +247,8 @@ public class Rules {
      * @return A {@link Future} that can provide the copy of the rule context, including possible return values.
      * @throws IllegalArgumentException If a rule with the specified UID doesn't exist.
      * @throws IllegalStateException If no {@link RuleManager} instance exists.
+     * @throws UnsupportedOperationException If asynchronous execution isn't supported by the active
+     *             {@link RuleManager}.
      */
     public static Future<Map<String, @Nullable Object>> runAsync(String ruleUid, boolean considerConditions,
             @Nullable Map<String, @Nullable Object> context) {

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImportSectionNamespaceScopeProvider.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImportSectionNamespaceScopeProvider.java
@@ -43,12 +43,30 @@ public class ScriptImportSectionNamespaceScopeProvider extends XImportSectionNam
             "core", "persistence", "extensions", "PersistenceExtensions", "RiemannType");
     public static final QualifiedName MODEL_SCRIPT_ACTIONS_PACKAGE = QualifiedName.create("org", "openhab", "core",
             "model", "script", "actions");
+    public static final QualifiedName LANG_RUNNABLE_IF = QualifiedName.create("java", "lang", "Runnable");
     public static final QualifiedName TIME_PACKAGE = QualifiedName.create("java", "time");
     public static final QualifiedName TIME_FORMAT_PACKAGE = QualifiedName.create("java", "time", "format");
     public static final QualifiedName TIME_TEMPORAL_PACKAGE = QualifiedName.create("java", "time", "temporal");
+    public static final QualifiedName UTIL_CALLABLE_IF = QualifiedName.create("java", "util", "concurrent", "Callable");
+    public static final QualifiedName UTIL_FUTURE_IF = QualifiedName.create("java", "util", "concurrent", "Future");
+    public static final QualifiedName UTIL_LOCK_IF = QualifiedName.create("java", "util", "concurrent", "locks",
+            "Lock");
+    public static final QualifiedName UTIL_REENTRANTLOCK_CLASS = QualifiedName.create("java", "util", "concurrent",
+            "locks", "ReentrantLock");
+    public static final QualifiedName UTIL_REENTRANTREADWRITELOCK_CLASS = QualifiedName.create("java", "util",
+            "concurrent", "locks", "ReentrantReadWriteLock");
     public static final QualifiedName UTIL_REGEX_PACKAGE = QualifiedName.create("java", "util", "regex");
+    public static final QualifiedName UTIL_ARRAYLIST_CLASS = QualifiedName.create("java", "util", "ArrayList");
+    public static final QualifiedName UTIL_COLLECTION_IF = QualifiedName.create("java", "util", "Collection");
+    public static final QualifiedName UTIL_HASHMAP_CLASS = QualifiedName.create("java", "util", "HashMap");
+    public static final QualifiedName UTIL_HASHSET_CLASS = QualifiedName.create("java", "util", "HashSet");
+    public static final QualifiedName UTIL_LINKEDHASHMAP_CLASS = QualifiedName.create("java", "util", "LinkedHashMap");
+    public static final QualifiedName UTIL_LIST_IF = QualifiedName.create("java", "util", "List");
     public static final QualifiedName UTIL_LOCALE_CLASS = QualifiedName.create("java", "util", "Locale");
+    public static final QualifiedName UTIL_MAP_IF = QualifiedName.create("java", "util", "Map");
+    public static final QualifiedName UTIL_SET_IF = QualifiedName.create("java", "util", "Set");
     public static final QualifiedName UTIL_TIMEZONE_CLASS = QualifiedName.create("java", "util", "TimeZone");
+    public static final QualifiedName UTIL_TREEMAP_CLASS = QualifiedName.create("java", "util", "TreeMap");
     public static final QualifiedName QUANTITY_PACKAGE = QualifiedName.create("javax", "measure", "quantity");
     public static final QualifiedName CHANNELS_CLASS = QualifiedName.create("org", "openhab", "core", "model", "script",
             "lib", "Channels");
@@ -71,12 +89,27 @@ public class ScriptImportSectionNamespaceScopeProvider extends XImportSectionNam
         implicitImports.add(doCreateImportNormalizer(CORE_PERSISTENCE_PACKAGE, true, false));
         implicitImports.add(doCreateImportNormalizer(CORE_PERSISTENCE_RIEMANNTYPE_CLASS, false, false));
         implicitImports.add(doCreateImportNormalizer(MODEL_SCRIPT_ACTIONS_PACKAGE, true, false));
+        implicitImports.add(doCreateImportNormalizer(LANG_RUNNABLE_IF, false, false));
         implicitImports.add(doCreateImportNormalizer(TIME_PACKAGE, true, false));
         implicitImports.add(doCreateImportNormalizer(TIME_FORMAT_PACKAGE, true, false));
         implicitImports.add(doCreateImportNormalizer(TIME_TEMPORAL_PACKAGE, true, false));
+        implicitImports.add(doCreateImportNormalizer(UTIL_CALLABLE_IF, false, false));
+        implicitImports.add(doCreateImportNormalizer(UTIL_FUTURE_IF, false, false));
+        implicitImports.add(doCreateImportNormalizer(UTIL_LOCK_IF, false, false));
+        implicitImports.add(doCreateImportNormalizer(UTIL_REENTRANTLOCK_CLASS, false, false));
+        implicitImports.add(doCreateImportNormalizer(UTIL_REENTRANTREADWRITELOCK_CLASS, false, false));
         implicitImports.add(doCreateImportNormalizer(UTIL_REGEX_PACKAGE, true, false));
+        implicitImports.add(doCreateImportNormalizer(UTIL_ARRAYLIST_CLASS, false, false));
+        implicitImports.add(doCreateImportNormalizer(UTIL_COLLECTION_IF, false, false));
+        implicitImports.add(doCreateImportNormalizer(UTIL_HASHMAP_CLASS, false, false));
+        implicitImports.add(doCreateImportNormalizer(UTIL_HASHSET_CLASS, false, false));
+        implicitImports.add(doCreateImportNormalizer(UTIL_LINKEDHASHMAP_CLASS, false, false));
+        implicitImports.add(doCreateImportNormalizer(UTIL_LIST_IF, false, false));
         implicitImports.add(doCreateImportNormalizer(UTIL_LOCALE_CLASS, false, false));
+        implicitImports.add(doCreateImportNormalizer(UTIL_MAP_IF, false, false));
+        implicitImports.add(doCreateImportNormalizer(UTIL_SET_IF, false, false));
         implicitImports.add(doCreateImportNormalizer(UTIL_TIMEZONE_CLASS, false, false));
+        implicitImports.add(doCreateImportNormalizer(UTIL_TREEMAP_CLASS, false, false));
         implicitImports.add(doCreateImportNormalizer(QUANTITY_PACKAGE, true, false));
         implicitImports.add(doCreateImportNormalizer(CHANNELS_CLASS, false, false));
         implicitImports.add(doCreateImportNormalizer(ITEMS_CLASS, false, false));


### PR DESCRIPTION
In the rush before 5.2.0, things were merged in an order and timeframe that made it impossible to get everything covered. This is a "continuation of" #5481 with some methods that didn't exist when it was merged. Specifically, it's the methods needed to run rules asynchronously from DSL, without waiting for the other rule to finish.

In addition, various user cases on the forum have made me realize that many of the "commonly used" Java classes aren't implicitly imported, which is very inconvenient since you can't explicitly import when using DSL actions/conditions (basically anything that aren't part of a `.rules` file).

As we examined in #5481, the cost of adding extra implicit imports is very minimal, when the rule is "compiled" into an AST tree, fully qualified class names are used anyway, so imports are "dropped". The only "cost" of doing implicit imports is thus some microseconds extra when "compiling" the rule, plus the risk of name collision. I don't believe any of the added imports risk name collision.

Ideally, I'd like to see this backported as well, it provides access to methods that were made available (in core/Java) in 5.2.0.