### PR TITLE
Remove country specification from default certificate

### DIFF
--- a/bundles/org.openhab.core.io.jetty.certificate/src/main/java/org/openhab/core/io/jetty/certificate/internal/CertificateGenerator.java
+++ b/bundles/org.openhab.core.io.jetty.certificate/src/main/java/org/openhab/core/io/jetty/certificate/internal/CertificateGenerator.java
@@ -75,7 +75,7 @@ public class CertificateGenerator implements BundleActivator {
     private static final String KEY_FACTORY_TYPE = "EC";
     private static final String CONTENT_SIGNER_ALGORITHM = "SHA256withECDSA";
     private static final String CERTIFICATE_X509_TYPE = "X.509";
-    private static final String X500_NAME = "CN=openhab.org, OU=None, O=None, L=None, C=None";
+    private static final String X500_NAME = "CN=openhab.org, OU=None, O=None, L=None";
 
     private Logger logger;
 


### PR DESCRIPTION
BouncyCastle now validates the X.520 country-code (2.5.4.6) attribute against ISO 3166-1, which requires exactly 2 characters. This no longer allows "C=None".
https://github.com/bcgit/bc-java/blob/8654f2fe4dab3ec57df9bd3e2189d82f63a0090b/core/src/main/java/org/bouncycastle/asn1/x500/style/BCStyle.java#L339

This avoids the following log message:
~~~
[ERROR] [Events.Framework                    ] - FrameworkEvent ERROR
org.osgi.framework.BundleException: Exception in org.openhab.core.io.jetty.certificate.internal.CertificateGenerator.start() of bundle org.openhab.core.io.jetty.certificate.
        at org.eclipse.osgi.internal.framework.BundleContextImpl.startActivator(BundleContextImpl.java:859)
        at org.eclipse.osgi.internal.framework.BundleContextImpl.start(BundleContextImpl.java:780)
        at org.eclipse.osgi.internal.framework.EquinoxBundle.startWorker0(EquinoxBundle.java:1082)
        at org.eclipse.osgi.internal.framework.EquinoxBundle$EquinoxModule.startWorker(EquinoxBundle.java:394)
        at org.eclipse.osgi.container.Module.doStart(Module.java:643)
        at org.eclipse.osgi.container.Module.start(Module.java:500)
        at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel$2.run(ModuleContainer.java:2110)
        at org.eclipse.osgi.internal.framework.EquinoxContainerAdaptor$1$1.execute(EquinoxContainerAdaptor.java:146)
        at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.incStartLevel(ModuleContainer.java:2101)
        at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.incStartLevel(ModuleContainer.java:2043)
        at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.doContainerStartLevel(ModuleContainer.java:2003)
        at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.dispatchEvent(ModuleContainer.java:1915)
        at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.dispatchEvent(ModuleContainer.java:1)
        at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230)
        at org.eclipse.osgi.framework.eventmgr.EventManager$EventThread.run(EventManager.java:341)
Caused by: java.lang.IllegalArgumentException: country code attribute 2.5.4.6 must be exactly 2 characters per ISO 3166-1 / X.520, got 4: 'None'
        at org.bouncycastle.asn1.x500.style.BCStyle.encodeStringValue(Unknown Source)
        at org.bouncycastle.asn1.x500.style.AbstractX500NameStyle.stringToValue(Unknown Source)
        at org.bouncycastle.asn1.x500.X500NameBuilder.addRDN(Unknown Source)
        at org.bouncycastle.asn1.x500.style.IETFUtils.addRDN(Unknown Source)
        at org.bouncycastle.asn1.x500.style.IETFUtils.addRDNs(Unknown Source)
        at org.bouncycastle.asn1.x500.style.IETFUtils.rDNsFromString(Unknown Source)
        at org.bouncycastle.asn1.x500.style.BCStyle.fromString(Unknown Source)
        at org.bouncycastle.asn1.x500.X500Name.<init>(Unknown Source)
        at org.bouncycastle.asn1.x500.X500Name.<init>(Unknown Source)
        at org.openhab.core.io.jetty.certificate.internal.CertificateGenerator.generateCertificate(CertificateGenerator.java:183)
        at org.openhab.core.io.jetty.certificate.internal.CertificateGenerator.start(CertificateGenerator.java:92)
        at org.eclipse.osgi.internal.framework.BundleContextImpl$2.run(BundleContextImpl.java:838)
        at org.eclipse.osgi.internal.framework.BundleContextImpl$2.run(BundleContextImpl.java:1)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:571)
        at org.eclipse.osgi.internal.framework.BundleContextImpl.startActivator(BundleContextImpl.java:830)
        ... 14 more
~~~

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").

ATTENTION: Don't use "git merge" when working with your pull request branch!
This can clutter your Git history and make your PR unusable.
Use "git rebase" instead. See this forum post for further details:
https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358

All PRs should be created using the "main" branch as base.
Important bugfixes are cherry-picked by maintainers to the patch release branch after a PR has been merged.

If your PR's code is not backward compatible with previous releases (which
should be avoided), add a message to the release notes by filing another PR:
https://github.com/openhab/openhab-distro/blob/main/distributions/openhab/src/main/resources/bin/update.lst

# Title

Provide a short summary in the *Title* above. It will show up in the release notes.
For example:
- Introduce metadata for all add-ons
- Fix memory leak in ScriptedRuleProvider

# Description

Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the Core README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis?
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work

If your pull request contains a new contribution, it will likely take some time
before it is reviewed and processed by maintainers.
-->
