### PR TITLE
Introduce the downloadData and downloadImage overloads that take proxy parameters

### DIFF
--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
@@ -404,7 +404,32 @@ public class HttpUtil {
      *         not an image or the data size is too big
      */
     public static RawType downloadImage(String url, boolean scanTypeInContent, long maxContentLength, int timeout) {
-        return downloadData(url, "image/.*", scanTypeInContent, maxContentLength, timeout);
+        final ProxyParams proxyParams = prepareProxyParams();
+
+        return downloadImage(url, scanTypeInContent, maxContentLength, timeout, proxyParams.proxyHost,
+                proxyParams.proxyPort, proxyParams.proxyUser, proxyParams.proxyPassword, proxyParams.nonProxyHosts);
+    }
+
+    /**
+     * Download the image data from a URL.
+     *
+     * @param url the URL of the image to be downloaded
+     * @param scanTypeInContent true to allow the scan of data to determine the content type if not found in the headers
+     * @param maxContentLength the maximum data size in bytes to trigger the download; any negative value to ignore the
+     *            data size
+     * @param timeout the socket timeout in milliseconds to wait for data
+     * @param proxyHost the hostname of the proxy
+     * @param proxyPort the port of the proxy
+     * @param proxyUser the username to authenticate with the proxy
+     * @param proxyPassword the password to authenticate with the proxy
+     * @param nonProxyHosts the hosts that won't be routed through the proxy
+     * @return a RawType object containing the image, null if the content type could not be found or the content type is
+     *         not an image or the data size is too big
+     */
+    public static RawType downloadImage(String url, boolean scanTypeInContent, long maxContentLength, int timeout,
+            String proxyHost, Integer proxyPort, String proxyUser, String proxyPassword, String nonProxyHosts) {
+        return downloadData(url, "image/.*", scanTypeInContent, maxContentLength, timeout, proxyHost, proxyPort,
+                proxyUser, proxyPassword, nonProxyHosts);
     }
 
     /**
@@ -439,11 +464,34 @@ public class HttpUtil {
             long maxContentLength, int timeout) {
         final ProxyParams proxyParams = prepareProxyParams();
 
+        return downloadData(url, contentTypeRegex, scanTypeInContent, maxContentLength, timeout, proxyParams.proxyHost,
+                proxyParams.proxyPort, proxyParams.proxyUser, proxyParams.proxyPassword, proxyParams.nonProxyHosts);
+    }
+
+    /**
+     * Download the data from a URL.
+     *
+     * @param url the URL of the data to be downloaded
+     * @param contentTypeRegex the REGEX the content type must match; null to ignore the content type
+     * @param scanTypeInContent true to allow the scan of data to determine the content type if not found in the headers
+     * @param maxContentLength the maximum data size in bytes to trigger the download; any negative value to ignore the
+     *            data size
+     * @param timeout the socket timeout in milliseconds to wait for data
+     * @param proxyHost the hostname of the proxy
+     * @param proxyPort the port of the proxy
+     * @param proxyUser the username to authenticate with the proxy
+     * @param proxyPassword the password to authenticate with the proxy
+     * @param nonProxyHosts the hosts that won't be routed through the proxy
+     * @return a RawType object containing the downloaded data, null if the content type does not match the expected
+     *         type or the data size is too big
+     */
+    public static RawType downloadData(String url, String contentTypeRegex, boolean scanTypeInContent,
+            long maxContentLength, int timeout, String proxyHost, Integer proxyPort, String proxyUser,
+            String proxyPassword, String nonProxyHosts) {
         RawType rawData = null;
         try {
-            ContentResponse response = executeUrlAndGetReponse("GET", url, null, null, null, timeout,
-                    proxyParams.proxyHost, proxyParams.proxyPort, proxyParams.proxyUser, proxyParams.proxyPassword,
-                    proxyParams.nonProxyHosts);
+            ContentResponse response = executeUrlAndGetReponse("GET", url, null, null, null, timeout, proxyHost,
+                    proxyPort, proxyUser, proxyPassword, nonProxyHosts);
             byte[] data = response.getContent();
             if (data == null) {
                 data = new byte[0];


### PR DESCRIPTION
This fixes #5730 by introducing `downloadImage` and `downloadData` overloads that take proxy configuration as individual parameters like what's already done for `executeUrl`

This has also been discussed in the forum: https://community.openhab.org/t/proxy-configuration-for-addons/169836/4