### PR TITLE
[rest] VoiceResource: Select all available LLM tools by default

### DIFF
--- a/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/VoiceResource.java
+++ b/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/VoiceResource.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
@@ -202,7 +203,7 @@ public class VoiceResource implements RESTResource {
     public Response interpret(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @QueryParam("conversation") @Parameter(description = "Conversation id") @Nullable String conversationId,
-            @QueryParam("llmTools") @Parameter(description = "Comma separated list of llm-tool ids") @Nullable List<String> llmToolIds,
+            @DefaultValue("*") @QueryParam("llmTools") @Parameter(description = "Comma separated list of llm-tool ids or * wildcard") @Nullable List<String> llmToolIds,
             @QueryParam("locationItem") @Parameter(description = "Location item id to contextualize the command") @Nullable String locationItem,
             @Parameter(description = "text to interpret", required = true) String text,
             @PathParam("ids") @Parameter(description = "comma separated list of interpreter ids") List<String> ids) {
@@ -212,7 +213,7 @@ public class VoiceResource implements RESTResource {
 
         final Locale locale = localeService.getLocale(language);
         InterpretationArguments args = new InterpretationArguments(String.join(",", ids),
-                Objects.requireNonNullElse(conversationId, ""), llmToolIds == null ? "" : String.join(",", llmToolIds),
+                Objects.requireNonNullElse(conversationId, ""), llmToolIds == null ? "*" : String.join(",", llmToolIds),
                 locationItem, locale);
         try {
             String answer = voiceManager.interpret(text, args);
@@ -233,7 +234,7 @@ public class VoiceResource implements RESTResource {
     public Response interpret(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @QueryParam("conversation") @Parameter(description = "Conversation id") @Nullable String conversationId,
-            @QueryParam("llmTools") @Parameter(description = "Comma separated list of llm-tool ids") @Nullable List<String> llmToolIds,
+            @DefaultValue(".*") @QueryParam("llmTools") @Parameter(description = "Comma separated list of llm-tool ids or * wildcard") @Nullable List<String> llmToolIds,
             @QueryParam("locationItem") @Parameter(description = "Location item id to contextualize the command") @Nullable String locationItem,
             @Parameter(description = "text to interpret", required = true) String text) {
         final Locale locale = localeService.getLocale(language);
@@ -243,7 +244,7 @@ public class VoiceResource implements RESTResource {
         }
 
         InterpretationArguments args = new InterpretationArguments("", Objects.requireNonNullElse(conversationId, ""),
-                llmToolIds == null ? "" : String.join(",", llmToolIds), locationItem, locale);
+                llmToolIds == null ? "*" : String.join(",", llmToolIds), locationItem, locale);
         try {
             String answer = voiceManager.interpret(text, args);
             return Response.ok(answer, MediaType.TEXT_PLAIN).build();

--- a/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/VoiceResource.java
+++ b/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/VoiceResource.java
@@ -234,7 +234,7 @@ public class VoiceResource implements RESTResource {
     public Response interpret(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @QueryParam("conversation") @Parameter(description = "Conversation id") @Nullable String conversationId,
-            @DefaultValue(".*") @QueryParam("llmTools") @Parameter(description = "Comma separated list of llm-tool ids or * wildcard") @Nullable List<String> llmToolIds,
+            @DefaultValue("*") @QueryParam("llmTools") @Parameter(description = "Comma separated list of llm-tool ids or * wildcard") @Nullable List<String> llmToolIds,
             @QueryParam("locationItem") @Parameter(description = "Location item id to contextualize the command") @Nullable String locationItem,
             @Parameter(description = "text to interpret", required = true) String text) {
         final Locale locale = localeService.getLocale(language);

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMToolRegistry.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMToolRegistry.java
@@ -31,12 +31,17 @@ public interface LLMToolRegistry extends Registry<LLMTool, String> {
      * Retrieves a {@link LLMTool} collection.
      * If no services match the provided ids returns an empty list.
      *
-     * @param ids Comma separated list of LLM tool ids to use
+     * @param ids Comma separated list of LLM tool ids to get, or <code>*</code> wildcard to get all available tools
      * @return a list of {@link LLMTool} or an empty list if none of them is available
      */
     default List<LLMTool> getByIds(@Nullable String ids) {
-        return ids == null || ids.isBlank() ? List.of()
-                : getByIds(Arrays.stream(ids.split(",")).map(String::trim).filter(s -> !s.isEmpty()).toList());
+        if (ids == null || ids.isBlank()) {
+            return List.of();
+        }
+        if ("*".equals(ids)) {
+            return stream().toList();
+        }
+        return getByIds(Arrays.stream(ids.split(",")).map(String::trim).filter(s -> !s.isEmpty()).toList());
     }
 
     /**

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/llm/LLMToolRegistryImplTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/llm/LLMToolRegistryImplTest.java
@@ -87,6 +87,17 @@ public class LLMToolRegistryImplTest {
     }
 
     @Test
+    public void getByIdsStringsReturnsAllLLMToolsForWildcard() {
+        registry.addLLMTool(tool1);
+        registry.addLLMTool(tool2);
+
+        List<LLMTool> result = registry.getByIds("*");
+        assertEquals(2, result.size());
+        assertTrue(result.contains(tool1));
+        assertTrue(result.contains(tool2));
+    }
+
+    @Test
     public void getByIdsStringHandlesBlankStringOrNull() {
         registry.addLLMTool(tool1);
         registry.addLLMTool(tool2);

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/llm/LLMToolRegistryImplTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/interpreter/llm/LLMToolRegistryImplTest.java
@@ -87,7 +87,7 @@ public class LLMToolRegistryImplTest {
     }
 
     @Test
-    public void getByIdsStringsReturnsAllLLMToolsForWildcard() {
+    public void getByIdsStringReturnsAllLLMToolsForWildcard() {
         registry.addLLMTool(tool1);
         registry.addLLMTool(tool2);
 


### PR DESCRIPTION
Improves REST API backward compatibility with API clients that expect to call the interpret endpoints without having to explicitly select LLM tools.

I recommend backporting this to 5.2.x.