### PR TITLE
[voice] LLMItemSerializer: Get semantic relationships from metadata & Include semantic children of non-semantic groups

### DIFF
--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticTags.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticTags.java
@@ -33,6 +33,18 @@ import org.openhab.core.types.StateDescription;
 @NonNullByDefault
 public class SemanticTags {
 
+    /**
+     * The namespace to use for the semantics metadata.
+     */
+    public static final String METADATA_NAMESPACE = "semantics";
+
+    // the config property names to use for the metadata
+    public static final String REL_HAS_LOCATION = "hasLocation";
+    public static final String REL_IS_PART_OF = "isPartOf";
+    public static final String REL_IS_POINT_OF = "isPointOf";
+    public static final String REL_HAS_POINT = "hasPoint";
+    public static final String REL_RELATES_TO = "relatesTo";
+
     private static final Map<String, Class<? extends Tag>> TAGS = Collections.synchronizedMap(new TreeMap<>());
 
     static {

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticsMetadataProvider.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticsMetadataProvider.java
@@ -12,6 +12,13 @@
  */
 package org.openhab.core.semantics.internal;
 
+import static org.openhab.core.semantics.SemanticTags.METADATA_NAMESPACE;
+import static org.openhab.core.semantics.SemanticTags.REL_HAS_LOCATION;
+import static org.openhab.core.semantics.SemanticTags.REL_HAS_POINT;
+import static org.openhab.core.semantics.SemanticTags.REL_IS_PART_OF;
+import static org.openhab.core.semantics.SemanticTags.REL_IS_POINT_OF;
+import static org.openhab.core.semantics.SemanticTags.REL_RELATES_TO;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -63,16 +70,6 @@ public class SemanticsMetadataProvider extends AbstractProvider<Metadata>
 
     private final Logger logger = LoggerFactory.getLogger(SemanticsMetadataProvider.class);
 
-    // the namespace to use for the metadata
-    public static final String NAMESPACE = "semantics";
-
-    // the config property names to use for the metadata
-    public static final String REL_HAS_LOCATION = "hasLocation";
-    public static final String REL_IS_PART_OF = "isPartOf";
-    public static final String REL_IS_POINT_OF = "isPointOf";
-    public static final String REL_HAS_POINT = "hasPoint";
-    public static final String REL_RELATES_TO = "relatesTo";
-
     // holds the static definition of the relations between entities
     private final Map<List<Class<? extends Tag>>, String> parentRelations = new HashMap<>();
     private final Map<List<Class<? extends Tag>>, String> memberRelations = new HashMap<>();
@@ -118,7 +115,7 @@ public class SemanticsMetadataProvider extends AbstractProvider<Metadata>
 
     @Override
     public Collection<String> getReservedNamespaces() {
-        return Set.of(NAMESPACE);
+        return Set.of(METADATA_NAMESPACE);
     }
 
     /**
@@ -131,7 +128,7 @@ public class SemanticsMetadataProvider extends AbstractProvider<Metadata>
     }
 
     private void processItem(Item item, List<String> parentItems) {
-        MetadataKey key = new MetadataKey(NAMESPACE, item.getName());
+        MetadataKey key = new MetadataKey(METADATA_NAMESPACE, item.getName());
         Map<String, Object> configuration = new HashMap<>();
         Class<? extends Tag> type = SemanticTags.getSemanticType(item);
         if (type != null) {

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticsMetadataProvider.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticsMetadataProvider.java
@@ -66,6 +66,13 @@ public class SemanticsMetadataProvider extends AbstractProvider<Metadata>
     // the namespace to use for the metadata
     public static final String NAMESPACE = "semantics";
 
+    // the config property names to use for the metadata
+    public static final String REL_HAS_LOCATION = "hasLocation";
+    public static final String REL_IS_PART_OF = "isPartOf";
+    public static final String REL_IS_POINT_OF = "isPointOf";
+    public static final String REL_HAS_POINT = "hasPoint";
+    public static final String REL_RELATES_TO = "relatesTo";
+
     // holds the static definition of the relations between entities
     private final Map<List<Class<? extends Tag>>, String> parentRelations = new HashMap<>();
     private final Map<List<Class<? extends Tag>>, String> memberRelations = new HashMap<>();
@@ -77,7 +84,7 @@ public class SemanticsMetadataProvider extends AbstractProvider<Metadata>
     private final ItemRegistry itemRegistry;
     private final SemanticTagRegistry semanticTagRegistry;
 
-    private SemanticTagRegistryChangeListener listener;
+    private final SemanticTagRegistryChangeListener listener;
 
     @Activate
     public SemanticsMetadataProvider(final @Reference ItemRegistry itemRegistry,
@@ -254,15 +261,15 @@ public class SemanticsMetadataProvider extends AbstractProvider<Metadata>
     }
 
     private void initRelations() {
-        parentRelations.put(List.of(Equipment.class, Location.class), "hasLocation");
-        parentRelations.put(List.of(Point.class, Location.class), "hasLocation");
-        parentRelations.put(List.of(Location.class, Location.class), "isPartOf");
-        parentRelations.put(List.of(Equipment.class, Equipment.class), "isPartOf");
-        parentRelations.put(List.of(Point.class, Equipment.class), "isPointOf");
+        parentRelations.put(List.of(Equipment.class, Location.class), REL_HAS_LOCATION);
+        parentRelations.put(List.of(Point.class, Location.class), REL_HAS_LOCATION);
+        parentRelations.put(List.of(Location.class, Location.class), REL_IS_PART_OF);
+        parentRelations.put(List.of(Equipment.class, Equipment.class), REL_IS_PART_OF);
+        parentRelations.put(List.of(Point.class, Equipment.class), REL_IS_POINT_OF);
 
-        memberRelations.put(List.of(Equipment.class, Point.class), "hasPoint");
+        memberRelations.put(List.of(Equipment.class, Point.class), REL_HAS_POINT);
 
-        propertyRelations.put(List.of(Point.class), "relatesTo");
+        propertyRelations.put(List.of(Point.class), REL_RELATES_TO);
     }
 
     @Override

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -57,6 +57,7 @@ import org.openhab.core.i18n.LocaleProvider;
 import org.openhab.core.i18n.TranslationProvider;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.MetadataRegistry;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.storage.Storage;
 import org.openhab.core.storage.StorageService;
@@ -129,6 +130,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
     private final LLMToolRegistry llmToolRegistry;
     private final ConversationManager conversationManager;
     private final ItemRegistry itemRegistry;
+    private final MetadataRegistry metadataRegistry;
     private final ItemPermissionResolver itemPermissionResolver;
 
     private final WeakHashMap<String, DialogContext> activeDialogGroups = new WeakHashMap<>();
@@ -153,7 +155,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
             final @Reference StorageService storageService, final @Reference LLMToolRegistry llmToolRegistry,
             final @Reference ConversationManager conversationManager,
             final @Reference ConfigDescriptionRegistry configDescriptionRegistry,
-            final @Reference ItemRegistry itemRegistry,
+            final @Reference ItemRegistry itemRegistry, final @Reference MetadataRegistry metadataRegistry,
             final @Reference ItemPermissionResolver itemPermissionResolver) {
         this.localeProvider = localeProvider;
         this.audioManager = audioManager;
@@ -164,6 +166,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
         this.conversationManager = conversationManager;
         this.llmToolRegistry = llmToolRegistry;
         this.itemRegistry = itemRegistry;
+        this.metadataRegistry = metadataRegistry;
         this.itemPermissionResolver = itemPermissionResolver;
         this.configuration = new VoiceManagerConfiguration(configDescriptionRegistry);
     }
@@ -1146,7 +1149,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
         String base = baseSystemPrompt != null ? baseSystemPrompt : "";
         List<Item> accessibleItems = itemRegistry.getItems().stream().filter(itemPermissionResolver::isAccessible)
                 .toList();
-        String serializedItems = LLMItemSerializer.serialize(accessibleItems, locale);
+        String serializedItems = LLMItemSerializer.serialize(accessibleItems, metadataRegistry, locale);
         if (serializedItems.isEmpty()) {
             return base;
         }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
@@ -75,7 +75,7 @@ public class LLMItemSerializer {
     }
 
     private record NonSemanticItemNode(String name, @Nullable String label, String type,
-            List<CommandOptionNode> commandOptions) {
+            List<CommandOptionNode> commandOptions, List<NonSemanticItemNode> children) {
     }
 
     private record RootNode(List<LocationNode> locationItems, List<EquipmentNode> equipmentItems,
@@ -109,13 +109,10 @@ public class LLMItemSerializer {
             boolean isEquipment = SemanticTags.getEquipment(child) != null;
             boolean isPoint = SemanticTags.getPoint(child) != null || SemanticTags.getProperty(child) != null;
 
-            if (!isLocation && !isEquipment && !isPoint) {
-                continue;
-            }
+            List<String> parentNames = findParentNames(metadataRegistry, child, itemMap, isLocation, isEquipment,
+                    isPoint);
 
-            String parentName = findParentName(metadataRegistry, child, itemMap, isLocation, isEquipment, isPoint);
-
-            if (parentName != null) {
+            for (String parentName : parentNames) {
                 parentToChildren.computeIfAbsent(parentName, k -> new ArrayList<>()).add(child);
                 childNames.add(child.getName());
             }
@@ -144,7 +141,9 @@ public class LLMItemSerializer {
                     rootPoints.add(item);
                 }
             } else {
-                nonSemanticItems.add(item);
+                if (!childNames.contains(item.getName())) {
+                    nonSemanticItems.add(item);
+                }
             }
         }
 
@@ -168,19 +167,20 @@ public class LLMItemSerializer {
             rootPtNodes.add(buildPointNode(pt, locale));
         }
         for (Item item : nonSemanticItems) {
-            nonSemanticNodes.add(new NonSemanticItemNode(item.getName(), getOrNullLabel(item), item.getType(),
-                    getCommandOptions(item, locale)));
+            nonSemanticNodes.add(buildNonSemanticNode(item, parentToChildren, locale));
         }
         RootNode root = new RootNode(rootLocNodes, rootEqNodes, rootPtNodes, nonSemanticNodes);
         return formatRoot(root);
     }
 
     /**
-     * Resolves the parent item name for a child item using semantic relation metadata first,
-     * falling back to standard Group membership hierarchy.
+     * Resolves the parent item names for a child item using semantic relation metadata first,
+     * falling back to standard Group membership hierarchy, and including non-semantic group parents.
      */
-    private static @Nullable String findParentName(MetadataRegistry metadataRegistry, Item child,
+    private static List<String> findParentNames(MetadataRegistry metadataRegistry, Item child,
             Map<String, Item> itemMap, boolean isLocation, boolean isEquipment, boolean isPoint) {
+
+        List<String> parents = new ArrayList<>();
 
         // Try resolving via SemanticsMetadataProvider configuration keys
         Metadata md = metadataRegistry.get(new MetadataKey(NAMESPACE, child.getName()));
@@ -191,55 +191,71 @@ public class LLMItemSerializer {
                 // Sub-location -> Parent Location
                 String parentLoc = getValidTarget(config.get(REL_IS_PART_OF), itemMap);
                 if (parentLoc != null) {
-                    return parentLoc;
+                    parents.add(parentLoc);
                 }
             } else if (isEquipment) {
                 // Sub-equipment -> Parent Equipment
                 String parentEq = getValidTarget(config.get(REL_IS_PART_OF), itemMap);
                 if (parentEq != null) {
-                    return parentEq;
-                }
-                // Equipment -> Parent Location
-                String parentLoc = getValidTarget(config.get(REL_HAS_LOCATION), itemMap);
-                if (parentLoc != null) {
-                    return parentLoc;
+                    parents.add(parentEq);
+                } else {
+                    // Equipment -> Parent Location
+                    String parentLoc = getValidTarget(config.get(REL_HAS_LOCATION), itemMap);
+                    if (parentLoc != null) {
+                        parents.add(parentLoc);
+                    }
                 }
             } else if (isPoint) {
                 // Point -> Parent Equipment
                 String parentEq = getValidTarget(config.get(REL_IS_POINT_OF), itemMap);
                 if (parentEq != null) {
-                    return parentEq;
-                }
-                // Loose Point -> Parent Location
-                String parentLoc = getValidTarget(config.get(REL_HAS_LOCATION), itemMap);
-                if (parentLoc != null) {
-                    return parentLoc;
+                    parents.add(parentEq);
+                } else {
+                    // Loose Point -> Parent Location
+                    String parentLoc = getValidTarget(config.get(REL_HAS_LOCATION), itemMap);
+                    if (parentLoc != null) {
+                        parents.add(parentLoc);
+                    }
                 }
             }
         }
 
-        // Fallback: Resolve parent via Group membership
-        String fallbackParent = null;
+        // Group membership processing (semantic parent fallback + non-semantic group parents)
+        String semanticFallbackParent = null;
+
         for (String groupName : child.getGroupNames()) {
             Item parent = itemMap.get(groupName);
             if (parent == null) {
                 continue;
             }
 
-            if (isLocation) {
-                if (SemanticTags.getLocation(parent) != null) {
-                    return groupName;
+            boolean parentIsLocation = SemanticTags.getLocation(parent) != null;
+            boolean parentIsEquipment = SemanticTags.getEquipment(parent) != null;
+
+            if (parents.isEmpty()) {
+                if (isLocation) {
+                    if (parentIsLocation) {
+                        parents.add(groupName);
+                    }
+                } else {
+                    if (parentIsEquipment) {
+                        parents.add(groupName); // Direct Equipment parent has higher priority
+                    } else if (parentIsLocation && semanticFallbackParent == null) {
+                        semanticFallbackParent = groupName;
+                    }
                 }
-            } else {
-                if (SemanticTags.getEquipment(parent) != null) {
-                    return groupName; // Direct Equipment parent has higher priority
-                } else if (SemanticTags.getLocation(parent) != null && fallbackParent == null) {
-                    fallbackParent = groupName; // Location parent is fallback for Equipment/Points
-                }
+            }
+
+            if (!parentIsLocation && !parentIsEquipment && !parents.contains(groupName)) {
+                parents.add(groupName);
             }
         }
 
-        return fallbackParent;
+        if (parents.isEmpty() && semanticFallbackParent != null) {
+            parents.addFirst(semanticFallbackParent);
+        }
+
+        return parents;
     }
 
     private static @Nullable String getValidTarget(@Nullable Object targetName, Map<String, Item> itemMap) {
@@ -453,8 +469,27 @@ public class LLMItemSerializer {
         sb.append("\n");
     }
 
+    private static NonSemanticItemNode buildNonSemanticNode(Item item, Map<String, List<Item>> parentToChildren,
+            @Nullable Locale locale) {
+        List<Item> children = parentToChildren.getOrDefault(item.getName(), List.of());
+        List<NonSemanticItemNode> childNodes = new ArrayList<>();
+
+        for (Item child : children) {
+            childNodes.add(buildNonSemanticNode(child, parentToChildren, locale));
+        }
+
+        childNodes.sort(Comparator.comparing(NonSemanticItemNode::name));
+
+        return new NonSemanticItemNode(item.getName(), getOrNullLabel(item), item.getType(),
+                getCommandOptions(item, locale), childNodes);
+    }
+
     private static void formatNonSemanticItemNode(NonSemanticItemNode item, StringBuilder sb) {
-        sb.append(item.name());
+        formatNonSemanticItemNode(item, 0, sb);
+    }
+
+    private static void formatNonSemanticItemNode(NonSemanticItemNode item, int depth, StringBuilder sb) {
+        sb.append(getIndent(depth)).append(item.name());
 
         if (!"Group".equals(item.type())) {
             sb.append(" ").append(item.type());
@@ -466,6 +501,10 @@ public class LLMItemSerializer {
             sb.append(" (").append(formatCommandOptions(item.commandOptions())).append(")");
         }
         sb.append("\n");
+
+        for (NonSemanticItemNode child : item.children()) {
+            formatNonSemanticItemNode(child, depth + 1, sb);
+        }
     }
 
     private static boolean shouldPrintLabel(String name, @Nullable String label) {

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
@@ -12,6 +12,11 @@
  */
 package org.openhab.core.voice.text.interpreter.llm;
 
+import static org.openhab.core.semantics.internal.SemanticsMetadataProvider.NAMESPACE;
+import static org.openhab.core.semantics.internal.SemanticsMetadataProvider.REL_HAS_LOCATION;
+import static org.openhab.core.semantics.internal.SemanticsMetadataProvider.REL_IS_PART_OF;
+import static org.openhab.core.semantics.internal.SemanticsMetadataProvider.REL_IS_POINT_OF;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,6 +31,9 @@ import java.util.Set;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.Item;
+import org.openhab.core.items.Metadata;
+import org.openhab.core.items.MetadataKey;
+import org.openhab.core.items.MetadataRegistry;
 import org.openhab.core.semantics.Equipment;
 import org.openhab.core.semantics.Location;
 import org.openhab.core.semantics.Point;
@@ -37,10 +45,12 @@ import org.openhab.core.types.CommandOption;
 
 /**
  * {@link LLMItemSerializer} is a utility class to serialize a collection of items (both semantic and non-semantic) into
- * a structured,
- * hierarchical string representation for passing into the context of a Large Language Model (LLM) based
+ * a structured, hierarchical string representation for passing into the context of a Large Language Model (LLM) based
  * {@link org.openhab.core.voice.text.HumanLanguageInterpreter}.
- * The output format is a custom format designed to be highly token-efficient.
+ * <p>
+ * Evaluates semantic relations via {@link MetadataRegistry} (using keys like {@code hasLocation}, {@code isPartOf}, and
+ * {@code isPointOf}) with fallback to standard Group membership hierarchy.
+ * Output is formatted in a custom, token-efficient syntax.
  *
  * @author Florian Hotze - Initial contribution
  */
@@ -73,13 +83,15 @@ public class LLMItemSerializer {
     }
 
     /**
-     * Serializes a collection of items, localizing command options with the given locale if available.
+     * Serializes a collection of items, evaluating openHAB semantic relations and group membership,
+     * localizing command options with the given locale if available.
      *
      * @param items the items to serialize
+     * @param metadataRegistry the metadata registry used to query semantic relation metadata, or null
      * @param locale the locale to use for command options localization
-     * @return the serialized representation (YAML) of the items
+     * @return the serialized representation of the items
      */
-    public static String serialize(Collection<Item> items, @Nullable Locale locale) {
+    public static String serialize(Collection<Item> items, MetadataRegistry metadataRegistry, @Nullable Locale locale) {
         if (items.isEmpty()) {
             return "";
         }
@@ -101,29 +113,7 @@ public class LLMItemSerializer {
                 continue;
             }
 
-            String parentName = null;
-            String fallbackParent = null;
-            for (String groupName : child.getGroupNames()) {
-                Item parent = itemMap.get(groupName);
-                if (parent != null) {
-                    if (isLocation) {
-                        if (SemanticTags.getLocation(parent) != null) {
-                            parentName = groupName;
-                            break;
-                        }
-                    } else {
-                        if (SemanticTags.getEquipment(parent) != null) {
-                            parentName = groupName;
-                            break;
-                        } else if (SemanticTags.getLocation(parent) != null && fallbackParent == null) {
-                            fallbackParent = groupName;
-                        }
-                    }
-                }
-            }
-            if (parentName == null) {
-                parentName = fallbackParent;
-            }
+            String parentName = findParentName(metadataRegistry, child, itemMap, isLocation, isEquipment, isPoint);
 
             if (parentName != null) {
                 parentToChildren.computeIfAbsent(parentName, k -> new ArrayList<>()).add(child);
@@ -183,6 +173,80 @@ public class LLMItemSerializer {
         }
         RootNode root = new RootNode(rootLocNodes, rootEqNodes, rootPtNodes, nonSemanticNodes);
         return formatRoot(root);
+    }
+
+    /**
+     * Resolves the parent item name for a child item using semantic relation metadata first,
+     * falling back to standard Group membership hierarchy.
+     */
+    private static @Nullable String findParentName(MetadataRegistry metadataRegistry, Item child,
+            Map<String, Item> itemMap, boolean isLocation, boolean isEquipment, boolean isPoint) {
+
+        // Try resolving via SemanticsMetadataProvider configuration keys
+        Metadata md = metadataRegistry.get(new MetadataKey(NAMESPACE, child.getName()));
+        if (md != null) {
+            Map<String, Object> config = md.getConfiguration();
+
+            if (isLocation) {
+                // Sub-location -> Parent Location
+                String parentLoc = getValidTarget(config.get(REL_IS_PART_OF), itemMap);
+                if (parentLoc != null) {
+                    return parentLoc;
+                }
+            } else if (isEquipment) {
+                // Sub-equipment -> Parent Equipment
+                String parentEq = getValidTarget(config.get(REL_IS_PART_OF), itemMap);
+                if (parentEq != null) {
+                    return parentEq;
+                }
+                // Equipment -> Parent Location
+                String parentLoc = getValidTarget(config.get(REL_HAS_LOCATION), itemMap);
+                if (parentLoc != null) {
+                    return parentLoc;
+                }
+            } else if (isPoint) {
+                // Point -> Parent Equipment
+                String parentEq = getValidTarget(config.get(REL_IS_POINT_OF), itemMap);
+                if (parentEq != null) {
+                    return parentEq;
+                }
+                // Loose Point -> Parent Location
+                String parentLoc = getValidTarget(config.get(REL_HAS_LOCATION), itemMap);
+                if (parentLoc != null) {
+                    return parentLoc;
+                }
+            }
+        }
+
+        // Fallback: Resolve parent via Group membership
+        String fallbackParent = null;
+        for (String groupName : child.getGroupNames()) {
+            Item parent = itemMap.get(groupName);
+            if (parent == null) {
+                continue;
+            }
+
+            if (isLocation) {
+                if (SemanticTags.getLocation(parent) != null) {
+                    return groupName;
+                }
+            } else {
+                if (SemanticTags.getEquipment(parent) != null) {
+                    return groupName; // Direct Equipment parent has higher priority
+                } else if (SemanticTags.getLocation(parent) != null && fallbackParent == null) {
+                    fallbackParent = groupName; // Location parent is fallback for Equipment/Points
+                }
+            }
+        }
+
+        return fallbackParent;
+    }
+
+    private static @Nullable String getValidTarget(@Nullable Object targetName, Map<String, Item> itemMap) {
+        if (targetName instanceof String name && itemMap.containsKey(name)) {
+            return name;
+        }
+        return null;
     }
 
     private static LocationNode buildLocationNode(Item loc, Map<String, List<Item>> parentToChildren,

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.core.voice.text.interpreter.llm;
 
-import static org.openhab.core.semantics.internal.SemanticsMetadataProvider.NAMESPACE;
-import static org.openhab.core.semantics.internal.SemanticsMetadataProvider.REL_HAS_LOCATION;
-import static org.openhab.core.semantics.internal.SemanticsMetadataProvider.REL_IS_PART_OF;
-import static org.openhab.core.semantics.internal.SemanticsMetadataProvider.REL_IS_POINT_OF;
+import static org.openhab.core.semantics.SemanticTags.METADATA_NAMESPACE;
+import static org.openhab.core.semantics.SemanticTags.REL_HAS_LOCATION;
+import static org.openhab.core.semantics.SemanticTags.REL_IS_PART_OF;
+import static org.openhab.core.semantics.SemanticTags.REL_IS_POINT_OF;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -183,7 +183,7 @@ public class LLMItemSerializer {
         List<String> parents = new ArrayList<>();
 
         // Resolve semantic parent via SemanticsMetadataProvider configuration keys
-        Metadata md = metadataRegistry.get(new MetadataKey(NAMESPACE, child.getName()));
+        Metadata md = metadataRegistry.get(new MetadataKey(METADATA_NAMESPACE, child.getName()));
         if (md != null) {
             Map<String, Object> config = md.getConfiguration();
 

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
@@ -174,15 +174,15 @@ public class LLMItemSerializer {
     }
 
     /**
-     * Resolves the parent item names for a child item using semantic relation metadata first,
-     * falling back to standard Group membership hierarchy, and including non-semantic group parents.
+     * Resolves the parent item names for a child item using semantic relation metadata for semantic parents
+     * and group membership for non-semantic parent groups.
      */
     private static List<String> findParentNames(MetadataRegistry metadataRegistry, Item child,
             Map<String, Item> itemMap, boolean isLocation, boolean isEquipment, boolean isPoint) {
 
         List<String> parents = new ArrayList<>();
 
-        // Try resolving via SemanticsMetadataProvider configuration keys
+        // Resolve semantic parent via SemanticsMetadataProvider configuration keys
         Metadata md = metadataRegistry.get(new MetadataKey(NAMESPACE, child.getName()));
         if (md != null) {
             Map<String, Object> config = md.getConfiguration();
@@ -220,9 +220,7 @@ public class LLMItemSerializer {
             }
         }
 
-        // Group membership processing (semantic parent fallback + non-semantic group parents)
-        String semanticFallbackParent = null;
-
+        // Add non-semantic parent groups from group membership
         for (String groupName : child.getGroupNames()) {
             Item parent = itemMap.get(groupName);
             if (parent == null) {
@@ -232,27 +230,9 @@ public class LLMItemSerializer {
             boolean parentIsLocation = SemanticTags.getLocation(parent) != null;
             boolean parentIsEquipment = SemanticTags.getEquipment(parent) != null;
 
-            if (parents.isEmpty()) {
-                if (isLocation) {
-                    if (parentIsLocation) {
-                        parents.add(groupName);
-                    }
-                } else {
-                    if (parentIsEquipment) {
-                        parents.add(groupName); // Direct Equipment parent has higher priority
-                    } else if (parentIsLocation && semanticFallbackParent == null) {
-                        semanticFallbackParent = groupName;
-                    }
-                }
-            }
-
             if (!parentIsLocation && !parentIsEquipment && !parents.contains(groupName)) {
                 parents.add(groupName);
             }
-        }
-
-        if (parents.isEmpty() && semanticFallbackParent != null) {
-            parents.addFirst(semanticFallbackParent);
         }
 
         return parents;

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializer.java
@@ -82,6 +82,9 @@ public class LLMItemSerializer {
             List<PointNode> pointItems, List<NonSemanticItemNode> items) {
     }
 
+    private record ResolvedParents(List<String> semanticParents, List<String> nonSemanticParents) {
+    }
+
     /**
      * Serializes a collection of items, evaluating openHAB semantic relations and group membership,
      * localizing command options with the given locale if available.
@@ -102,19 +105,23 @@ public class LLMItemSerializer {
         }
 
         Map<String, List<Item>> parentToChildren = new HashMap<>();
-        Set<String> childNames = new HashSet<>();
+        Set<String> semanticChildNames = new HashSet<>();
+        Set<String> nonSemanticChildNames = new HashSet<>();
 
         for (Item child : items) {
             boolean isLocation = SemanticTags.getLocation(child) != null;
             boolean isEquipment = SemanticTags.getEquipment(child) != null;
             boolean isPoint = SemanticTags.getPoint(child) != null || SemanticTags.getProperty(child) != null;
 
-            List<String> parentNames = findParentNames(metadataRegistry, child, itemMap, isLocation, isEquipment,
-                    isPoint);
+            ResolvedParents parents = findParents(metadataRegistry, child, itemMap, isLocation, isEquipment, isPoint);
 
-            for (String parentName : parentNames) {
+            for (String parentName : parents.semanticParents()) {
                 parentToChildren.computeIfAbsent(parentName, k -> new ArrayList<>()).add(child);
-                childNames.add(child.getName());
+                semanticChildNames.add(child.getName());
+            }
+            for (String parentName : parents.nonSemanticParents()) {
+                parentToChildren.computeIfAbsent(parentName, k -> new ArrayList<>()).add(child);
+                nonSemanticChildNames.add(child.getName());
             }
         }
 
@@ -129,19 +136,19 @@ public class LLMItemSerializer {
             boolean isPoint = SemanticTags.getPoint(item) != null || SemanticTags.getProperty(item) != null;
 
             if (isLocation) {
-                if (!childNames.contains(item.getName())) {
+                if (!semanticChildNames.contains(item.getName())) {
                     rootLocations.add(item);
                 }
             } else if (isEquipment) {
-                if (!childNames.contains(item.getName())) {
+                if (!semanticChildNames.contains(item.getName())) {
                     rootEquipments.add(item);
                 }
             } else if (isPoint) {
-                if (!childNames.contains(item.getName())) {
+                if (!semanticChildNames.contains(item.getName())) {
                     rootPoints.add(item);
                 }
             } else {
-                if (!childNames.contains(item.getName())) {
+                if (!nonSemanticChildNames.contains(item.getName())) {
                     nonSemanticItems.add(item);
                 }
             }
@@ -167,7 +174,7 @@ public class LLMItemSerializer {
             rootPtNodes.add(buildPointNode(pt, locale));
         }
         for (Item item : nonSemanticItems) {
-            nonSemanticNodes.add(buildNonSemanticNode(item, parentToChildren, locale));
+            nonSemanticNodes.add(buildNonSemanticNode(item, parentToChildren, Set.of(), locale));
         }
         RootNode root = new RootNode(rootLocNodes, rootEqNodes, rootPtNodes, nonSemanticNodes);
         return formatRoot(root);
@@ -177,10 +184,11 @@ public class LLMItemSerializer {
      * Resolves the parent item names for a child item using semantic relation metadata for semantic parents
      * and group membership for non-semantic parent groups.
      */
-    private static List<String> findParentNames(MetadataRegistry metadataRegistry, Item child,
-            Map<String, Item> itemMap, boolean isLocation, boolean isEquipment, boolean isPoint) {
+    private static ResolvedParents findParents(MetadataRegistry metadataRegistry, Item child, Map<String, Item> itemMap,
+            boolean isLocation, boolean isEquipment, boolean isPoint) {
 
-        List<String> parents = new ArrayList<>();
+        List<String> semanticParents = new ArrayList<>();
+        List<String> nonSemanticParents = new ArrayList<>();
 
         // Resolve semantic parent via SemanticsMetadataProvider configuration keys
         Metadata md = metadataRegistry.get(new MetadataKey(METADATA_NAMESPACE, child.getName()));
@@ -191,30 +199,30 @@ public class LLMItemSerializer {
                 // Sub-location -> Parent Location
                 String parentLoc = getValidTarget(config.get(REL_IS_PART_OF), itemMap);
                 if (parentLoc != null) {
-                    parents.add(parentLoc);
+                    semanticParents.add(parentLoc);
                 }
             } else if (isEquipment) {
                 // Sub-equipment -> Parent Equipment
                 String parentEq = getValidTarget(config.get(REL_IS_PART_OF), itemMap);
                 if (parentEq != null) {
-                    parents.add(parentEq);
+                    semanticParents.add(parentEq);
                 } else {
                     // Equipment -> Parent Location
                     String parentLoc = getValidTarget(config.get(REL_HAS_LOCATION), itemMap);
                     if (parentLoc != null) {
-                        parents.add(parentLoc);
+                        semanticParents.add(parentLoc);
                     }
                 }
             } else if (isPoint) {
                 // Point -> Parent Equipment
                 String parentEq = getValidTarget(config.get(REL_IS_POINT_OF), itemMap);
                 if (parentEq != null) {
-                    parents.add(parentEq);
+                    semanticParents.add(parentEq);
                 } else {
                     // Loose Point -> Parent Location
                     String parentLoc = getValidTarget(config.get(REL_HAS_LOCATION), itemMap);
                     if (parentLoc != null) {
-                        parents.add(parentLoc);
+                        semanticParents.add(parentLoc);
                     }
                 }
             }
@@ -230,12 +238,12 @@ public class LLMItemSerializer {
             boolean parentIsLocation = SemanticTags.getLocation(parent) != null;
             boolean parentIsEquipment = SemanticTags.getEquipment(parent) != null;
 
-            if (!parentIsLocation && !parentIsEquipment && !parents.contains(groupName)) {
-                parents.add(groupName);
+            if (!parentIsLocation && !parentIsEquipment && !semanticParents.contains(groupName)) {
+                nonSemanticParents.add(groupName);
             }
         }
 
-        return parents;
+        return new ResolvedParents(semanticParents, nonSemanticParents);
     }
 
     private static @Nullable String getValidTarget(@Nullable Object targetName, Map<String, Item> itemMap) {
@@ -450,12 +458,17 @@ public class LLMItemSerializer {
     }
 
     private static NonSemanticItemNode buildNonSemanticNode(Item item, Map<String, List<Item>> parentToChildren,
-            @Nullable Locale locale) {
+            Set<String> ancestors, @Nullable Locale locale) {
         List<Item> children = parentToChildren.getOrDefault(item.getName(), List.of());
         List<NonSemanticItemNode> childNodes = new ArrayList<>();
 
+        Set<String> newAncestors = new HashSet<>(ancestors);
+        newAncestors.add(item.getName());
+
         for (Item child : children) {
-            childNodes.add(buildNonSemanticNode(child, parentToChildren, locale));
+            if (!newAncestors.contains(child.getName())) {
+                childNodes.add(buildNonSemanticNode(child, parentToChildren, newAncestors, locale));
+            }
         }
 
         childNodes.sort(Comparator.comparing(NonSemanticItemNode::name));

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
@@ -327,4 +327,31 @@ public class LLMItemSerializerTest {
 
         assertEquals(expected, LLMItemSerializer.serialize(items, metadataRegistry, null));
     }
+
+    @Test
+    public void testSerializeItemInSemanticAndNonSemanticGroups() {
+        MetadataRegistry metadataRegistry = mockMetadataRegistry(
+                Map.of("LivingRoom_Light", Map.of("hasLocation", "LivingRoom")));
+
+        Item livingRoom = mockItem("LivingRoom", null, "Group", Set.of("Mock_Location_Room_LivingRoom"), List.of());
+        Item gLights = mockItem("gLights", "All Lights", "Group", Set.of(), List.of());
+        Item lrLight = mockItem("LivingRoom_Light", "Living Room Light", "Dimmer", Set.of("Mock_Point_Control_Light"),
+                List.of("LivingRoom", "gLights"));
+
+        List<Item> items = List.of(livingRoom, gLights, lrLight);
+
+        String expected = """
+                # Format: [..]name [type] ["label"] [:semanticClass] [[properties]] [(commandOptions: COMMAND=Label)]
+
+                # Semantic Items
+                LivingRoom :MockLivingRoom
+                ..LivingRoom_Light Dimmer :MockLight
+
+                # Non-semantic Items
+                gLights "All Lights"
+                ..LivingRoom_Light Dimmer
+                """;
+
+        assertEquals(expected, LLMItemSerializer.serialize(items, metadataRegistry, null));
+    }
 }

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.openhab.core.semantics.internal.SemanticsMetadataProvider.NAMESPACE;
+import static org.openhab.core.semantics.SemanticTags.METADATA_NAMESPACE;
 
 import java.util.Collections;
 import java.util.List;
@@ -116,7 +116,7 @@ public class LLMItemSerializerTest {
         MetadataRegistry registry = mock(MetadataRegistry.class);
         when(registry.get(any(MetadataKey.class))).thenAnswer(invocation -> {
             MetadataKey key = invocation.getArgument(0);
-            if (NAMESPACE.equals(key.getNamespace())) {
+            if (METADATA_NAMESPACE.equals(key.getNamespace())) {
                 Map<String, Object> config = semanticsConfigMap.get(key.getItemName());
                 if (config != null) {
                     return new Metadata(key, "", config);
@@ -352,6 +352,66 @@ public class LLMItemSerializerTest {
                 # Non-semantic Items
                 gLights "All Lights"
                 ..LivingRoom_Light Dimmer
+                """;
+
+        assertEquals(expected, LLMItemSerializer.serialize(items, metadataRegistry, null));
+    }
+
+    @Test
+    public void testSerializeSemanticRootInNonSemanticGroup() {
+        MetadataRegistry metadataRegistry = mockMetadataRegistry(Map.of());
+
+        Item gSensors = mockItem("gSensors", "Sensors Group", "Group", Set.of(), List.of());
+        Item tempSensor = mockItem("Temperature_Sensor", "Temperature Sensor", "Number",
+                Set.of("Mock_Point_Control_Light"), List.of("gSensors"));
+
+        List<Item> items = List.of(gSensors, tempSensor);
+
+        String expected = """
+                # Format: [..]name [type] ["label"] [:semanticClass] [[properties]] [(commandOptions: COMMAND=Label)]
+
+                # Semantic Items
+                Temperature_Sensor Number :MockLight
+
+                # Non-semantic Items
+                gSensors "Sensors Group"
+                ..Temperature_Sensor Number
+                """;
+
+        assertEquals(expected, LLMItemSerializer.serialize(items, metadataRegistry, null));
+    }
+
+    @Test
+    public void testSerializeRecursiveGroups() {
+        MetadataRegistry metadataRegistry = mockMetadataRegistry(Map.of());
+
+        Item groupA = mockItem("GroupA", "Group A", "Group", Set.of(), List.of("GroupC"));
+        Item groupB = mockItem("GroupB", "Group B", "Group", Set.of(), List.of("GroupA"));
+        Item groupC = mockItem("GroupC", "Group C", "Group", Set.of(), List.of("GroupB"));
+
+        List<Item> items = List.of(groupA, groupB, groupC);
+
+        String result = LLMItemSerializer.serialize(items, metadataRegistry, null);
+        assertEquals("", result);
+    }
+
+    @Test
+    public void testSerializeRecursiveGroupsFromRoot() {
+        MetadataRegistry metadataRegistry = mockMetadataRegistry(Map.of());
+
+        Item groupA = mockItem("GroupA", "Label A", "Group", Set.of(), List.of());
+        Item groupB = mockItem("GroupB", "Label B", "Group", Set.of(), List.of("GroupA", "GroupC"));
+        Item groupC = mockItem("GroupC", "Label C", "Group", Set.of(), List.of("GroupB"));
+
+        List<Item> items = List.of(groupA, groupB, groupC);
+
+        String expected = """
+                # Format: [..]name [type] ["label"] [:semanticClass] [[properties]] [(commandOptions: COMMAND=Label)]
+
+                # Non-semantic Items
+                GroupA "Label A"
+                ..GroupB "Label B"
+                ....GroupC "Label C"
                 """;
 
         assertEquals(expected, LLMItemSerializer.serialize(items, metadataRegistry, null));

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
@@ -16,9 +16,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.openhab.core.semantics.internal.SemanticsMetadataProvider.NAMESPACE;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -27,6 +29,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.items.Item;
+import org.openhab.core.items.Metadata;
+import org.openhab.core.items.MetadataKey;
+import org.openhab.core.items.MetadataRegistry;
 import org.openhab.core.semantics.Equipment;
 import org.openhab.core.semantics.Location;
 import org.openhab.core.semantics.Point;
@@ -107,13 +112,30 @@ public class LLMItemSerializerTest {
         return item;
     }
 
+    private MetadataRegistry mockMetadataRegistry(Map<String, Map<String, Object>> semanticsConfigMap) {
+        MetadataRegistry registry = mock(MetadataRegistry.class);
+        when(registry.get(any(MetadataKey.class))).thenAnswer(invocation -> {
+            MetadataKey key = invocation.getArgument(0);
+            if (NAMESPACE.equals(key.getNamespace())) {
+                Map<String, Object> config = semanticsConfigMap.get(key.getItemName());
+                if (config != null) {
+                    return new Metadata(key, "", config);
+                }
+            }
+            return null;
+        });
+        return registry;
+    }
+
     @Test
     public void testSerializeNullOrEmpty() {
-        assertEquals("", LLMItemSerializer.serialize(Collections.emptyList(), null));
+        MetadataRegistry metadataRegistry = mockMetadataRegistry(Map.of());
+        assertEquals("", LLMItemSerializer.serialize(Collections.emptyList(), metadataRegistry, null));
     }
 
     @Test
     public void testSerializeNonSemanticItemsOnly() {
+        MetadataRegistry metadataRegistry = mockMetadataRegistry(Map.of());
         Item item1 = mockItem("ItemB", "Label B", "Switch", Set.of(), List.of());
         Item item2 = mockItem("ItemA", null, "Dimmer", Set.of(), List.of());
 
@@ -125,11 +147,13 @@ public class LLMItemSerializerTest {
                 ItemB Switch "Label B"
                 """;
 
-        assertEquals(expected, LLMItemSerializer.serialize(List.of(item1, item2), null));
+        assertEquals(expected, LLMItemSerializer.serialize(List.of(item1, item2), metadataRegistry, null));
     }
 
     @Test
     public void testSerializeHierarchicalModel() {
+        MetadataRegistry metadataRegistry = mockMetadataRegistry(Map.of());
+
         // GF Floor
         Item gf = mockItem("GF", "Ground Floor", "Group", Set.of("Mock_Location_Floor"), List.of());
 
@@ -168,11 +192,45 @@ public class LLMItemSerializerTest {
                 System_Mode String
                 """;
 
-        assertEquals(expected, LLMItemSerializer.serialize(items, null));
+        assertEquals(expected, LLMItemSerializer.serialize(items, metadataRegistry, null));
+    }
+
+    @Test
+    public void testSerializeSemanticRelationsMetadata() {
+        MetadataRegistry metadataRegistry = mockMetadataRegistry(Map.of("LivingRoom", Map.of("isPartOf", "GF"), //
+                "TV", Map.of("hasLocation", "LivingRoom"), //
+                "TV_Power", Map.of("isPointOf", "TV"), //
+                "LivingRoom_Light", Map.of("hasLocation", "LivingRoom")));
+
+        Item gf = mockItem("GF", "Ground Floor", "Group", Set.of("Mock_Location_Floor"), List.of());
+        Item livingRoom = mockItem("LivingRoom", "Living Room", "Group", Set.of("Mock_Location_Room_LivingRoom"),
+                List.of());
+        Item tv = mockItem("TV", "Living Room TV", "Group", Set.of("Mock_Equipment_Television"), List.of());
+        Item tvPower = mockItem("TV_Power", "TV Power", "Switch",
+                Set.of("Mock_Point_Control_Power", "Mock_Property_Power"), List.of());
+        Item lrLight = mockItem("LivingRoom_Light", "Living Room Light", "Dimmer", Set.of("Mock_Point_Control_Light"),
+                List.of());
+
+        List<Item> items = List.of(tvPower, livingRoom, lrLight, tv, gf);
+
+        String expected = """
+                # Format: [..]name [type] ["label"] [:semanticClass] [[properties]] [(commandOptions: COMMAND=Label)]
+
+                # Semantic Items
+                GF "Ground Floor" :MockFloor
+                ..LivingRoom :MockLivingRoom
+                ....TV "Living Room TV" :MockTV
+                ......TV_Power Switch :MockPower [MockPowerProperty]
+                ....LivingRoom_Light Dimmer :MockLight
+                """;
+
+        assertEquals(expected, LLMItemSerializer.serialize(items, metadataRegistry, null));
     }
 
     @Test
     public void testSerializeWithCommandOptions() {
+        MetadataRegistry metadataRegistry = mockMetadataRegistry(Map.of());
+
         Item item1 = mockItem("ItemB", "Label B", "Switch", Set.of(), List.of(),
                 List.of(new CommandOption("ON", "On"), new CommandOption("OFF", "")));
         Item item2 = mockItem("ItemA", null, "Dimmer", Set.of(), List.of(), null);
@@ -206,7 +264,67 @@ public class LLMItemSerializerTest {
                 ItemB Switch "Label B" (ON=On,OFF)
                 """;
 
-        assertEquals(expected,
-                LLMItemSerializer.serialize(List.of(item1, item2, item3, locationItem, eqItem, ptItem), null));
+        assertEquals(expected, LLMItemSerializer.serialize(List.of(item1, item2, item3, locationItem, eqItem, ptItem),
+                metadataRegistry, null));
+    }
+
+    @Test
+    public void testSerializeComplexSemanticModelWithNestedEquipmentAndRelations() {
+        /*
+         * Complex model hierarchy:
+         * House (Location)
+         * ├── GroundFloor (Location, isPartOf House)
+         * ├── LivingRoom (Location, isPartOf GroundFloor)
+         * │ ├── EqA (Equipment, hasLocation LivingRoom)
+         * │ │ └── EqB (Equipment, isPartOf EqA)
+         * │ │ __└── EqC (Equipment, isPartOf EqB)
+         * │ │ ____└── PointC (Point, isPointOf EqC)
+         * │ └── RoomLight (Point, hasLocation LivingRoom)
+         * └── OutdoorEq (Equipment, hasLocation GroundFloor via group fallback)
+         * 
+         * Specifically, EqC has isPartOf EqB (so EqA -> EqC is NOT serialized directly under EqA).
+         */
+
+        MetadataRegistry metadataRegistry = mockMetadataRegistry(Map.of("GroundFloor", Map.of("isPartOf", "House"), //
+                "LivingRoom", Map.of("isPartOf", "GroundFloor"), //
+                "EqA", Map.of("hasLocation", "LivingRoom"), //
+                "EqB", Map.of("isPartOf", "EqA"), //
+                "EqC", Map.of("isPartOf", "EqB"), //
+                "PointC", Map.of("isPointOf", "EqC"), //
+                "RoomLight", Map.of("hasLocation", "LivingRoom")));
+
+        Item house = mockItem("House", "Main House", "Group", Set.of("Mock_Location_Floor"), List.of());
+        Item gf = mockItem("GroundFloor", null, "Group", Set.of("Mock_Location_Floor"), List.of());
+        Item livingRoom = mockItem("LivingRoom", null, "Group", Set.of("Mock_Location_Room_LivingRoom"), List.of());
+
+        Item eqA = mockItem("EqA", "Equipment A", "Group", Set.of("Mock_Equipment_Television"), List.of());
+        Item eqB = mockItem("EqB", "Equipment B", "Group", Set.of("Mock_Equipment_Television"), List.of());
+        Item eqC = mockItem("EqC", "Equipment C", "Group", Set.of("Mock_Equipment_Television"), List.of());
+        Item pointC = mockItem("PointC", "Point C", "Switch", Set.of("Mock_Point_Control_Power"), List.of());
+
+        Item roomLight = mockItem("RoomLight", "Room Light", "Dimmer", Set.of("Mock_Point_Control_Light"), List.of());
+
+        // Uses group fallback for parent location resolution
+        Item outdoorEq = mockItem("OutdoorEq", "Outdoor Equipment", "Group", Set.of("Mock_Equipment_Television"),
+                List.of("GroundFloor"));
+
+        List<Item> items = List.of(pointC, eqC, eqB, eqA, livingRoom, roomLight, outdoorEq, gf, house);
+
+        String expected = """
+                # Format: [..]name [type] ["label"] [:semanticClass] [[properties]] [(commandOptions: COMMAND=Label)]
+
+                # Semantic Items
+                House "Main House" :MockFloor
+                ..GroundFloor :MockFloor
+                ....LivingRoom :MockLivingRoom
+                ......EqA "Equipment A" :MockTV
+                ........EqB "Equipment B" :MockTV
+                ..........EqC "Equipment C" :MockTV
+                ............PointC Switch :MockPower
+                ......RoomLight Dimmer :MockLight
+                ....OutdoorEq "Outdoor Equipment" :MockTV
+                """;
+
+        assertEquals(expected, LLMItemSerializer.serialize(items, metadataRegistry, null));
     }
 }

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/text/interpreter/llm/LLMItemSerializerTest.java
@@ -152,7 +152,10 @@ public class LLMItemSerializerTest {
 
     @Test
     public void testSerializeHierarchicalModel() {
-        MetadataRegistry metadataRegistry = mockMetadataRegistry(Map.of());
+        MetadataRegistry metadataRegistry = mockMetadataRegistry(Map.of("LivingRoom", Map.of("isPartOf", "GF"), //
+                "TV", Map.of("hasLocation", "LivingRoom"), //
+                "TV_Power", Map.of("isPointOf", "TV"), //
+                "LivingRoom_Light", Map.of("hasLocation", "LivingRoom")));
 
         // GF Floor
         Item gf = mockItem("GF", "Ground Floor", "Group", Set.of("Mock_Location_Floor"), List.of());
@@ -229,7 +232,8 @@ public class LLMItemSerializerTest {
 
     @Test
     public void testSerializeWithCommandOptions() {
-        MetadataRegistry metadataRegistry = mockMetadataRegistry(Map.of());
+        MetadataRegistry metadataRegistry = mockMetadataRegistry(Map.of("TV", Map.of("hasLocation", "LocationA"), //
+                "TV_Channel", Map.of("isPointOf", "TV")));
 
         Item item1 = mockItem("ItemB", "Label B", "Switch", Set.of(), List.of(),
                 List.of(new CommandOption("ON", "On"), new CommandOption("OFF", "")));
@@ -273,16 +277,14 @@ public class LLMItemSerializerTest {
         /*
          * Complex model hierarchy:
          * House (Location)
-         * ├── GroundFloor (Location, isPartOf House)
-         * ├── LivingRoom (Location, isPartOf GroundFloor)
-         * │ ├── EqA (Equipment, hasLocation LivingRoom)
-         * │ │ └── EqB (Equipment, isPartOf EqA)
-         * │ │ __└── EqC (Equipment, isPartOf EqB)
-         * │ │ ____└── PointC (Point, isPointOf EqC)
-         * │ └── RoomLight (Point, hasLocation LivingRoom)
-         * └── OutdoorEq (Equipment, hasLocation GroundFloor via group fallback)
-         * 
-         * Specifically, EqC has isPartOf EqB (so EqA -> EqC is NOT serialized directly under EqA).
+         * └── GroundFloor (Location, isPartOf House)
+         * __├── LivingRoom (Location, isPartOf GroundFloor)
+         * __│ ├── EqA (Equipment, hasLocation LivingRoom)
+         * __│ │ └── EqB (Equipment, isPartOf EqA)
+         * __│ │ __└── EqC (Equipment, isPartOf EqB)
+         * __│ │ ____└── PointC (Point, isPointOf EqC)
+         * __│ └── RoomLight (Point, hasLocation LivingRoom)
+         * __└── OutdoorEq (Equipment, hasLocation GroundFloor)
          */
 
         MetadataRegistry metadataRegistry = mockMetadataRegistry(Map.of("GroundFloor", Map.of("isPartOf", "House"), //
@@ -291,7 +293,8 @@ public class LLMItemSerializerTest {
                 "EqB", Map.of("isPartOf", "EqA"), //
                 "EqC", Map.of("isPartOf", "EqB"), //
                 "PointC", Map.of("isPointOf", "EqC"), //
-                "RoomLight", Map.of("hasLocation", "LivingRoom")));
+                "RoomLight", Map.of("hasLocation", "LivingRoom"), //
+                "OutdoorEq", Map.of("hasLocation", "GroundFloor")));
 
         Item house = mockItem("House", "Main House", "Group", Set.of("Mock_Location_Floor"), List.of());
         Item gf = mockItem("GroundFloor", null, "Group", Set.of("Mock_Location_Floor"), List.of());
@@ -304,7 +307,6 @@ public class LLMItemSerializerTest {
 
         Item roomLight = mockItem("RoomLight", "Room Light", "Dimmer", Set.of("Mock_Point_Control_Light"), List.of());
 
-        // Uses group fallback for parent location resolution
         Item outdoorEq = mockItem("OutdoorEq", "Outdoor Equipment", "Group", Set.of("Mock_Equipment_Television"),
                 List.of("GroundFloor"));
 


### PR DESCRIPTION
- Get semantic relationships from semantics metadata instead of checking group memberships (so `SemanticsMetadataProvider` is single source of truth for building the model).
- Include semantic children of non-semantic groups in the non-semantic items section of the output.