### PR TITLE
All state types acceptable for an Item are acceptable in its Timeseries

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ColorItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ColorItem.java
@@ -115,7 +115,7 @@ public class ColorItem extends DimmerItem {
 
     @Override
     public void setTimeSeries(TimeSeries timeSeries) {
-        if (timeSeries.getStates().allMatch(s -> s.state() instanceof HSBType)) {
+        if (timeSeries.getStates().allMatch(s -> isAcceptedState(ACCEPTED_DATA_TYPES, s.state()))) {
             applyTimeSeries(timeSeries);
         } else {
             logSetTypeError(timeSeries);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ContactItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ContactItem.java
@@ -65,7 +65,7 @@ public class ContactItem extends GenericItem {
 
     @Override
     public void setTimeSeries(TimeSeries timeSeries) {
-        if (timeSeries.getStates().allMatch(s -> s.state() instanceof OpenClosedType)) {
+        if (timeSeries.getStates().allMatch(s -> isAcceptedState(ACCEPTED_DATA_TYPES, s.state()))) {
             applyTimeSeries(timeSeries);
         } else {
             logSetTypeError(timeSeries);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DateTimeItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DateTimeItem.java
@@ -90,7 +90,7 @@ public class DateTimeItem extends GenericItem {
 
     @Override
     public void setTimeSeries(TimeSeries timeSeries) {
-        if (timeSeries.getStates().allMatch(s -> s.state() instanceof DateTimeType)) {
+        if (timeSeries.getStates().allMatch(s -> isAcceptedState(ACCEPTED_DATA_TYPES, s.state()))) {
             applyTimeSeries(timeSeries);
         } else {
             logSetTypeError(timeSeries);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DimmerItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DimmerItem.java
@@ -116,7 +116,7 @@ public class DimmerItem extends SwitchItem {
 
     @Override
     public void setTimeSeries(TimeSeries timeSeries) {
-        if (timeSeries.getStates().allMatch(s -> s.state() instanceof PercentType)) {
+        if (timeSeries.getStates().allMatch(s -> isAcceptedState(ACCEPTED_DATA_TYPES, s.state()))) {
             super.applyTimeSeries(timeSeries);
         } else {
             logSetTypeError(timeSeries);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ImageItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ImageItem.java
@@ -63,7 +63,7 @@ public class ImageItem extends GenericItem {
 
     @Override
     public void setTimeSeries(TimeSeries timeSeries) {
-        if (timeSeries.getStates().allMatch(s -> s.state() instanceof RawType)) {
+        if (timeSeries.getStates().allMatch(s -> isAcceptedState(ACCEPTED_DATA_TYPES, s.state()))) {
             applyTimeSeries(timeSeries);
         } else {
             logSetTypeError(timeSeries);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/LocationItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/LocationItem.java
@@ -100,7 +100,7 @@ public class LocationItem extends GenericItem {
 
     @Override
     public void setTimeSeries(TimeSeries timeSeries) {
-        if (timeSeries.getStates().allMatch(s -> s.state() instanceof PointType)) {
+        if (timeSeries.getStates().allMatch(s -> isAcceptedState(ACCEPTED_DATA_TYPES, s.state()))) {
             applyTimeSeries(timeSeries);
         } else {
             logSetTypeError(timeSeries);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/NumberItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/NumberItem.java
@@ -219,9 +219,11 @@ public class NumberItem extends GenericItem implements MetadataAwareItem {
         timeSeries.getStates().forEach(s -> internalSeries.add(s.timestamp(),
                 Objects.requireNonNullElse(getInternalState(s.state()), UnDefType.NULL)));
 
-        if (dimension != null && internalSeries.getStates().allMatch(s -> s.state() instanceof QuantityType<?>)) {
+        if (dimension != null && internalSeries.getStates()
+                .allMatch(s -> s.state() instanceof QuantityType<?> || s.state() instanceof UnDefType)) {
             applyTimeSeries(internalSeries);
-        } else if (internalSeries.getStates().allMatch(s -> s.state() instanceof DecimalType)) {
+        } else if (internalSeries.getStates()
+                .allMatch(s -> s.state() instanceof DecimalType || s.state() instanceof UnDefType)) {
             applyTimeSeries(internalSeries);
         } else {
             logSetTypeError(timeSeries);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/PlayerItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/PlayerItem.java
@@ -129,8 +129,7 @@ public class PlayerItem extends GenericItem {
 
     @Override
     public void setTimeSeries(TimeSeries timeSeries) {
-        if (timeSeries.getStates()
-                .allMatch(s -> s.state() instanceof PlayPauseType || s.state() instanceof RewindFastforwardType)) {
+        if (timeSeries.getStates().allMatch(s -> isAcceptedState(ACCEPTED_DATA_TYPES, s.state()))) {
             applyTimeSeries(timeSeries);
         } else {
             logSetTypeError(timeSeries);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/StringItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/StringItem.java
@@ -101,7 +101,7 @@ public class StringItem extends GenericItem {
 
     @Override
     public void setTimeSeries(TimeSeries timeSeries) {
-        if (timeSeries.getStates().allMatch(s -> s.state() instanceof StringType)) {
+        if (timeSeries.getStates().allMatch(s -> isAcceptedState(ACCEPTED_DATA_TYPES, s.state()))) {
             applyTimeSeries(timeSeries);
         } else {
             logSetTypeError(timeSeries);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/SwitchItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/SwitchItem.java
@@ -87,7 +87,7 @@ public class SwitchItem extends GenericItem {
 
     @Override
     public void setTimeSeries(TimeSeries timeSeries) {
-        if (timeSeries.getStates().allMatch(s -> s.state() instanceof OnOffType)) {
+        if (timeSeries.getStates().allMatch(s -> isAcceptedState(ACCEPTED_DATA_TYPES, s.state()))) {
             applyTimeSeries(timeSeries);
         } else {
             logSetTypeError(timeSeries);


### PR DESCRIPTION
States that can be set via updateState should also be acceptable in TimeSeries passed to setTimeSeries. CallItem and RollerShutterItem were the only ones that already did that.