### PR TITLE
Sitemaps: widget order in sitemap groups

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -871,28 +871,21 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     private void sortByMetadata(List<Item> members) {
-        members.sort((u1, u2) -> {
-            String u1Name = u1.getName();
-            String u2Name = u2.getName();
+        // Location items are sorted among themselves (by hierarchy, then widgetOrder),
+        // and placed ahead of all other members.
+        Map<Boolean, List<Item>> byLocation = members.stream().collect(Collectors.partitioningBy(this::isLocationItem));
+        List<Item> sorted = new ArrayList<>(byLocation.getOrDefault(true, List.of()).stream()
+                .sorted(Comparator.comparing(Item::getName, this::compareLocationMembers)).toList());
+        sorted.addAll(byLocation.getOrDefault(false, List.of()).stream()
+                .sorted(Comparator.comparing(Item::getName, this::compareWidgetOrder)).toList());
+        members.clear();
+        members.addAll(sorted);
+    }
 
-            boolean isLocationContext = true;
-            MetadataKey u1SemanticsKey = new MetadataKey(SEMANTICS_KEY, u1Name);
-            Metadata u1Semantics = metadataRegistry.get(u1SemanticsKey);
-            isLocationContext &= (u1Semantics != null && u1Semantics.getValue().startsWith(SEMANTICS_LOCATION));
-            MetadataKey u2SemanticsKey = new MetadataKey(SEMANTICS_KEY, u2Name);
-            Metadata u2Semantics = metadataRegistry.get(u2SemanticsKey);
-            isLocationContext &= (u2Semantics != null && u2Semantics.getValue().startsWith(SEMANTICS_LOCATION));
-
-            if (isLocationContext) {
-                int modelOrder = compareLocationParents(u1Name, u2Name);
-                if (modelOrder != 0) {
-                    // For Location Items, own-item widgetOrder only used to compare Items sharing the same parent
-                    // location
-                    return modelOrder;
-                }
-            }
-            return compareWidgetOrder(u1Name, u2Name);
-        });
+    private boolean isLocationItem(Item item) {
+        MetadataKey semanticsKey = new MetadataKey(SEMANTICS_KEY, item.getName());
+        Metadata semantics = metadataRegistry.get(semanticsKey);
+        return semantics != null && semantics.getValue().startsWith(SEMANTICS_LOCATION);
     }
 
     private String getItemLabel(Item item) {
@@ -912,24 +905,18 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return isPartOf instanceof String ? (String) isPartOf : null;
     }
 
