### PR TITLE
Use local schema for add-on JAXB generation

### DIFF
--- a/bundles/org.openhab.core.addon/pom.xml
+++ b/bundles/org.openhab.core.addon/pom.xml
@@ -27,4 +27,16 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jvnet.jaxb2.maven2</groupId>
+        <artifactId>maven-jaxb2-plugin</artifactId>
+        <configuration>
+          <catalog>schema/catalog.cat</catalog>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/bundles/org.openhab.core.addon/schema/catalog.cat
+++ b/bundles/org.openhab.core.addon/schema/catalog.cat
@@ -1,0 +1,1 @@
+REWRITE_SYSTEM "https://openhab.org/schemas/" "../../org.openhab.core.config.core/schema/"


### PR DESCRIPTION
## Description

The [build log of #5720](https://github.com/openhab/openhab-core/actions/runs/30165880084/job/89698693351?pr=5720) shows that JAXB/XJC timed out while downloading:

```text
https://openhab.org/schemas/config-description-1.0.0.xsd
```

The failed import subsequently caused errors such as:

```text
undefined simple type 'config-description:idRestrictionPattern'
```

This PR adds an XML catalog to `org.openhab.core.addon` so that the schema is resolved from the local `org.openhab.core.config.core` module instead.

This follows the same approach already used by the `org.openhab.core.thing` bundle.

## Benefits

- Prevents JAXB generation failures when `openhab.org` is temporarily unavailable.
- Removes an unnecessary network dependency from the build.
- Reduces requests to `openhab.org` during CI and local builds.
- Keeps the canonical public schema URL in the XSD.
- Does not change the generated Java sources.

## Testing

The change can be tested easily by building the bundle without network access, or by specifically blocking access to `openhab.org`, and verifying that JAXB source generation still succeeds.

- Compared `src/generated/java` before and after the change; no differences were found.
- Confirmed that JAXB source generation succeeds while access to `openhab.org` is blocked.

See also: #5731