### PR TITLE
Prevent concurrency issues during XStream SPI lookup

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/XmlDocumentReader.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/XmlDocumentReader.java
@@ -38,9 +38,21 @@ import com.thoughtworks.xstream.io.xml.StaxDriver;
 @NonNullByDefault
 public abstract class XmlDocumentReader<@NonNull T> {
 
+    /**
+     * SPI lookups are <b>not</b> thread-safe, leading to "random failures" during {@link XStream} initialization,
+     * especially during tests. {@link XStream} instances themselves are thread-safe once initialized, and they
+     * are supposed to share the lifecycle of the application. That's not practical in an OSGi environment, where
+     * there is no overall lifecycle, but many bundles with their individual lifecycles.
+     * <p>
+     * To try to protect against concurrency issues during SPI resolution, this static lock exists. By serializing
+     * SPI lookups using this lock, there should be no opportunity for concurrency issues. The lock object is public
+     * to enable other classes to apply the same lock. The lock object itself shares its lifecycle with the JVM.
+     */
+    public static final Object XSTREAM_SPI_LOCK = new Object();
+
     protected static final String[] DEFAULT_ALLOWED_TYPES_WILDCARD = new String[] { "org.openhab.core.**" };
 
-    private final XStream xstream = new XStream(new StaxDriver());
+    private final XStream xstream;
 
     /**
      * The default constructor of this class initializes the {@code XStream} object by calling:
@@ -52,6 +64,9 @@ public abstract class XmlDocumentReader<@NonNull T> {
      * </ol>
      */
     public XmlDocumentReader() {
+        synchronized (XSTREAM_SPI_LOCK) {
+            xstream = new XStream(new StaxDriver());
+        }
         configureSecurity(xstream);
         registerConverters(xstream);
         registerAliases(xstream);


### PR DESCRIPTION
I just had a CI build failure in #5720 that makes no sense to me: https://github.com/openhab/openhab-core/actions/runs/30165880084/job/89698693351?pr=5720

```shell
[ERROR] Error while parsing schema(s).Location [ file:/home/runner/work/openhab-core/openhab-core/bundles/org.openhab.core.addon/schema/addon-1.0.0.xsd{40,89}].
org.xml.sax.SAXParseException: undefined simple type 'config-description:idRestrictionPattern'
    at com.sun.xml.xsom.impl.parser.ParserContext$1.reportError (ParserContext.java:150)
    at com.sun.xml.xsom.impl.parser.NGCCRuntimeEx.reportError (NGCCRuntimeEx.java:149)
    at com.sun.xml.xsom.impl.parser.DelayedRef.resolve (DelayedRef.java:80)
    at com.sun.xml.xsom.impl.parser.DelayedRef.run (DelayedRef.java:55)
    at com.sun.xml.xsom.impl.parser.ParserContext.getResult (ParserContext.java:105)
    at com.sun.xml.xsom.parser.XSOMParser.getResult (XSOMParser.java:184)
    at com.sun.tools.xjc.ModelLoader.createXSOM (ModelLoader.java:479)
    at com.sun.tools.xjc.ModelLoader.loadXMLSchema (ModelLoader.java:319)
    at com.sun.tools.xjc.ModelLoader.load (ModelLoader.java:121)
    at com.sun.tools.xjc.ModelLoader.load (ModelLoader.java:76)
    at org.jvnet.mjiip.v_2_3.XJC23Mojo.loadModel (XJC23Mojo.java:50)
    at org.jvnet.mjiip.v_2_3.XJC23Mojo.doExecute (XJC23Mojo.java:40)
    at org.jvnet.mjiip.v_2_3.XJC23Mojo.doExecute (XJC23Mojo.java:28)
    at org.jvnet.jaxb2.maven2.RawXJC2Mojo.doExecute (RawXJC2Mojo.java:477)
    at org.jvnet.jaxb2.maven2.RawXJC2Mojo.execute (RawXJC2Mojo.java:319)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:328)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:193)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:180)
    at java.util.concurrent.FutureTask.run (FutureTask.java:317)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:572)
    at java.util.concurrent.FutureTask.run (FutureTask.java:317)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1144)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:642)
    at java.lang.Thread.run (Thread.java:1583)
```

It seems unrelated to anything I've done in the PR, so I suspected a flaky test. Force pushing the branch with no actual changed (just a new hash for the last commit) triggered a new build that didn't fail, which I interpret as a confirmation that it was a flaky test.

I've tried to dig in and find what could possibly have caused it, and I can't be 100% sure, but SPI lookups aren't thread-safe. Each time a `XmlDocumentReader` instance is created, an SPI lookup is done to find the actual XML parser implementation. My theory is that while tests are being run concurrently, multiple SPI lookups might happen to happen at the same time, which makes them fail/see incomplete data, which could explain the above error.

I can't guarantee that this is what's causing the flakiness, but it seems plausible, and knowing that SPI lookups aren't thread-safe, it can hardly hurt for force serialization of the lookups.

There are add-ons that also create `XStream` instances, but they are very unlikely to occur in parallel with anything else, so I think it's acceptable to let them remain "unprotected". I've made the lock public though, in case there is a situation where there's a need for other parts of the code to share the same lock.