### PR TITLE
Sitemaps: validate icon when provided as string

### DIFF
--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -40,7 +40,7 @@ ModelText:
     ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelGroup:
-    'Group' (('item=' item=GroupItemRef) | ('label=' label=(ID | STRING)) |
+    'Group' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
     ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
@@ -222,12 +222,9 @@ ModelVisibilityRule:
     conditions+=ModelCondition ('AND' conditions+=ModelCondition)*;
 
 ModelCondition:
-    (item=ID)? (condition=('==' | '>' | '<' | '>=' | '<=' | '!='))? (sign=('-' | '+'))? (state=XState);
+    (item=ItemRef)? (condition=('==' | '>' | '<' | '>=' | '<=' | '!='))? (sign=('-' | '+'))? (state=XState);
 
 ItemRef:
-    ID;
-
-GroupItemRef:
     ID;
 
 Icon returns ecore::EString:

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -235,10 +235,10 @@ Icon returns ecore::EString:
 
 // Allow hyphen inside an icon segment
 IconSegment:
-    (ID '-')* ID;
+    INT | ID;
 
 Period:
-    (ID '-')? ID;
+    STRING | ('-'? ID);
 
 Command returns ecore::EString:
     Number | ID | STRING;
@@ -251,8 +251,8 @@ XState returns ecore::EString:
 
 @Override 
 terminal ID:
-    ('^'? ('a'..'z' | 'A'..'Z' | '_') ('a'..'z' | 'A'..'Z' | '_' | '0'..'9')*) |
-    (('0'..'9')+ ('a'..'z' | 'A'..'Z' | '_') ('0'..'9' | 'a'..'z' | 'A'..'Z' | '_')*);
+    ('^'? ('a'..'z' | 'A'..'Z' | '_') ('a'..'z' | 'A'..'Z' | '_' | '-' | '0'..'9')*) |
+    (('0'..'9')+ ('a'..'z' | 'A'..'Z' | '_' | '-') ('a'..'z' | 'A'..'Z' | '_' | '-' | '0'..'9')*);
 
 terminal FLOAT returns ecore::EBigDecimal:
     INT '.' INT;

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -231,10 +231,10 @@ GroupItemRef:
     ID;
 
 Icon returns ecore::EString:
-    STRING | (ID ':' (ID ':')?)? IconName;
+    STRING | (IconSegment ':' (IconSegment ':')?)? IconSegment;
 
-// Allow hyphen inside an icon name
-IconName:
+// Allow hyphen inside an icon segment
+IconSegment:
     (ID '-')* ID;
 
 Period:

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
@@ -82,6 +82,15 @@ class SitemapValidator extends AbstractSitemapValidator {
     }
 
     @Check
+    def checkSitemapName(ModelSitemap sitemap) {
+        val name = sitemap.name
+        if (name.contains("-") || name.substring(0, 1).matches("[0-9]")) {
+            error(buildMsgWithLineNb("Sitemap name must not contain dash and must not start with a number", sitemap, null, null),
+                SitemapPackage.Literals.MODEL_WIDGET.getEStructuralFeature(SitemapPackage.MODEL_SITEMAP__NAME))
+        }
+    }
+    
+    @Check
     def void checkAtLeastOneWidget(ModelSitemap sitemap) {
         if (sitemap.children === null || sitemap.children.size === 0) {
             warning(buildMsgWithLineNb("Sitemap should have at least one widget", sitemap, null, null),
@@ -116,6 +125,18 @@ class SitemapValidator extends AbstractSitemapValidator {
         }
     }
 
+    @Check
+    def checkWidgetItemName(ModelWidget w) {
+        val item = w.item
+        if (item === null) {
+            return
+        }
+        if (item.contains("-") || item.substring(0, 1).matches("[0-9]")) {
+            error(buildMsgWithLineNb(getWidgetType(w) + " widget item name must not contain dash and must not start with a number", w, null, null),
+                SitemapPackage.Literals.MODEL_WIDGET.getEStructuralFeature(SitemapPackage.MODEL_WIDGET__ITEM))
+        }
+    }
+    
     @Check
     def void checkWidgetIcon(ModelWidget w) {
         val className = getWidgetType(w)

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
@@ -38,6 +38,7 @@ import org.openhab.core.model.sitemap.sitemap.ModelWebview
 import org.openhab.core.model.sitemap.sitemap.ModelVideo
 import org.openhab.core.model.sitemap.sitemap.ModelWidget
 import org.openhab.core.model.sitemap.sitemap.SitemapPackage
+import org.openhab.core.model.sitemap.sitemap.ModelCondition
 
 /**
  * Custom validation rules.
@@ -86,7 +87,7 @@ class SitemapValidator extends AbstractSitemapValidator {
         val name = sitemap.name
         if (name.contains("-") || name.substring(0, 1).matches("[0-9]")) {
             error(buildMsgWithLineNb("Sitemap name must not contain dash and must not start with a number", sitemap, null, null),
-                SitemapPackage.Literals.MODEL_WIDGET.getEStructuralFeature(SitemapPackage.MODEL_SITEMAP__NAME))
+                SitemapPackage.Literals.MODEL_SITEMAP.getEStructuralFeature(SitemapPackage.MODEL_SITEMAP__NAME))
         }
     }
     
@@ -125,18 +126,34 @@ class SitemapValidator extends AbstractSitemapValidator {
         }
     }
 
+    private def boolean isInvalidItemName(String name) {
+        return !name.isEmpty && (name.contains("-") || name.substring(0, 1).matches("[0-9]"))
+    }
+
     @Check
     def checkWidgetItemName(ModelWidget w) {
         val item = w.item
         if (item === null) {
             return
         }
-        if (item.contains("-") || item.substring(0, 1).matches("[0-9]")) {
+        if (isInvalidItemName(item)) {
             error(buildMsgWithLineNb(getWidgetType(w) + " widget item name must not contain dash and must not start with a number", w, null, null),
                 SitemapPackage.Literals.MODEL_WIDGET.getEStructuralFeature(SitemapPackage.MODEL_WIDGET__ITEM))
         }
     }
     
+    @Check
+    def checkConditionItemName(ModelCondition c) {
+        val item = c.item
+        if (item === null || item.isEmpty) {
+            return
+        }
+        if (isInvalidItemName(item)) {
+            error(buildMsgWithLineNb("Item name must not contain dash and must not start with a number", c, null, null),
+                SitemapPackage.Literals.MODEL_CONDITION.getEStructuralFeature(SitemapPackage.MODEL_CONDITION__ITEM))
+        }
+    }
+
     @Check
     def void checkWidgetIcon(ModelWidget w) {
         val className = getWidgetType(w)

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/valueconverter/SitemapConverters.java
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/valueconverter/SitemapConverters.java
@@ -41,10 +41,6 @@ public class SitemapConverters extends DefaultTerminalConverters {
                         || (string.startsWith("\"") && string.endsWith("\""))) {
                     trimmedString = STRING().toValue(string, node);
                 }
-                // For backward compatibility, we allow the icon name to contain a file extension, but we remove it when
-                // validating the name
-                int lastDotIndex = trimmedString.lastIndexOf(".");
-                trimmedString = lastDotIndex != -1 ? trimmedString.substring(0, lastDotIndex) : trimmedString;
                 String[] segments = trimmedString.split(":", -1);
                 if (segments.length > 3) {
                     throw new ValueConverterException("Icon name cannot contain more than 3 segments separated by ':'",
@@ -55,7 +51,16 @@ public class SitemapConverters extends DefaultTerminalConverters {
                     if (i != 0) {
                         sb.append(":");
                     }
-                    String[] parts = segments[i].split("-", -1);
+                    String segment = segments[i];
+                    if (i == segments.length - 1) {
+                        // For backward compatibility, we allow the icon name to contain a file extension, but we remove
+                        // it when validating the name
+                        int lastDotIndex = segment.lastIndexOf(".");
+                        segment = (lastDotIndex != -1) && (lastDotIndex != segment.length() - 1)
+                                ? segment.substring(0, lastDotIndex)
+                                : segment;
+                    }
+                    String[] parts = segment.split("-", -1);
                     for (int j = 0; j < parts.length; j++) {
                         if (j != 0) {
                             sb.append("-");

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/valueconverter/SitemapConverters.java
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/valueconverter/SitemapConverters.java
@@ -43,7 +43,9 @@ public class SitemapConverters extends DefaultTerminalConverters {
                 }
                 // For backward compatibility, we allow the icon name to contain a file extension, but we remove it when
                 // validating the name
-                String[] segments = trimmedString.split("\\.")[0].trim().split(":", -1);
+                int lastDotIndex = trimmedString.lastIndexOf(".");
+                trimmedString = lastDotIndex != -1 ? trimmedString.substring(0, lastDotIndex) : trimmedString;
+                String[] segments = trimmedString.split(":", -1);
                 if (segments.length > 3) {
                     throw new ValueConverterException("Icon name cannot contain more than 3 segments separated by ':'",
                             node, null);
@@ -62,7 +64,7 @@ public class SitemapConverters extends DefaultTerminalConverters {
                             throw new ValueConverterException(
                                     "Icon name segment '" + segments[i] + "' is not a valid identifier", node, null);
                         }
-                        sb.append(parts[j]);
+                        sb.append(ID().toValue(parts[j], node));
                     }
                 }
                 return sb.toString();

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/valueconverter/SitemapConverters.java
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/valueconverter/SitemapConverters.java
@@ -24,11 +24,13 @@ import org.eclipse.xtext.nodemodel.INode;
 public class SitemapConverters extends DefaultTerminalConverters {
 
     private static final Pattern ID_PATTERN = Pattern
-            .compile("(?:[A-Za-z_][A-Za-z_0-9]*|[0-9]+[A-Za-z_][A-Za-z_0-9]*)");
-    // allow for ^ prefix when parsing DSL to escape reserved names
-    private static final Pattern ID_EXT_PATTERN = Pattern
-            .compile("(?:\\^?[A-Za-z_][A-Za-z_0-9]*|[0-9]+[A-Za-z_][A-Za-z_0-9]*)");
-    private static final Pattern INT_PATTERN = Pattern.compile("[0-9]+");
+            .compile("(?:[A-Za-z_\\-][A-Za-z_\\-0-9]*|[0-9]+[A-Za-z_\\-][A-Za-z_\\-0-9]*)");
+    private static final Pattern INT_PATTERN = Pattern.compile("(?:[0-9]+)");
+    private static final Pattern ICON_SEGMENT_PATTERN = Pattern.compile("(?:[A-Za-z_0-9][A-Za-z_0-9\\-]*)");
+    private static final Pattern PERIOD_PATTERN = Pattern.compile("""
+            (?:(P(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+S)?)?|\\d*[YMWDh])-)?\
+            -?((P(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+S)?)?|\\d*[YMWDh])?)\
+            """);
 
     @ValueConverter(rule = "Icon")
     public IValueConverter<String> Icon() {
@@ -60,17 +62,13 @@ public class SitemapConverters extends DefaultTerminalConverters {
                                 ? segment.substring(0, lastDotIndex)
                                 : segment;
                     }
-                    String[] parts = segment.split("-", -1);
-                    for (int j = 0; j < parts.length; j++) {
-                        if (j != 0) {
-                            sb.append("-");
-                        }
-                        if (!ID_EXT_PATTERN.matcher(parts[j]).matches()) {
-                            throw new ValueConverterException(
-                                    "Icon name segment '" + segments[i] + "' is not a valid identifier", node, null);
-                        }
-                        sb.append(ID().toValue(parts[j], node));
+                    // allow for ^ prefix when parsing DSL to escape reserved names
+                    segment = segment.startsWith("^") ? segment.substring(1) : segment;
+                    if (!ICON_SEGMENT_PATTERN.matcher(segment).matches()) {
+                        throw new ValueConverterException(
+                                "Icon name segment '" + segment + "' is not a valid identifier", node, null);
                     }
+                    sb.append(segment);
                 }
                 return sb.toString();
             }
@@ -86,16 +84,10 @@ public class SitemapConverters extends DefaultTerminalConverters {
                     if (i != 0) {
                         sb.append(":");
                     }
-                    String[] parts = segments[i].split("-", -1);
-                    for (int j = 0; j < parts.length; j++) {
-                        if (j != 0) {
-                            sb.append("-");
-                        }
-                        if (!ID_PATTERN.matcher(parts[j]).matches()) {
-                            return STRING().toString(value);
-                        }
-                        sb.append(ID().toString(parts[j]));
+                    if (!ICON_SEGMENT_PATTERN.matcher(segments[i]).matches()) {
+                        return STRING().toString(value);
                     }
+                    sb.append(ID().toString(segments[i]));
                 }
                 return sb.toString();
             }
@@ -112,7 +104,9 @@ public class SitemapConverters extends DefaultTerminalConverters {
                         || (string.startsWith("\"") && string.endsWith("\""))) {
                     return STRING().toValue(string, node);
                 }
-                if (ID_EXT_PATTERN.matcher(string).matches()) {
+                // allow for ^ prefix when parsing DSL to escape reserved names
+                String trimmedString = string.startsWith("^") ? string.substring(1) : string;
+                if (ID_PATTERN.matcher(trimmedString).matches()) {
                     return ID().toValue(string, node);
                 }
                 // Don't interpret each part as INT() to preserve leading zeros, but validate that they are numbers
@@ -162,6 +156,43 @@ public class SitemapConverters extends DefaultTerminalConverters {
             @Override
             protected String internalToString(String value) throws ValueConverterException {
                 if (ID_PATTERN.matcher(value).matches()) {
+                    return ID().toString(value);
+                } else {
+                    return STRING().toString(value);
+                }
+            }
+        };
+    }
+
+    @ValueConverter(rule = "Period")
+    public IValueConverter<String> Period() {
+        return new AbstractNullSafeConverter<>() {
+            @Override
+            protected String internalToValue(String string, INode node) throws ValueConverterException {
+                boolean isQuoted = (string.startsWith("'") && string.endsWith("'"))
+                        || (string.startsWith("\"") && string.endsWith("\""));
+                boolean startsWithDash = false;
+                String trimmedString = isQuoted ? STRING().toValue(string, node) : string;
+                if (trimmedString.startsWith("-")) {
+                    startsWithDash = true;
+                    trimmedString = trimmedString.substring(1);
+                }
+                // allow for ^ prefix when parsing DSL to escape reserved names
+                trimmedString = trimmedString.startsWith("^") ? trimmedString.substring(1) : trimmedString;
+                if (!PERIOD_PATTERN.matcher(trimmedString).matches()) {
+                    throw new ValueConverterException("Period value '" + trimmedString
+                            + "' is not a valid period format, should be ISO 8601 'PnYnMnDTnHnMnS-PnYnMnDTnHnMnS'",
+                            node, null);
+                }
+                if (isQuoted) {
+                    return STRING().toValue(string, node);
+                }
+                return (startsWithDash ? "-" : "") + trimmedString;
+            }
+
+            @Override
+            protected String internalToString(String value) throws ValueConverterException {
+                if (PERIOD_PATTERN.matcher(value).matches()) {
                     return ID().toString(value);
                 } else {
                     return STRING().toString(value);

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/valueconverter/SitemapConverters.java
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/valueconverter/SitemapConverters.java
@@ -36,65 +36,60 @@ public class SitemapConverters extends DefaultTerminalConverters {
         return new AbstractNullSafeConverter<>() {
             @Override
             public String internalToValue(String string, INode node) throws ValueConverterException {
+                String trimmedString = string;
                 if ((string.startsWith("'") && string.endsWith("'"))
                         || (string.startsWith("\"") && string.endsWith("\""))) {
-                    return STRING().toValue(string, node);
+                    trimmedString = STRING().toValue(string, node);
                 }
-                String[] parts = string.split(":", -1);
-                if (parts.length > 3) {
-                    throw new ValueConverterException("Icon name cannot contain more than 3 parts separated by ':'",
+                // For backward compatibility, we allow the icon name to contain a file extension, but we remove it when
+                // validating the name
+                String[] segments = trimmedString.split("\\.")[0].trim().split(":", -1);
+                if (segments.length > 3) {
+                    throw new ValueConverterException("Icon name cannot contain more than 3 segments separated by ':'",
                             node, null);
                 }
                 StringBuilder sb = new StringBuilder();
-                for (int i = 0; i < parts.length - 1; i++) {
-                    if (!ID_EXT_PATTERN.matcher(parts[i]).matches()) {
-                        throw new ValueConverterException("Icon name part '" + parts[i] + "' is not a valid identifier",
-                                node, null);
-                    }
-                    sb.append(ID().toValue(parts[i], node)).append(":");
-                }
-                String[] lastParts = parts[parts.length - 1].split("-", -1);
-                for (int i = 0; i < lastParts.length; i++) {
+                for (int i = 0; i < segments.length; i++) {
                     if (i != 0) {
-                        sb.append("-");
+                        sb.append(":");
                     }
-                    if (!ID_EXT_PATTERN.matcher(lastParts[i]).matches()) {
-                        throw new ValueConverterException(
-                                "Icon name part '" + parts[parts.length - 1] + "' is not a valid identifier", node,
-                                null);
+                    String[] parts = segments[i].split("-", -1);
+                    for (int j = 0; j < parts.length; j++) {
+                        if (j != 0) {
+                            sb.append("-");
+                        }
+                        if (!ID_EXT_PATTERN.matcher(parts[j]).matches()) {
+                            throw new ValueConverterException(
+                                    "Icon name segment '" + segments[i] + "' is not a valid identifier", node, null);
+                        }
+                        sb.append(parts[j]);
                     }
-                    sb.append(ID().toValue(lastParts[i], node));
                 }
                 return sb.toString();
             }
 
             @Override
             public String internalToString(String value) throws ValueConverterException {
-                if (containsWhiteSpace(value)) {
-                    return STRING().toString(value);
-                }
-                String[] parts = value.split(":", -1);
-                if (parts.length > 3) {
+                String[] segments = value.split(":", -1);
+                if (segments.length > 3) {
                     return STRING().toString(value);
                 }
                 StringBuilder sb = new StringBuilder();
-                for (int i = 0; i < parts.length - 1; i++) {
-                    if (!ID_PATTERN.matcher(parts[i]).matches()) {
-                        return STRING().toString(value);
-                    }
-                    sb.append(ID().toString(parts[i])).append(":");
-                }
-                String[] lastParts = parts[parts.length - 1].split("-", -1);
-                for (int i = 0; i < lastParts.length; i++) {
+                for (int i = 0; i < segments.length; i++) {
                     if (i != 0) {
-                        sb.append("-");
+                        sb.append(":");
                     }
-                    if (!ID_PATTERN.matcher(lastParts[i]).matches()) {
-                        return STRING().toString(value);
+                    String[] parts = segments[i].split("-", -1);
+                    for (int j = 0; j < parts.length; j++) {
+                        if (j != 0) {
+                            sb.append("-");
+                        }
+                        if (!ID_PATTERN.matcher(parts[j]).matches()) {
+                            return STRING().toString(value);
+                        }
+                        sb.append(ID().toString(parts[j]));
                     }
-                    sb.append(ID().toString(lastParts[i]));
                 }
-
                 return sb.toString();
             }
         };
@@ -166,16 +161,5 @@ public class SitemapConverters extends DefaultTerminalConverters {
                 }
             }
         };
-    }
-
-    public static boolean containsWhiteSpace(final String string) {
-        if (string != null) {
-            for (int i = 0; i < string.length(); i++) {
-                if (Character.isWhitespace(string.charAt(i))) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 }

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/valueconverter/SitemapConverters.java
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/valueconverter/SitemapConverters.java
@@ -24,7 +24,7 @@ import org.eclipse.xtext.nodemodel.INode;
 public class SitemapConverters extends DefaultTerminalConverters {
 
     private static final Pattern ID_PATTERN = Pattern
-            .compile("(?:[A-Za-z_\\-][A-Za-z_\\-0-9]*|[0-9]+[A-Za-z_\\-][A-Za-z_\\-0-9]*)");
+            .compile("(?:[A-Za-z_][A-Za-z_\\-0-9]*|[0-9]+[A-Za-z_\\-][A-Za-z_\\-0-9]*)");
     private static final Pattern INT_PATTERN = Pattern.compile("(?:[0-9]+)");
     private static final Pattern ICON_SEGMENT_PATTERN = Pattern.compile("(?:[A-Za-z_0-9][A-Za-z_0-9\\-]*)");
     private static final Pattern PERIOD_PATTERN = Pattern.compile("""


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-core/issues/5706

Hypens are now allowed in all segments of an icon name, with a maximum of 3 segments separated by :.
Icons names provided as a string will also get validated with the same rules and throw an error when not valid.
For backward compatibility, file extensions are still allowed DSL definitions of icons (only when provided as a string in quotes), but will be dropped when loading the DSL file, or saving in the UI. This should avoid problems with old sitemaps and conversions to YAML.