### PR TITLE
Fix script providersupport package export

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/ProviderRegistry.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/ProviderRegistry.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.automation.module.script.providersupport.internal;
+package org.openhab.core.automation.module.script.providersupport;
 
 /**
  * Interface to be implemented by all {@link org.openhab.core.common.registry.Registry} (delegates) that are used to

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/ProviderScriptExtension.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/ProviderScriptExtension.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.automation.module.script.providersupport.internal;
+package org.openhab.core.automation.module.script.providersupport;
 
 import java.util.Collection;
 import java.util.HashMap;

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderItemChannelLinkRegistry.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderItemChannelLinkRegistry.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.automation.module.script.providersupport.internal.ProviderRegistry;
+import org.openhab.core.automation.module.script.providersupport.ProviderRegistry;
 import org.openhab.core.common.registry.Registry;
 import org.openhab.core.common.registry.RegistryChangeListener;
 import org.openhab.core.thing.ThingUID;

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderItemRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderItemRegistryDelegate.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.automation.module.script.providersupport.internal.ProviderRegistry;
+import org.openhab.core.automation.module.script.providersupport.ProviderRegistry;
 import org.openhab.core.common.registry.RegistryChangeListener;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderMetadataRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderMetadataRegistryDelegate.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.automation.module.script.providersupport.internal.ProviderRegistry;
+import org.openhab.core.automation.module.script.providersupport.ProviderRegistry;
 import org.openhab.core.common.registry.RegistryChangeListener;
 import org.openhab.core.items.Metadata;
 import org.openhab.core.items.MetadataKey;

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderThingRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderThingRegistryDelegate.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.automation.module.script.providersupport.internal.ProviderRegistry;
+import org.openhab.core.automation.module.script.providersupport.ProviderRegistry;
 import org.openhab.core.common.registry.RegistryChangeListener;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.Channel;


### PR DESCRIPTION
I noticed that Eclipse displayed this warning, and went to investigate:

```
Export org.openhab.core.automation.module.script.providersupport.shared,  has 1,  private references [org.openhab.core.automation.module.script.providersupport.internal] (biz.aQute.bnd:bnd-maven-plugin:7.3.0:bnd-process:default:process-classes)
```

It turns out that the reason for the warning is that `ProviderItemRegistryDelegate` exports (by implementing it) `ProviderRegistry`, but `ProviderRegistry` itself is unavailable for other bundles because it's in an `internal` package. This leads to OSGi resolution problems.

I then looked at `ProviderScriptExtension` and discovered that it too was meant to be used by other bundles, like those running the rules using the methods. I therefore moved both classes out of `internal` so that they will be exported and available for resolution by other bundles.

I see that it has been like this for around a year. I don't quite know why this has worked at all, but I assume that it's because it's primarily been used from Graal, which "doesn't care" about the OSGi export restrictions because it invokes everything using reflection, and will invoke any method that it can find on the actual object in hand. Not everything is as crude as Graal, so this will fail for other some languages.

I'd recommend backporting this, so we don't have to "live with" this issue until 5.3. 