### PR TITLE
Pass timestamps from Timeseries to ModifiablePersistenceServices

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/ModifiablePersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/ModifiablePersistenceService.java
@@ -12,12 +12,8 @@
  */
 package org.openhab.core.persistence;
 
-import java.time.ZonedDateTime;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.items.Item;
-import org.openhab.core.types.State;
 
 /**
  * This class provides an interface to the a {@link PersistenceService} to allow data to be stored
@@ -29,44 +25,6 @@ import org.openhab.core.types.State;
  */
 @NonNullByDefault
 public interface ModifiablePersistenceService extends QueryablePersistenceService {
-    /**
-     * <p>
-     * Stores the historic item value. This allows the item, time and value to be specified.
-     *
-     * <p>
-     * Adding data with the same time as an existing record should update the current record value rather than adding a
-     * new record.
-     *
-     * <p>
-     * Implementors should keep in mind that all registered {@link PersistenceService}s are called synchronously. Hence
-     * long running operations should be processed asynchronously. E.g. <code>store</code> adds things to a queue which
-     * is processed by some asynchronous workers (Quartz Job, Thread, etc.).
-     *
-     * @param item the data to be stored
-     * @param date the date of the record
-     * @param state the state to be recorded
-     */
-    void store(Item item, ZonedDateTime date, State state);
-
-    /**
-     * <p>
-     * Stores the historic item value under a specified alias. This allows the item, time and value to be specified.
-     *
-     * <p>
-     * Adding data with the same time as an existing record should update the current record value rather than adding a
-     * new record.
-     *
-     * <p>
-     * Implementors should keep in mind that all registered {@link PersistenceService}s are called synchronously. Hence
-     * long running operations should be processed asynchronously. E.g. <code>store</code> adds things to a queue which
-     * is processed by some asynchronous workers (Quartz Job, Thread, etc.).
-     *
-     * @param item the data to be stored
-     * @param date the date of the record
-     * @param state the state to be recorded
-     */
-    void store(Item item, ZonedDateTime date, State state, @Nullable String alias);
-
     /**
      * Removes data associated with an item from a persistence service.
      * If all data is removed for the specified item, the persistence service should free any resources associated with

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/PersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/PersistenceService.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.persistence;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Locale;
 
@@ -19,6 +20,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.Item;
 import org.openhab.core.persistence.strategy.PersistenceStrategy;
+import org.openhab.core.types.State;
 
 /**
  * A persistence service which can be used to store data from openHAB.
@@ -50,7 +52,60 @@ public interface PersistenceService {
     String getLabel(@Nullable Locale locale);
 
     /**
+     * <p>
+     * Stores the historic item value. This allows the item, time and value to be specified.
+     *
+     * <p>
+     * Adding data with the same time as an existing record should update the current record value rather than adding a
+     * new record.
+     *
+     * <p>
+     * Implementors SHOULD NOT rely on the default. It is provided solely for compatibility with existing
+     * implementations which do not provide a store method which allows date and state to be specified.
+     *
+     * <p>
+     * Implementors should keep in mind that all registered {@link PersistenceService}s are called synchronously. Hence
+     * long running operations should be processed asynchronously. E.g. <code>store</code> adds things to a queue which
+     * is processed by some asynchronous workers (Quartz Job, Thread, etc.).
+     *
+     * @param item the data to be stored
+     * @param date the date of the record
+     * @param state the state to be recorded
+     */
+    default void store(Item item, ZonedDateTime date, State state) {
+        store(item);
+    }
+
+    /**
+     * <p>
+     * Stores the historic item value under a specified alias. This allows the item, time and value to be specified.
+     *
+     * <p>
+     * Adding data with the same time as an existing record should update the current record value rather than adding a
+     * new record.
+     *
+     * <p>
+     * Implementors SHOULD NOT rely on the default. It is provided solely for compatibility with existing
+     * implementations which do not provide a store method which allows date and state to be specified.
+     *
+     * <p>
+     * Implementors should keep in mind that all registered {@link PersistenceService}s are called synchronously. Hence
+     * long running operations should be processed asynchronously. E.g. <code>store</code> adds things to a queue which
+     * is processed by some asynchronous workers (Quartz Job, Thread, etc.).
+     *
+     * @param item the data to be stored
+     * @param date the date of the record
+     * @param state the state to be recorded
+     */
+    default void store(Item item, ZonedDateTime date, State state, @Nullable String alias) {
+        store(item, alias);
+    }
+
+    /**
      * Stores the current value of the given item.
+     *
+     * This method has been deprecated and {@link #store(Item, ZonedDateTime, State, String)} MUST be used instead.
+     *
      * <p>
      * Implementors should keep in mind that all registered {@link PersistenceService}s are called synchronously. Hence
      * long running operations should be processed asynchronously. E.g. <code>store</code> adds things to a queue which
@@ -58,11 +113,16 @@ public interface PersistenceService {
      *
      * @param item the item which state should be persisted.
      */
-    void store(Item item);
+    @Deprecated
+    default void store(Item item) {
+        store(item, ZonedDateTime.now(), item.getState(), null);
+    }
 
     /**
      * <p>
      * Stores the current value of the given item under a specified alias.
+     *
+     * This method has been deprecated and {@link #store(Item, ZonedDateTime, State, String)} MUST be used instead.
      *
      * <p>
      * Implementors should keep in mind that all registered {@link PersistenceService}s are called synchronously. Hence
@@ -72,7 +132,10 @@ public interface PersistenceService {
      * @param item the item which state should be persisted.
      * @param alias the alias under which the item should be persisted.
      */
-    void store(Item item, @Nullable String alias);
+    @Deprecated
+    default void store(Item item, @Nullable String alias) {
+        store(item, ZonedDateTime.now(), item.getState(), alias);
+    }
 
     /**
      * Provides default persistence strategies that are used for all items if no user defined configuration is found.

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
@@ -195,7 +195,14 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
                 .filter(itemConfig -> itemConfig.filters().stream().allMatch(filter -> filter.apply(item)))
                 .forEach(itemConfig -> {
                     itemConfig.filters().forEach(filter -> filter.persisted(item));
-                    container.getPersistenceService().store(item, container.getAlias(item));
+                    PersistenceService persistenceService = container.getPersistenceService();
+                    if (persistenceService instanceof ModifiablePersistenceService modPersistenceService) {
+                        modPersistenceService.store(item,
+                                Objects.requireNonNullElse(item.getLastStateUpdate(), ZonedDateTime.now()),
+                                item.getState(), container.getAlias(item));
+                    } else {
+                        persistenceService.store(item, container.getAlias(item));
+                    }
                 });
     }
 
@@ -817,12 +824,18 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
         }
 
         private void persistJob(List<PersistenceItemConfiguration> itemConfigs) {
+            ZonedDateTime now = ZonedDateTime.now();
+
             itemConfigs.forEach(itemConfig -> {
                 for (Item item : getAllItems(itemConfig)) {
                     if (itemConfig.filters().stream().allMatch(filter -> filter.apply(item))) {
                         long startTime = System.nanoTime();
                         itemConfig.filters().forEach(filter -> filter.persisted(item));
-                        persistenceService.store(item, getAlias(item));
+                        if (persistenceService instanceof ModifiablePersistenceService modPersistenceService) {
+                            modPersistenceService.store(item, now, item.getState(), getAlias(item));
+                        } else {
+                            persistenceService.store(item, getAlias(item));
+                        }
                         logger.trace("Storing item '{}' with persistence service '{}' took {}ms", item.getName(),
                                 configuration.getUID(), TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime));
                     }

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
@@ -821,14 +821,12 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
         }
 
         private void persistJob(List<PersistenceItemConfiguration> itemConfigs) {
-            ZonedDateTime now = ZonedDateTime.now();
-
             itemConfigs.forEach(itemConfig -> {
                 for (Item item : getAllItems(itemConfig)) {
                     if (itemConfig.filters().stream().allMatch(filter -> filter.apply(item))) {
                         long startTime = System.nanoTime();
                         itemConfig.filters().forEach(filter -> filter.persisted(item));
-                        persistenceService.store(item, now, item.getState(), getAlias(item));
+                        persistenceService.store(item, ZonedDateTime.now(), item.getState(), getAlias(item));
                         logger.trace("Storing item '{}' with persistence service '{}' took {}ms", item.getName(),
                                 configuration.getUID(), TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime));
                     }

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
@@ -191,18 +191,15 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
     }
 
     private void storeItem(PersistenceServiceContainer container, Item item, PersistenceStrategy changeStrategy) {
+        ZonedDateTime now = ZonedDateTime.now();
+
         container.getMatchingConfigurations(changeStrategy).filter(itemConfig -> appliesToItem(itemConfig, item))
                 .filter(itemConfig -> itemConfig.filters().stream().allMatch(filter -> filter.apply(item)))
                 .forEach(itemConfig -> {
                     itemConfig.filters().forEach(filter -> filter.persisted(item));
                     PersistenceService persistenceService = container.getPersistenceService();
-                    if (persistenceService instanceof ModifiablePersistenceService modPersistenceService) {
-                        modPersistenceService.store(item,
-                                Objects.requireNonNullElse(item.getLastStateUpdate(), ZonedDateTime.now()),
-                                item.getState(), container.getAlias(item));
-                    } else {
-                        persistenceService.store(item, container.getAlias(item));
-                    }
+                    persistenceService.store(item, Objects.requireNonNullElse(item.getLastStateUpdate(), now),
+                            item.getState(), container.getAlias(item));
                 });
     }
 
@@ -831,11 +828,7 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
                     if (itemConfig.filters().stream().allMatch(filter -> filter.apply(item))) {
                         long startTime = System.nanoTime();
                         itemConfig.filters().forEach(filter -> filter.persisted(item));
-                        if (persistenceService instanceof ModifiablePersistenceService modPersistenceService) {
-                            modPersistenceService.store(item, now, item.getState(), getAlias(item));
-                        } else {
-                            persistenceService.store(item, getAlias(item));
-                        }
+                        persistenceService.store(item, now, item.getState(), getAlias(item));
                         logger.trace("Storing item '{}' with persistence service '{}' took {}ms", item.getName(),
                                 configuration.getUID(), TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime));
                     }

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/internal/PersistenceManagerTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/internal/PersistenceManagerTest.java
@@ -214,7 +214,7 @@ public class PersistenceManagerTest {
 
         manager.stateUpdated(TEST_ITEM, TEST_STATE);
 
-        verify(persistenceServiceMock).store(TEST_ITEM, null);
+        verify(persistenceServiceMock).store(eq(TEST_ITEM), any(ZonedDateTime.class), any(State.class), eq(null));
         verifyNoMoreInteractions(persistenceServiceMock);
     }
 
@@ -235,7 +235,7 @@ public class PersistenceManagerTest {
 
         manager.stateUpdated(TEST_GROUP_ITEM, TEST_STATE);
 
-        verify(persistenceServiceMock).store(TEST_GROUP_ITEM, null);
+        verify(persistenceServiceMock).store(eq(TEST_GROUP_ITEM), any(ZonedDateTime.class), any(State.class), eq(null));
         verifyNoMoreInteractions(persistenceServiceMock);
     }
 
@@ -246,7 +246,7 @@ public class PersistenceManagerTest {
 
         manager.stateUpdated(TEST_ITEM, TEST_STATE);
 
-        verify(persistenceServiceMock).store(TEST_ITEM, null);
+        verify(persistenceServiceMock).store(eq(TEST_ITEM), any(ZonedDateTime.class), any(State.class), eq(null));
         verifyNoMoreInteractions(persistenceServiceMock);
     }
 
@@ -270,9 +270,9 @@ public class PersistenceManagerTest {
         manager.stateUpdated(TEST_ITEM2, TEST_STATE);
         manager.stateUpdated(TEST_GROUP_ITEM, TEST_STATE);
 
-        verify(persistenceServiceMock).store(TEST_ITEM, null);
-        verify(persistenceServiceMock).store(TEST_ITEM2, null);
-        verify(persistenceServiceMock).store(TEST_GROUP_ITEM, null);
+        verify(persistenceServiceMock).store(eq(TEST_ITEM), any(ZonedDateTime.class), any(State.class), eq(null));
+        verify(persistenceServiceMock).store(eq(TEST_ITEM2), any(ZonedDateTime.class), any(State.class), eq(null));
+        verify(persistenceServiceMock).store(eq(TEST_GROUP_ITEM), any(ZonedDateTime.class), any(State.class), eq(null));
 
         verifyNoMoreInteractions(persistenceServiceMock);
     }
@@ -297,8 +297,8 @@ public class PersistenceManagerTest {
         manager.stateUpdated(TEST_ITEM2, TEST_STATE);
         manager.stateUpdated(TEST_GROUP_ITEM, TEST_STATE);
 
-        verify(persistenceServiceMock).store(TEST_ITEM2, null);
-        verify(persistenceServiceMock).store(TEST_GROUP_ITEM, null);
+        verify(persistenceServiceMock).store(eq(TEST_ITEM2), any(ZonedDateTime.class), any(State.class), eq(null));
+        verify(persistenceServiceMock).store(eq(TEST_GROUP_ITEM), any(ZonedDateTime.class), any(State.class), eq(null));
 
         verifyNoMoreInteractions(persistenceServiceMock);
     }
@@ -313,8 +313,8 @@ public class PersistenceManagerTest {
         manager.stateUpdated(TEST_ITEM2, TEST_STATE);
         manager.stateUpdated(TEST_GROUP_ITEM, TEST_STATE);
 
-        verify(persistenceServiceMock).store(TEST_ITEM2, null);
-        verify(persistenceServiceMock).store(TEST_GROUP_ITEM, null);
+        verify(persistenceServiceMock).store(eq(TEST_ITEM2), any(ZonedDateTime.class), any(State.class), eq(null));
+        verify(persistenceServiceMock).store(eq(TEST_GROUP_ITEM), any(ZonedDateTime.class), any(State.class), eq(null));
 
         verifyNoMoreInteractions(persistenceServiceMock);
     }
@@ -331,8 +331,8 @@ public class PersistenceManagerTest {
         manager.stateUpdated(TEST_ITEM3, DecimalType.ZERO);
         manager.stateUpdated(TEST_GROUP_ITEM2, DecimalType.ZERO);
 
-        verify(persistenceServiceMock).store(TEST_ITEM2, null);
-        verify(persistenceServiceMock).store(TEST_GROUP_ITEM, null);
+        verify(persistenceServiceMock).store(eq(TEST_ITEM2), any(ZonedDateTime.class), any(State.class), eq(null));
+        verify(persistenceServiceMock).store(eq(TEST_GROUP_ITEM), any(ZonedDateTime.class), any(State.class), eq(null));
 
         verifyNoMoreInteractions(persistenceServiceMock);
     }
@@ -345,7 +345,8 @@ public class PersistenceManagerTest {
         manager.stateUpdated(TEST_ITEM, TEST_STATE);
         manager.stateUpdated(TEST_ITEM, TEST_STATE);
 
-        verify(persistenceServiceMock, times(2)).store(TEST_ITEM, null);
+        verify(persistenceServiceMock, times(2)).store(eq(TEST_ITEM), any(ZonedDateTime.class), any(State.class),
+                eq(null));
 
         verifyNoMoreInteractions(persistenceServiceMock);
     }
@@ -366,7 +367,7 @@ public class PersistenceManagerTest {
 
         manager.stateChanged(TEST_ITEM, UnDefType.UNDEF, TEST_STATE);
 
-        verify(persistenceServiceMock).store(TEST_ITEM, null);
+        verify(persistenceServiceMock).store(eq(TEST_ITEM), any(ZonedDateTime.class), any(State.class), eq(null));
         verifyNoMoreInteractions(persistenceServiceMock);
     }
 
@@ -485,7 +486,7 @@ public class PersistenceManagerTest {
         assertThat(lastStateChange.toInstant(), is(firstEntry.timestamp()));
 
         // Check if other persistence services got updated
-        verify(persistenceServiceMock).store(TEST_ITEM, null);
+        verify(persistenceServiceMock).store(eq(TEST_ITEM), any(ZonedDateTime.class), any(State.class), eq(null));
         verify(persistenceServiceMock, atLeast(0)).getId();
         verifyNoMoreInteractions(persistenceServiceMock);
 
@@ -539,7 +540,7 @@ public class PersistenceManagerTest {
         manager.handleExternalPersistenceDataChange(queryablePersistenceServiceMock, TEST_ITEM);
         verify(queryablePersistenceServiceMock).persistedItem(eq(TEST_ITEM_NAME), any());
         assertEquals(TEST_STATE, TEST_ITEM.getState());
-        verify(persistenceServiceMock).store(TEST_ITEM, null);
+        verify(persistenceServiceMock).store(eq(TEST_ITEM), any(ZonedDateTime.class), any(State.class), eq(null));
     }
 
     @Test
@@ -568,9 +569,11 @@ public class PersistenceManagerTest {
         verify(cronSchedulerMock, times(2)).schedule(any(), any());
         verify(scheduledFutureMock, times(2)).cancel(true);
         // no filter - persist everything
-        verify(persistenceServiceMock, times(2)).store(TEST_ITEM3, null);
+        verify(persistenceServiceMock, times(2)).store(eq(TEST_ITEM3), any(ZonedDateTime.class), any(State.class),
+                eq(null));
         // filter - persist filtered value
-        verify(queryablePersistenceServiceMock, times(1)).store(TEST_ITEM3, null);
+        verify(queryablePersistenceServiceMock, times(1)).store(eq(TEST_ITEM3), any(ZonedDateTime.class),
+                any(State.class), eq(null));
     }
 
     @Test
@@ -600,7 +603,8 @@ public class PersistenceManagerTest {
         manager.stateUpdated(TEST_ITEM3, DecimalType.ZERO);
         manager.stateUpdated(TEST_ITEM3, DecimalType.ZERO);
 
-        verify(persistenceServiceMock, times(1)).store(TEST_ITEM3, null);
+        verify(persistenceServiceMock, times(1)).store(eq(TEST_ITEM3), any(ZonedDateTime.class), any(State.class),
+                eq(null));
 
         verifyNoMoreInteractions(persistenceServiceMock);
     }


### PR DESCRIPTION
Pass the timestamps given in Timeseries through to ModifiablePersistenceServices rather than just letting them pick their own and independent idea of "now".

N.B. It would be nice to have correct timestamps in QueryablePersistenceServices too but they don't have the extended store method and since it's an interface hierarchy rather than a class hierarchy fixing that might take a bit of coordination between core and addons. I don't think it's desperately urgent for the queryables...