-    /**
-     * Compares items based on widgetOrder or lexicographical order of their ancestors in Model (starting at the top
-     * level)
-     *
-     * @param u1
-     * @param u2
-     * @return 0 if both items are siblings, -1 if u1 is before u2, 1 if u1 is after u2
-     */
-    private int compareLocationParents(String u1Name, String u2Name) {
+    private int compareLocationMembers(String u1Name, String u2Name) {
         List<String> u1Ancestors = new ArrayList<>();
+        u1Ancestors.add(u1Name);
         String u1ParentName = getParentLocationName(u1Name);
-        while (u1ParentName != null) {
+        while (u1ParentName != null && !u1Ancestors.contains(u1ParentName)) {
             u1Ancestors.add(u1ParentName);
             u1ParentName = getParentLocationName(u1ParentName);
         }
         List<String> u2Ancestors = new ArrayList<>();
+        u2Ancestors.add(u2Name);
         String u2ParentName = getParentLocationName(u2Name);
-        while (u2ParentName != null) {
+        while (u2ParentName != null && !u2Ancestors.contains(u2ParentName)) {
             u2Ancestors.add(u2ParentName);
             u2ParentName = getParentLocationName(u2ParentName);
         }
@@ -954,9 +941,13 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         MetadataKey u2Key = new MetadataKey(WIDGET_ORDER_KEY, u2Name);
         Metadata u2Order = metadataRegistry.get(u2Key);
         Float u1OrderValue = null;
-        Float u2OrderValue = null;
         try {
             u1OrderValue = u1Order != null ? Float.parseFloat(u1Order.getValue()) : null;
+        } catch (NumberFormatException e) {
+            // ignore
+        }
+        Float u2OrderValue = null;
+        try {
             u2OrderValue = u2Order != null ? Float.parseFloat(u2Order.getValue()) : null;
         } catch (NumberFormatException e) {
             // ignore

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -131,7 +131,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     private static final int MAX_BUTTONS = 4;
 
     private static final String DEFAULT_SORTING = "NONE";
-    private static final String WIDGET_ORDER_KEY = "widgetOrder";
+    protected static final String WIDGET_ORDER_KEY = "widgetOrder";
 
     private final Logger logger = LoggerFactory.getLogger(ItemUIRegistryImpl.class);
 
@@ -837,12 +837,13 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                         case "LABEL":
                             members.sort((u1, u2) -> {
                                 String u1Label = u1.getLabel();
+                                u1Label = u1Label != null ? u1Label : u1.getName();
                                 String u2Label = u2.getLabel();
-                                if (u1Label != null && u2Label != null) {
-                                    return u1Label.compareTo(u2Label);
-                                } else {
+                                u2Label = u2Label != null ? u2Label : u2.getName();
+                                if (u1Label.equals(u2Label)) {
                                     return u1.getName().compareTo(u2.getName());
                                 }
+                                return u1Label.compareTo(u2Label);
                             });
                             break;
                         case "NAME":
@@ -862,6 +863,8 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                                     return 1;
                                 } else if (u2OrderValue == null) {
                                     return -1;
+                                } else if (u1OrderValue.equals(u2OrderValue)) {
+                                    return u1.getName().compareTo(u2.getName());
                                 } else {
                                     return u1OrderValue.compareTo(u2OrderValue);
                                 }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -132,6 +132,9 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
     private static final String DEFAULT_SORTING = "NONE";
     protected static final String WIDGET_ORDER_KEY = "widgetOrder";
+    protected static final String SEMANTICS_KEY = "semantics";
+    protected static final String SEMANTICS_LOCATION = "Location";
+    protected static final String SEMANTICS_PARENT_LOCATION_CONFIG = "isPartOf";
 
     private final Logger logger = LoggerFactory.getLogger(ItemUIRegistryImpl.class);
 
@@ -835,40 +838,13 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                     List<Item> members = new ArrayList<>(groupItem.getMembers());
                     switch (groupMembersSorting) {
                         case "LABEL":
-                            members.sort((u1, u2) -> {
-                                String u1Label = u1.getLabel();
-                                u1Label = u1Label != null ? u1Label : u1.getName();
-                                String u2Label = u2.getLabel();
-                                u2Label = u2Label != null ? u2Label : u2.getName();
-                                if (u1Label.equals(u2Label)) {
-                                    return u1.getName().compareTo(u2.getName());
-                                }
-                                return u1Label.compareTo(u2Label);
-                            });
+                            members.sort(Comparator.comparing(this::getItemLabel));
                             break;
                         case "NAME":
                             members.sort(Comparator.comparing(Item::getName));
                             break;
                         case "METADATA":
-                            members.sort((u1, u2) -> {
-                                MetadataKey u1Key = new MetadataKey(WIDGET_ORDER_KEY, u1.getName());
-                                Metadata u1Order = metadataRegistry.get(u1Key);
-                                String u1OrderValue = u1Order != null ? u1Order.getValue() : null;
-                                MetadataKey u2Key = new MetadataKey(WIDGET_ORDER_KEY, u2.getName());
-                                Metadata u2Order = metadataRegistry.get(u2Key);
-                                String u2OrderValue = u2Order != null ? u2Order.getValue() : null;
-                                if (u1OrderValue == null && u2OrderValue == null) {
-                                    return u1.getName().compareTo(u2.getName());
-                                } else if (u1OrderValue == null) {
-                                    return 1;
-                                } else if (u2OrderValue == null) {
-                                    return -1;
-                                } else if (u1OrderValue.equals(u2OrderValue)) {
-                                    return u1.getName().compareTo(u2.getName());
-                                } else {
-                                    return u1OrderValue.compareTo(u2OrderValue);
-                                }
-                            });
+                            sortByMetadata(members);
                             break;
                         default:
                             break;
@@ -892,6 +868,110 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                     group.getLabel(), itemName);
         }
         return children;
+    }
+
+    private void sortByMetadata(List<Item> members) {
+        members.sort((u1, u2) -> {
+            String u1Name = u1.getName();
+            String u2Name = u2.getName();
+
+            boolean isLocationContext = true;
+            MetadataKey u1SemanticsKey = new MetadataKey(SEMANTICS_KEY, u1Name);
+            Metadata u1Semantics = metadataRegistry.get(u1SemanticsKey);
+            isLocationContext &= (u1Semantics != null && u1Semantics.getValue().startsWith(SEMANTICS_LOCATION));
+            MetadataKey u2SemanticsKey = new MetadataKey(SEMANTICS_KEY, u2Name);
+            Metadata u2Semantics = metadataRegistry.get(u2SemanticsKey);
+            isLocationContext &= (u2Semantics != null && u2Semantics.getValue().startsWith(SEMANTICS_LOCATION));
+
+            if (isLocationContext) {
+                int modelOrder = compareLocationParents(u1Name, u2Name);
+                if (modelOrder != 0) {
+                    // For Location Items, own-item widgetOrder only used to compare Items sharing the same parent
+                    // location
+                    return modelOrder;
+                }
+            }
+            return compareWidgetOrder(u1Name, u2Name);
+        });
+    }
+
+    private String getItemLabel(Item item) {
+        String label = item.getLabel();
+        return label != null ? label : item.getName();
+    }
+
+    private String getItemLabel(String itemName) {
+        Item item = get(itemName);
+        return item != null ? getItemLabel(item) : itemName;
+    }
+
+    private @Nullable String getParentLocationName(String locationItemName) {
+        MetadataKey semanticsKey = new MetadataKey(SEMANTICS_KEY, locationItemName);
+        Metadata semantics = metadataRegistry.get(semanticsKey);
+        Object isPartOf = semantics != null ? semantics.getConfiguration().get(SEMANTICS_PARENT_LOCATION_CONFIG) : null;
+        return isPartOf instanceof String ? (String) isPartOf : null;
+    }
+
+    /**
+     * Compares items based on widgetOrder or lexicographical order of their ancestors in Model (starting at the top
+     * level)
+     *
+     * @param u1
+     * @param u2
+     * @return 0 if both items are siblings, -1 if u1 is before u2, 1 if u1 is after u2
+     */
+    private int compareLocationParents(String u1Name, String u2Name) {
+        List<String> u1Ancestors = new ArrayList<>();
+        String u1ParentName = getParentLocationName(u1Name);
+        while (u1ParentName != null) {
+            u1Ancestors.add(u1ParentName);
+            u1ParentName = getParentLocationName(u1ParentName);
+        }
+        List<String> u2Ancestors = new ArrayList<>();
+        String u2ParentName = getParentLocationName(u2Name);
+        while (u2ParentName != null) {
+            u2Ancestors.add(u2ParentName);
+            u2ParentName = getParentLocationName(u2ParentName);
+        }
+
+        int u1Depth = u1Ancestors.size();
+        int u2Depth = u2Ancestors.size();
+        int minDepth = Math.min(u1Depth, u2Depth);
+        for (int d = 0; d < minDepth; d++) {
+            String ancestorName1 = u1Ancestors.get(u1Depth - 1 - d);
+            String ancestorName2 = u2Ancestors.get(u2Depth - 1 - d);
+            if (!ancestorName1.equals(ancestorName2)) {
+                return compareWidgetOrder(ancestorName1, ancestorName2);
+            }
+        }
+        // A parent comes before its children
+        return Integer.compare(u1Depth, u2Depth);
+    }
+
+    private int compareWidgetOrder(String u1Name, String u2Name) {
+        MetadataKey u1Key = new MetadataKey(WIDGET_ORDER_KEY, u1Name);
+        Metadata u1Order = metadataRegistry.get(u1Key);
+        MetadataKey u2Key = new MetadataKey(WIDGET_ORDER_KEY, u2Name);
+        Metadata u2Order = metadataRegistry.get(u2Key);
+        Float u1OrderValue = null;
+        Float u2OrderValue = null;
+        try {
+            u1OrderValue = u1Order != null ? Float.parseFloat(u1Order.getValue()) : null;
+            u2OrderValue = u2Order != null ? Float.parseFloat(u2Order.getValue()) : null;
+        } catch (NumberFormatException e) {
+            // ignore
+        }
+
+        if ((u1OrderValue == null && u2OrderValue == null)
+                || (u1OrderValue != null && u1OrderValue.equals(u2OrderValue))) {
+            return getItemLabel(u1Name).compareTo(getItemLabel(u2Name));
+        } else if (u1OrderValue == null) {
+            return 1;
+        } else if (u2OrderValue == null) {
+            return -1;
+        } else {
+            return u1OrderValue.compareTo(u2OrderValue);
+        }
     }
 
     private boolean isReadOnly(String itemName) {

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -44,6 +44,9 @@ import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemNotUniqueException;
 import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.Metadata;
+import org.openhab.core.items.MetadataKey;
+import org.openhab.core.items.MetadataRegistry;
 import org.openhab.core.library.items.CallItem;
 import org.openhab.core.library.items.ColorItem;
 import org.openhab.core.library.items.ContactItem;
@@ -128,12 +131,14 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     private static final int MAX_BUTTONS = 4;
 
     private static final String DEFAULT_SORTING = "NONE";
+    private static final String WIDGET_ORDER_KEY = "widgetOrder";
 
     private final Logger logger = LoggerFactory.getLogger(ItemUIRegistryImpl.class);
 
     protected final Set<ItemUIProvider> itemUIProviders = new HashSet<>();
 
     private final ItemRegistry itemRegistry;
+    private final MetadataRegistry metadataRegistry;
     private final SitemapFactory sitemapFactory;
     private final TimeZoneProvider timeZoneProvider;
 
@@ -153,8 +158,10 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
     @Activate
     public ItemUIRegistryImpl(final @Reference ItemRegistry itemRegistry,
-            final @Reference SitemapFactory sitemapFactory, final @Reference TimeZoneProvider timeZoneProvider) {
+            final @Reference MetadataRegistry metadataRegistry, final @Reference SitemapFactory sitemapFactory,
+            final @Reference TimeZoneProvider timeZoneProvider) {
         this.itemRegistry = itemRegistry;
+        this.metadataRegistry = metadataRegistry;
         this.sitemapFactory = sitemapFactory;
         this.timeZoneProvider = timeZoneProvider;
     }
@@ -840,6 +847,25 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                             break;
                         case "NAME":
                             members.sort(Comparator.comparing(Item::getName));
+                            break;
+                        case "METADATA":
+                            members.sort((u1, u2) -> {
+                                MetadataKey u1Key = new MetadataKey(WIDGET_ORDER_KEY, u1.getName());
+                                Metadata u1Order = metadataRegistry.get(u1Key);
+                                String u1OrderValue = u1Order != null ? u1Order.getValue() : null;
+                                MetadataKey u2Key = new MetadataKey(WIDGET_ORDER_KEY, u2.getName());
+                                Metadata u2Order = metadataRegistry.get(u2Key);
+                                String u2OrderValue = u2Order != null ? u2Order.getValue() : null;
+                                if (u1OrderValue == null && u2OrderValue == null) {
+                                    return u1.getName().compareTo(u2.getName());
+                                } else if (u1OrderValue == null) {
+                                    return 1;
+                                } else if (u2OrderValue == null) {
+                                    return -1;
+                                } else {
+                                    return u1OrderValue.compareTo(u2OrderValue);
+                                }
+                            });
                             break;
                         default:
                             break;

--- a/bundles/org.openhab.core.ui/src/main/resources/OH-INF/config/sitemap.xml
+++ b/bundles/org.openhab.core.ui/src/main/resources/OH-INF/config/sitemap.xml
@@ -14,6 +14,7 @@
 				<option value="NONE">No sorting</option>
 				<option value="LABEL">Sorted by label</option>
 				<option value="NAME">Sorted by name</option>
+				<option value="METADATA">Sorted by item widget order metadata</option>
 			</options>
 			<default>NONE</default>
 		</parameter>

--- a/bundles/org.openhab.core.ui/src/main/resources/OH-INF/i18n/sitemap.properties
+++ b/bundles/org.openhab.core.ui/src/main/resources/OH-INF/i18n/sitemap.properties
@@ -3,6 +3,6 @@ system.config.sitemap.groupMembersSorting.description = Defines how the members 
 system.config.sitemap.groupMembersSorting.option.NONE = No sorting
 system.config.sitemap.groupMembersSorting.option.LABEL = Sorted by label
 system.config.sitemap.groupMembersSorting.option.NAME = Sorted by name
-system.config.sitemap.groupMembersSorting.option.METADATA = Sorted by semantic location and widgetOrder metadata
+system.config.sitemap.groupMembersSorting.option.METADATA = Sorted by item widget order metadata
 
 service.system.sitemap.label = Sitemap

--- a/bundles/org.openhab.core.ui/src/main/resources/OH-INF/i18n/sitemap.properties
+++ b/bundles/org.openhab.core.ui/src/main/resources/OH-INF/i18n/sitemap.properties
@@ -3,5 +3,6 @@ system.config.sitemap.groupMembersSorting.description = Defines how the members 
 system.config.sitemap.groupMembersSorting.option.NONE = No sorting
 system.config.sitemap.groupMembersSorting.option.LABEL = Sorted by label
 system.config.sitemap.groupMembersSorting.option.NAME = Sorted by name
+system.config.sitemap.groupMembersSorting.option.METADATA = Sorted by semantic location and widgetOrder metadata
 
 service.system.sitemap.label = Sitemap

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
@@ -43,6 +43,7 @@ import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.MetadataRegistry;
 import org.openhab.core.library.items.CallItem;
 import org.openhab.core.library.items.ColorItem;
 import org.openhab.core.library.items.ContactItem;
@@ -116,6 +117,7 @@ public class ItemUIRegistryImplTest {
     private @NonNullByDefault({}) ItemUIRegistryImpl uiRegistry;
 
     private @Mock @NonNullByDefault({}) ItemRegistry registryMock;
+    private @Mock @NonNullByDefault({}) MetadataRegistry metadataRegistryMock;
     private @Mock @NonNullByDefault({}) SitemapFactory sitemapFactoryMock;
     private @Mock @NonNullByDefault({}) TimeZoneProvider timeZoneProviderMock;
     private @Mock @NonNullByDefault({}) Sitemap sitemapMock;
@@ -153,7 +155,8 @@ public class ItemUIRegistryImplTest {
     @BeforeEach
     @SuppressWarnings("PMD.SetDefaultTimeZone")
     public void setup() throws Exception {
-        uiRegistry = new ItemUIRegistryImpl(registryMock, sitemapFactoryMock, timeZoneProviderMock);
+        uiRegistry = new ItemUIRegistryImpl(registryMock, metadataRegistryMock, sitemapFactoryMock,
+                timeZoneProviderMock);
 
         when(widgetMock.getItem()).thenReturn(ITEM_NAME);
         when(registryMock.getItem(ITEM_NAME)).thenReturn(itemMock);

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
@@ -165,8 +165,8 @@ public class ItemUIRegistryImplTest {
     @BeforeEach
     @SuppressWarnings("PMD.SetDefaultTimeZone")
     public void setup() throws Exception {
-        uiRegistry = new ItemUIRegistryImpl(registryMock, metadataRegistryMock, sitemapFactoryMock,
-                timeZoneProviderMock);
+        uiRegistry = spy(
+                new ItemUIRegistryImpl(registryMock, metadataRegistryMock, sitemapFactoryMock, timeZoneProviderMock));
 
         when(widgetMock.getItem()).thenReturn(ITEM_NAME);
         when(registryMock.getItem(ITEM_NAME)).thenReturn(itemMock);
@@ -1600,19 +1600,129 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void testDynamicGroupChildrenSortByMetadataStringNotNumericComparison() throws Exception {
+    public void testDynamicGroupChildrenSortByMetadataStringNumericComparison() throws Exception {
         setSorting("METADATA");
         setOrderMetadata(switchItemMock.getName(), "10");
         setOrderMetadata(dimmerItemMock.getName(), "2");
         setOrderMetadata(contactItemMock.getName(), "1");
 
         List<Widget> children = uiRegistry.getChildren(groupMock);
-        // Lexicographic string compare: "1" < "10" < "2"
-        assertEquals(List.of("Mango", "Zebra", "Alpha"), children.stream().map(Widget::getItem).toList());
+        assertEquals(List.of("Mango", "Alpha", "Zebra"), children.stream().map(Widget::getItem).toList());
+    }
+
+    @Test
+    public void testDynamicGroupChildrenSortByLocationHierarchySameParentUsesOwnWidgetOrder() throws Exception {
+        setSorting("METADATA");
+        setupThreeLocationMembers("Kitchen", "LivingRoom", "Garage");
+        setLocationMetadata("Kitchen", "GroundFloor");
+        setLocationMetadata("LivingRoom", "GroundFloor");
+        setLocationMetadata("Garage", "GroundFloor");
+        setOrderMetadata("Kitchen", "2");
+        setOrderMetadata("LivingRoom", "1");
+        setOrderMetadata("Garage", "3");
+
+        List<Widget> children = uiRegistry.getChildren(groupMock);
+        assertEquals(List.of("LivingRoom", "Kitchen", "Garage"), children.stream().map(Widget::getItem).toList());
+    }
+
+    @Test
+    public void testDynamicGroupChildrenSortByLocationHierarchyDifferentParentsUsesParentOrder() throws Exception {
+        setSorting("METADATA");
+        setupThreeLocationMembers("Kitchen", "Zzz_Bedroom", "Garage");
+        setLocationMetadata("Kitchen", "GroundFloor");
+        setLocationMetadata("Zzz_Bedroom", "FirstFloor");
+        setLocationMetadata("Garage", "GroundFloor");
+        setOrderMetadata("GroundFloor", "2");
+        setOrderMetadata("FirstFloor", "1");
+
+        List<Widget> children = uiRegistry.getChildren(groupMock);
+        // FirstFloor (order 1) < GroundFloor (order 2) => Bedroom before the GroundFloor rooms.
+        // Among the two GroundFloor siblings (Kitchen, Garage) with no own widgetOrder,
+        // falls back to label/name: "Garage" < "Kitchen".
+        assertEquals(List.of("Zzz_Bedroom", "Garage", "Kitchen"), children.stream().map(Widget::getItem).toList());
+    }
+
+    @Test
+    public void testDynamicGroupChildrenSortByLocationHierarchyThreeLevelsDivergesAtGrandparent() throws Exception {
+        setSorting("METADATA");
+        setupThreeLocationMembers("RoomA", "RoomB", "RoomC");
+        setLocationMetadata("RoomA", "Floor1");
+        setLocationMetadata("RoomB", "Floor2");
+        setLocationMetadata("RoomC", "Floor2");
+        setLocationMetadata("Floor1", "Home");
+        setLocationMetadata("Floor2", "Home");
+        setOrderMetadata("Floor1", "2");
+        setOrderMetadata("Floor2", "1");
+        setOrderMetadata("RoomB", "2");
+        setOrderMetadata("RoomC", "1");
+
+        List<Widget> children = uiRegistry.getChildren(groupMock);
+        // Floor2 (order 1) beats Floor1 (order 2) => RoomB/RoomC before RoomA.
+        // Within Floor2, siblings RoomB (order 2) vs RoomC (order 1) => RoomC before RoomB.
+        assertEquals(List.of("RoomC", "RoomB", "RoomA"), children.stream().map(Widget::getItem).toList());
+    }
+
+    @Test
+    public void testDynamicGroupChildrenSortByLocationHierarchyDifferentDepthShallowerFirst() throws Exception {
+        setSorting("METADATA");
+        setupThreeLocationMembers("RoomA", "RoomB", "RoomC");
+        setLocationMetadata("RoomA", "FirstFloor");
+        setLocationMetadata("RoomB", "FirstFloor");
+        setLocationMetadata("FirstFloor", "Home");
+        setLocationMetadata("RoomC", "Home");
+        setOrderMetadata("Room1", "2");
+        setOrderMetadata("RoomB", "1");
+        setOrderMetadata("FirstFloor", "10");
+        setOrderMetadata("RoomC", "9");
+
+        List<Widget> children = uiRegistry.getChildren(groupMock);
+        // FirstFloor & RoomC are both depth 1 -> compared by own widgetOrder (9 < 10).
+        assertEquals(List.of("RoomC", "RoomB", "RoomA"), children.stream().map(Widget::getItem).toList());
+    }
+
+    @Test
+    public void testDynamicGroupChildrenSortByMetadataMixedLocationAndNonLocationFallsBackToWidgetOrder()
+            throws Exception {
+        setSorting("METADATA");
+        setupThreeLocationMembers("Kitchen", "TemperatureSensor", "Garage");
+        setLocationMetadata("Kitchen", "GroundFloor");
+        setLocationMetadata("Garage", "GroundFloor");
+        setOrderMetadata("TemperatureSensor", "1");
+        setOrderMetadata("Kitchen", "2");
+
+        List<Widget> children = uiRegistry.getChildren(groupMock);
+        assertEquals(List.of("TemperatureSensor", "Kitchen", "Garage"),
+                children.stream().map(Widget::getItem).toList());
     }
 
     private void setOrderMetadata(String itemName, String value) {
         MetadataKey key = new MetadataKey(ItemUIRegistryImpl.WIDGET_ORDER_KEY, itemName);
         when(metadataRegistryMock.get(key)).thenReturn(new Metadata(key, value, null));
+    }
+
+    private void setLocationMetadata(String itemName, @Nullable String parentName) {
+        MetadataKey key = new MetadataKey(ItemUIRegistryImpl.SEMANTICS_KEY, itemName);
+        Map<String, Object> config = parentName != null
+                ? Map.of(ItemUIRegistryImpl.SEMANTICS_PARENT_LOCATION_CONFIG, parentName)
+                : Map.of();
+        // Value just needs to start with SEMANTICS_LOCATION for isLocationContext to be true.
+        when(metadataRegistryMock.get(key))
+                .thenReturn(new Metadata(key, ItemUIRegistryImpl.SEMANTICS_LOCATION + "_Room", config));
+    }
+
+    private void setupThreeLocationMembers(String name1, String name2, String name3) throws Exception {
+        GroupItem groupItem1 = new GroupItem(name1);
+        GroupItem groupItem2 = new GroupItem(name2);
+        GroupItem groupItem3 = new GroupItem(name3);
+        Group group1Mock = mock(Group.class);
+        Group group2Mock = mock(Group.class);
+        Group group3Mock = mock(Group.class);
+        when(groupItemMock.getMembers()).thenReturn(Set.of(groupItem1, groupItem2, groupItem3));
+        when(group1Mock.getItem()).thenReturn(name1);
+        when(group2Mock.getItem()).thenReturn(name2);
+        when(group3Mock.getItem()).thenReturn(name3);
+        doReturn(group1Mock).when(uiRegistry).getDefaultWidget(GroupItem.class, name1);
+        doReturn(group2Mock).when(uiRegistry).getDefaultWidget(GroupItem.class, name2);
+        doReturn(group3Mock).when(uiRegistry).getDefaultWidget(GroupItem.class, name3);
     }
 }

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
@@ -23,6 +23,8 @@ import java.text.DecimalFormatSymbols;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 
 import javax.measure.quantity.Temperature;
@@ -43,6 +45,8 @@ import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.Metadata;
+import org.openhab.core.items.MetadataKey;
 import org.openhab.core.items.MetadataRegistry;
 import org.openhab.core.library.items.CallItem;
 import org.openhab.core.library.items.ColorItem;
@@ -111,6 +115,7 @@ public class ItemUIRegistryImplTest {
     // we need to get the decimal separator of the default locale for our tests
     private static final char SEP = (new DecimalFormatSymbols().getDecimalSeparator());
     private static final String ITEM_NAME = "Item";
+    private static final String GROUP_ITEM_NAME = "GroupItem";
     private static final String SITEMAP_NAME = "Sitemap";
     private static final String DEFAULT_TIME_ZONE = "GMT-6";
 
@@ -123,6 +128,11 @@ public class ItemUIRegistryImplTest {
     private @Mock @NonNullByDefault({}) Sitemap sitemapMock;
     private @Mock @NonNullByDefault({}) Widget widgetMock;
     private @Mock @NonNullByDefault({}) Item itemMock;
+
+    private @Mock @NonNullByDefault({}) GroupItem groupItemMock;
+    private @Mock @NonNullByDefault({}) SwitchItem switchItemMock; // Will have Switch as default widget
+    private @Mock @NonNullByDefault({}) DimmerItem dimmerItemMock; // Will have Slider as default widget
+    private @Mock @NonNullByDefault({}) ContactItem contactItemMock; // Will have Text as default widget
 
     @BeforeAll
     public static void setUpClass() {
@@ -165,6 +175,7 @@ public class ItemUIRegistryImplTest {
         TimeZone.setDefault(TimeZone.getTimeZone(DEFAULT_TIME_ZONE));
 
         setupSitemapFactoryMock();
+        setupGroupItemMock();
     }
 
     private void setupSitemapFactoryMock() {
@@ -178,6 +189,20 @@ public class ItemUIRegistryImplTest {
         when(sitemapFactoryMock.createWidget("Selection")).thenReturn(selectionMock);
 
         when(sitemapFactoryMock.createMapping()).thenReturn(mappingMock);
+    }
+
+    private void setupGroupItemMock() throws Exception {
+        when(switchItemMock.getName()).thenReturn("Zebra");
+        when(switchItemMock.getLabel()).thenReturn("Alpha");
+        when(switchMock.getItem()).thenReturn("Zebra");
+        when(dimmerItemMock.getName()).thenReturn("Alpha");
+        when(dimmerItemMock.getLabel()).thenReturn("Zebra");
+        when(sliderMock.getItem()).thenReturn("Alpha");
+        when(contactItemMock.getName()).thenReturn("Mango"); // No label
+        when(textMock.getItem()).thenReturn("Mango");
+        when(groupItemMock.getMembers()).thenReturn(Set.of(switchItemMock, dimmerItemMock, contactItemMock));
+        when(registryMock.getItem(GROUP_ITEM_NAME)).thenReturn(groupItemMock);
+        when(groupMock.getItem()).thenReturn(GROUP_ITEM_NAME);
     }
 
     @Test
@@ -1531,5 +1556,63 @@ public class ItemUIRegistryImplTest {
         assertNull(uiRegistry.getWidget(sitemapMock, "01"));
         assertNull(uiRegistry.getWidget(sitemapMock, "0002"));
         assertNull(uiRegistry.getWidget(sitemapMock, "000101"));
+    }
+
+    private void setSorting(String mode) throws Exception {
+        uiRegistry.modified(Map.of("groupMembersSorting", mode));
+    }
+
+    @Test
+    public void testDynamicGroupChildrenSortByName() throws Exception {
+        setSorting("NAME");
+        List<Widget> children = uiRegistry.getChildren(groupMock);
+        assertEquals(List.of("Alpha", "Mango", "Zebra"), children.stream().map(Widget::getItem).toList());
+    }
+
+    @Test
+    public void testDynamicGroupChildrenSortByLabel() throws Exception {
+        setSorting("LABEL");
+        List<Widget> children = uiRegistry.getChildren(groupMock);
+        // switchItem label "Alpha", dimmerItem label "Zebra", contactItem no label -> falls back to name "Mango"
+        assertEquals(List.of("Zebra", "Mango", "Alpha"), // Alpha(label) < Mango(name-fallback) < Zebra(label)
+                children.stream().map(Widget::getItem).toList());
+    }
+
+    @Test
+    public void testDynamicGroupChildrenSortByMetadataWithValues() throws Exception {
+        setSorting("METADATA");
+        setOrderMetadata(switchItemMock.getName(), "2");
+        setOrderMetadata(dimmerItemMock.getName(), "1");
+        setOrderMetadata(contactItemMock.getName(), "3");
+
+        List<Widget> children = uiRegistry.getChildren(groupMock);
+        assertEquals(List.of("Alpha", "Zebra", "Mango"), children.stream().map(Widget::getItem).toList());
+    }
+
+    @Test
+    public void testDynamicGroupChildrenSortByMetadataMissingValuesGoLast() throws Exception {
+        setSorting("METADATA");
+        setOrderMetadata(dimmerItemMock.getName(), "1"); // only one member has metadata
+
+        List<Widget> children = uiRegistry.getChildren(groupMock);
+        // memberB (has metadata) first, then remaining two by name fallback: Mango, Zebra
+        assertEquals(List.of("Alpha", "Mango", "Zebra"), children.stream().map(Widget::getItem).toList());
+    }
+
+    @Test
+    public void testDynamicGroupChildrenSortByMetadataStringNotNumericComparison() throws Exception {
+        setSorting("METADATA");
+        setOrderMetadata(switchItemMock.getName(), "10");
+        setOrderMetadata(dimmerItemMock.getName(), "2");
+        setOrderMetadata(contactItemMock.getName(), "1");
+
+        List<Widget> children = uiRegistry.getChildren(groupMock);
+        // Lexicographic string compare: "1" < "10" < "2"
+        assertEquals(List.of("Mango", "Zebra", "Alpha"), children.stream().map(Widget::getItem).toList());
+    }
+
+    private void setOrderMetadata(String itemName, String value) {
+        MetadataKey key = new MetadataKey(ItemUIRegistryImpl.WIDGET_ORDER_KEY, itemName);
+        when(metadataRegistryMock.get(key)).thenReturn(new Metadata(key, value, null));
     }
 }

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
@@ -1670,7 +1670,7 @@ public class ItemUIRegistryImplTest {
         setLocationMetadata("RoomB", "FirstFloor");
         setLocationMetadata("FirstFloor", "Home");
         setLocationMetadata("RoomC", "Home");
-        setOrderMetadata("Room1", "2");
+        setOrderMetadata("RoomA", "2");
         setOrderMetadata("RoomB", "1");
         setOrderMetadata("FirstFloor", "10");
         setOrderMetadata("RoomC", "9");

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
@@ -1663,21 +1663,40 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void testDynamicGroupChildrenSortByLocationHierarchyDifferentDepthShallowerFirst() throws Exception {
+    public void testDynamicGroupChildrenSortByLocationHierarchyDifferentDepth() throws Exception {
         setSorting("METADATA");
         setupThreeLocationMembers("RoomA", "RoomB", "RoomC");
         setLocationMetadata("RoomA", "FirstFloor");
         setLocationMetadata("RoomB", "FirstFloor");
         setLocationMetadata("FirstFloor", "Home");
         setLocationMetadata("RoomC", "Home");
-        setOrderMetadata("RoomA", "2");
-        setOrderMetadata("RoomB", "1");
-        setOrderMetadata("FirstFloor", "10");
-        setOrderMetadata("RoomC", "9");
+        setOrderMetadata("RoomA", "10");
+        setOrderMetadata("RoomB", "9");
+        setOrderMetadata("FirstFloor", "1");
+        setOrderMetadata("RoomC", "2");
 
         List<Widget> children = uiRegistry.getChildren(groupMock);
-        // FirstFloor & RoomC are both depth 1 -> compared by own widgetOrder (9 < 10).
-        assertEquals(List.of("RoomC", "RoomB", "RoomA"), children.stream().map(Widget::getItem).toList());
+        // FirstFloor & RoomC are both depth 1 -> compared by own widgetOrder (1 < 2).
+        assertEquals(List.of("RoomB", "RoomA", "RoomC"), children.stream().map(Widget::getItem).toList());
+    }
+
+    @Test
+    public void testDynamicGroupChildrenSortByLocationHierarchyDifferentDepthShallowFirst() throws Exception {
+        setSorting("METADATA");
+        setupThreeLocationMembers("RoomA", "RoomB", "RoomC");
+        setLocationMetadata("RoomA", "Upstairs");
+        setLocationMetadata("RoomB", "FirstFloor");
+        setLocationMetadata("FirstFloor", "Upstairs");
+        setLocationMetadata("Upstairs", "Home");
+        setLocationMetadata("RoomC", "Home");
+        setOrderMetadata("Upstairs", "1");
+        setOrderMetadata("RoomC", "2");
+
+        List<Widget> children = uiRegistry.getChildren(groupMock);
+        // RoomA (depth 2) vs RoomB (depth 3): comparison is between RoomA and FirstFloor (depth 2), FirstFloor (and
+        // therefore RoomB) comes first
+        // RoomC (depth 1) compares to Upstairs -> widgetOrder of Upstairs (1) < RoomC (2)
+        assertEquals(List.of("RoomB", "RoomA", "RoomC"), children.stream().map(Widget::getItem).toList());
     }
 
     @Test
@@ -1687,11 +1706,11 @@ public class ItemUIRegistryImplTest {
         setupThreeLocationMembers("Kitchen", "TemperatureSensor", "Garage");
         setLocationMetadata("Kitchen", "GroundFloor");
         setLocationMetadata("Garage", "GroundFloor");
-        setOrderMetadata("TemperatureSensor", "1");
-        setOrderMetadata("Kitchen", "2");
+        setOrderMetadata("Kitchen", "1");
+        setOrderMetadata("Garage", "2");
 
         List<Widget> children = uiRegistry.getChildren(groupMock);
-        assertEquals(List.of("TemperatureSensor", "Kitchen", "Garage"),
+        assertEquals(List.of("Kitchen", "Garage", "TemperatureSensor"),
                 children.stream().map(Widget::getItem).toList());
     }
 


### PR DESCRIPTION
Creates a new option to order items in sitemap groups in the order defined by the widget order index metadata.
This same metadata is also used for MainUI widgets.
This is a crude way to get better sorting without creating the content of the group directly and aligns with the mainUI mechanism (uses the same metadata).

This has come up a few times, see also here: https://community.openhab.org/t/announcing-openhab-for-wear-os/169918/19