### PR TITLE
YamlItemConverter: create tags’ LinkedHashSet in place

### DIFF
--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemConverter.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemConverter.java
@@ -163,10 +163,7 @@ public class YamlItemConverter extends AbstractItemSerializer implements ItemPar
             });
         }
         if (!item.getTags().isEmpty()) {
-            dto.tags = new LinkedHashSet<>();
-            item.getTags().stream().sorted().collect(Collectors.toList()).forEach(tag -> {
-                dto.tags.add(tag);
-            });
+            dto.tags = item.getTags().stream().sorted().collect(Collectors.toCollection(LinkedHashSet::new));
         }
 
         if (channelLinks.size() == 1 && channelLinks.getFirst().getConfiguration().isEmpty()) {


### PR DESCRIPTION
Avoid converting a Stream to a List, and then putting the elements of the List in a Set.