### PR TITLE
Sitemaps: widget confirm command parameter

### DIFF
--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
@@ -728,7 +728,7 @@ public class SitemapResource
         bean.unit = itemUIRegistry.getUnitForWidget(widget);
         bean.type = widget.getWidgetType();
         bean.visibility = itemUIRegistry.getVisiblity(widget);
-        bean.confirmCmd = itemUIRegistry.getConfirmCmd(widget);
+        bean.confirmCmdMessage = itemUIRegistry.getConfirmCmdMessage(widget);
         if (widget instanceof LinkableWidget linkableWidget) {
             List<Widget> children = itemUIRegistry.getChildren(linkableWidget);
             if (widget instanceof Frame || widget instanceof Buttongrid) {

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
@@ -728,7 +728,7 @@ public class SitemapResource
         bean.unit = itemUIRegistry.getUnitForWidget(widget);
         bean.type = widget.getWidgetType();
         bean.visibility = itemUIRegistry.getVisiblity(widget);
-        bean.confirmCmdMessage = itemUIRegistry.getConfirmCmdMessage(widget);
+        bean.commandConfirmMessage = itemUIRegistry.getCommandConfirmMessage(widget);
         if (widget instanceof LinkableWidget linkableWidget) {
             List<Widget> children = itemUIRegistry.getChildren(linkableWidget);
             if (widget instanceof Frame || widget instanceof Buttongrid) {

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
@@ -152,6 +152,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * @author Laurent Garnier - Added support for new sitemap element Colortemperaturepicker
  * @author Mark Herwege - Implement sitemap registry, remove Guava dependency
  * @author Mark Herwege - Implement sitemap definition endpoints
+ * @author Mark Herwege - Add support for confirmation dialog for commands
  */
 @Component(service = { RESTResource.class, EventSubscriber.class })
 @JaxrsResource
@@ -727,6 +728,7 @@ public class SitemapResource
         bean.unit = itemUIRegistry.getUnitForWidget(widget);
         bean.type = widget.getWidgetType();
         bean.visibility = itemUIRegistry.getVisiblity(widget);
+        bean.confirmCmd = itemUIRegistry.getConfirmCmd(widget);
         if (widget instanceof LinkableWidget linkableWidget) {
             List<Widget> children = itemUIRegistry.getChildren(linkableWidget);
             if (widget instanceof Frame || widget instanceof Buttongrid) {
@@ -952,11 +954,13 @@ public class SitemapResource
             }
             // Consider items involved in any icon condition
             items.addAll(getItemsInRuleConditions(widget.getIconRules()));
-            // Consider items involved in any visibility, labelcolor, valuecolor and iconcolor condition
+            // Consider items involved in any visibility, labelcolor, valuecolor, iconcolor and confirm cmd rule
+            // condition
             items.addAll(getItemsInRuleConditions(widget.getVisibility()));
             items.addAll(getItemsInRuleConditions(widget.getLabelColor()));
             items.addAll(getItemsInRuleConditions(widget.getValueColor()));
             items.addAll(getItemsInRuleConditions(widget.getIconColor()));
+            items.addAll(getItemsInRuleConditions(widget.getConfirmCmdRules()));
         }
         return items;
     }

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapWidgetEvent.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapWidgetEvent.java
@@ -21,6 +21,7 @@ import org.openhab.core.io.rest.core.item.EnrichedItemDTO;
  * @author Laurent Garnier - New field iconcolor
  * @author Laurent Garnier - New field reloadIcon
  * @author Danny Baumann - New field labelSource
+ * @author Mark Herwege - Add support for confirmation dialog for commands
  */
 public class SitemapWidgetEvent extends SitemapEvent {
 
@@ -37,6 +38,7 @@ public class SitemapWidgetEvent extends SitemapEvent {
     public String state;
     public EnrichedItemDTO item;
     public boolean descriptionChanged;
+    public boolean confirmCmd;
 
     public SitemapWidgetEvent() {
     }

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapWidgetEvent.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapWidgetEvent.java
@@ -38,7 +38,7 @@ public class SitemapWidgetEvent extends SitemapEvent {
     public String state;
     public EnrichedItemDTO item;
     public boolean descriptionChanged;
-    public String confirmCmdMessage;
+    public String commandConfirmMessage;
 
     public SitemapWidgetEvent() {
     }

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapWidgetEvent.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapWidgetEvent.java
@@ -38,7 +38,7 @@ public class SitemapWidgetEvent extends SitemapEvent {
     public String state;
     public EnrichedItemDTO item;
     public boolean descriptionChanged;
-    public boolean confirmCmd;
+    public String confirmCmdMessage;
 
     public SitemapWidgetEvent() {
     }

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
@@ -46,8 +46,6 @@ public class WidgetDTO extends AbstractWidgetDTO {
     public String valuecolor;
     public String iconcolor;
 
-    public boolean confirmCmd;
-
     public String pattern;
     public String unit;
 

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
@@ -45,7 +45,7 @@ public class WidgetDTO extends AbstractWidgetDTO {
     public String labelcolor;
     public String valuecolor;
     public String iconcolor;
-    public String confirmCmdMessage;
+    public String commandConfirmMessage;
 
     public String pattern;
     public String unit;

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
@@ -45,6 +45,7 @@ public class WidgetDTO extends AbstractWidgetDTO {
     public String labelcolor;
     public String valuecolor;
     public String iconcolor;
+    public String confirmCmdMessage;
 
     public String pattern;
     public String unit;

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
@@ -33,6 +33,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * @author Laurent Garnier - Remove field columns
  * @author Laurent Garnier - New fields row, column, command, releaseCommand and stateless for Button element
  * @author Mark Herwege - Extends abstract widget DTO
+ * @author Mark Herwege - Add support for confirmation dialog for commands
  */
 @Schema(name = "SitemapWidget")
 public class WidgetDTO extends AbstractWidgetDTO {
@@ -44,6 +45,8 @@ public class WidgetDTO extends AbstractWidgetDTO {
     public String labelcolor;
     public String valuecolor;
     public String iconcolor;
+
+    public boolean confirmCmd;
 
     public String pattern;
     public String unit;

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetsChangeListener.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetsChangeListener.java
@@ -153,6 +153,10 @@ public class WidgetsChangeListener implements EventSubscriber {
                 for (Rule rule : widget.getIconColor()) {
                     addItemsFromConditions(items, rule.getConditions());
                 }
+                // now scan confirm command rules
+                for (Rule rule : widget.getConfirmCmdRules()) {
+                    addItemsFromConditions(items, rule.getConditions());
+                }
             }
         }
         return items;

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetsChangeListener.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetsChangeListener.java
@@ -243,7 +243,7 @@ public class WidgetsChangeListener implements EventSubscriber {
             event.labelSource = WidgetLabelSource.SITEMAP_WIDGET.toString();
         }
         event.visibility = itemUIRegistry.getVisiblity(widget);
-        event.confirmCmdMessage = itemUIRegistry.getConfirmCmdMessage(widget);
+        event.confirmCmdMessage = itemUIRegistry.getCommandConfirmMessage(widget);
         event.descriptionChanged = false;
         // event.item contains the (potentially changed) data of the item belonging to
         // the widget including its state (in event.item.state)

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetsChangeListener.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetsChangeListener.java
@@ -211,7 +211,7 @@ public class WidgetsChangeListener implements EventSubscriber {
             if (!skipWidget && w instanceof Chart chartWidget) {
                 skipWidget = chartWidget.getRefresh() > 0;
             }
-            if (!skipWidget || definesVisibilityOrColorOrIcon(w, item.getName())) {
+            if (!skipWidget || definesVisibilityOrConfirmOrColorOrIcon(w, item.getName())) {
                 SitemapWidgetEvent event = constructSitemapEventForWidget(item, state, w);
                 events.add(event);
             }
@@ -239,6 +239,7 @@ public class WidgetsChangeListener implements EventSubscriber {
             event.labelSource = WidgetLabelSource.SITEMAP_WIDGET.toString();
         }
         event.visibility = itemUIRegistry.getVisiblity(widget);
+        event.confirmCmd = itemUIRegistry.getConfirmCmd(widget);
         event.descriptionChanged = false;
         // event.item contains the (potentially changed) data of the item belonging to
         // the widget including its state (in event.item.state)
@@ -279,8 +280,9 @@ public class WidgetsChangeListener implements EventSubscriber {
         return null;
     }
 
-    private boolean definesVisibilityOrColorOrIcon(Widget w, String name) {
+    private boolean definesVisibilityOrConfirmOrColorOrIcon(Widget w, String name) {
         return w.getVisibility().stream().anyMatch(r -> conditionsDependsOnItem(r.getConditions(), name))
+                || w.getConfirmCmdRules().stream().anyMatch(r -> conditionsDependsOnItem(r.getConditions(), name))
                 || w.getLabelColor().stream().anyMatch(r -> conditionsDependsOnItem(r.getConditions(), name))
                 || w.getValueColor().stream().anyMatch(r -> conditionsDependsOnItem(r.getConditions(), name))
                 || w.getIconColor().stream().anyMatch(r -> conditionsDependsOnItem(r.getConditions(), name))

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetsChangeListener.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetsChangeListener.java
@@ -243,7 +243,7 @@ public class WidgetsChangeListener implements EventSubscriber {
             event.labelSource = WidgetLabelSource.SITEMAP_WIDGET.toString();
         }
         event.visibility = itemUIRegistry.getVisiblity(widget);
-        event.confirmCmdMessage = itemUIRegistry.getCommandConfirmMessage(widget);
+        event.commandConfirmMessage = itemUIRegistry.getCommandConfirmMessage(widget);
         event.descriptionChanged = false;
         // event.item contains the (potentially changed) data of the item belonging to
         // the widget including its state (in event.item.state)

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetsChangeListener.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetsChangeListener.java
@@ -243,7 +243,7 @@ public class WidgetsChangeListener implements EventSubscriber {
             event.labelSource = WidgetLabelSource.SITEMAP_WIDGET.toString();
         }
         event.visibility = itemUIRegistry.getVisiblity(widget);
-        event.confirmCmd = itemUIRegistry.getConfirmCmd(widget);
+        event.confirmCmdMessage = itemUIRegistry.getConfirmCmdMessage(widget);
         event.descriptionChanged = false;
         // event.item contains the (potentially changed) data of the item belonging to
         // the widget including its state (in event.item.state)

--- a/bundles/org.openhab.core.io.rest.sitemap/src/test/java/org/openhab/core/io/rest/sitemap/internal/SitemapResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/test/java/org/openhab/core/io/rest/sitemap/internal/SitemapResourceTest.java
@@ -90,7 +90,7 @@ public class SitemapResourceTest extends JavaTest {
     private static final String VALUE_COLOR_ITEM_NAME = "valueColorItemName";
     private static final String ICON_COLOR_ITEM_NAME = "iconColorItemName";
     private static final String ICON_ITEM_NAME = "iconItemName";
-    private static final String CONFIRM_CMD_ITEM_NAME = "confirmCmdItemName";
+    private static final String COMMAND_CONFIRM_ITEM_NAME = "commandConfirmItemName";
     private static final String WIDGET1_LABEL = "widget 1";
     private static final String WIDGET3_LABEL = "widget 3";
     private static final String GROUP_LABEL = "frame";
@@ -115,7 +115,7 @@ public class SitemapResourceTest extends JavaTest {
     private @NonNullByDefault({}) GenericItem valueColorItem;
     private @NonNullByDefault({}) GenericItem iconColorItem;
     private @NonNullByDefault({}) GenericItem iconItem;
-    private @NonNullByDefault({}) GenericItem confirmCmdItem;
+    private @NonNullByDefault({}) GenericItem commandConfirmItem;
 
     private @Mock @NonNullByDefault({}) HttpHeaders headersMock;
     private @Mock @NonNullByDefault({}) Sitemap defaultSitemapMock;
@@ -152,7 +152,7 @@ public class SitemapResourceTest extends JavaTest {
         valueColorItem = new TestItem(VALUE_COLOR_ITEM_NAME);
         iconColorItem = new TestItem(ICON_COLOR_ITEM_NAME);
         iconItem = new TestItem(ICON_ITEM_NAME);
-        confirmCmdItem = new TestItem(CONFIRM_CMD_ITEM_NAME);
+        commandConfirmItem = new TestItem(COMMAND_CONFIRM_ITEM_NAME);
 
         when(localeServiceMock.getLocale(null)).thenReturn(Locale.US);
 
@@ -412,7 +412,7 @@ public class SitemapResourceTest extends JavaTest {
     @Test
     public void whenLongPollingShouldObserveItemsFromConfirmCmdConditions() {
         ItemEvent itemEvent = mock(ItemEvent.class);
-        when(itemEvent.getItemName()).thenReturn(confirmCmdItem.getName());
+        when(itemEvent.getItemName()).thenReturn(commandConfirmItem.getName());
         executeWithDelay(() -> sitemapResource.receive(itemEvent));
 
         // non-null is sufficient here.
@@ -534,7 +534,7 @@ public class SitemapResourceTest extends JavaTest {
         when(itemUIRegistryMock.getItem(VALUE_COLOR_ITEM_NAME)).thenReturn(valueColorItem);
         when(itemUIRegistryMock.getItem(ICON_COLOR_ITEM_NAME)).thenReturn(iconColorItem);
         when(itemUIRegistryMock.getItem(ICON_ITEM_NAME)).thenReturn(iconItem);
-        when(itemUIRegistryMock.getItem(CONFIRM_CMD_ITEM_NAME)).thenReturn(confirmCmdItem);
+        when(itemUIRegistryMock.getItem(COMMAND_CONFIRM_ITEM_NAME)).thenReturn(commandConfirmItem);
     }
 
     private void configureWidgetStatesPage1(State state1, State state2) {
@@ -631,7 +631,7 @@ public class SitemapResourceTest extends JavaTest {
         // add confirm command conditions to the item:
         Rule confirmCmd = mock(Rule.class);
         Condition conditon4 = mock(Condition.class);
-        when(conditon4.getItem()).thenReturn(CONFIRM_CMD_ITEM_NAME);
+        when(conditon4.getItem()).thenReturn(COMMAND_CONFIRM_ITEM_NAME);
         List<Condition> conditions4 = new ArrayList<>();
         conditions4.add(conditon4);
         when(confirmCmd.getConditions()).thenReturn(conditions4);

--- a/bundles/org.openhab.core.io.rest.sitemap/src/test/java/org/openhab/core/io/rest/sitemap/internal/SitemapResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/test/java/org/openhab/core/io/rest/sitemap/internal/SitemapResourceTest.java
@@ -90,6 +90,7 @@ public class SitemapResourceTest extends JavaTest {
     private static final String VALUE_COLOR_ITEM_NAME = "valueColorItemName";
     private static final String ICON_COLOR_ITEM_NAME = "iconColorItemName";
     private static final String ICON_ITEM_NAME = "iconItemName";
+    private static final String CONFIRM_CMD_ITEM_NAME = "confirmCmdItemName";
     private static final String WIDGET1_LABEL = "widget 1";
     private static final String WIDGET3_LABEL = "widget 3";
     private static final String GROUP_LABEL = "frame";
@@ -114,6 +115,7 @@ public class SitemapResourceTest extends JavaTest {
     private @NonNullByDefault({}) GenericItem valueColorItem;
     private @NonNullByDefault({}) GenericItem iconColorItem;
     private @NonNullByDefault({}) GenericItem iconItem;
+    private @NonNullByDefault({}) GenericItem confirmCmdItem;
 
     private @Mock @NonNullByDefault({}) HttpHeaders headersMock;
     private @Mock @NonNullByDefault({}) Sitemap defaultSitemapMock;
@@ -150,6 +152,7 @@ public class SitemapResourceTest extends JavaTest {
         valueColorItem = new TestItem(VALUE_COLOR_ITEM_NAME);
         iconColorItem = new TestItem(ICON_COLOR_ITEM_NAME);
         iconItem = new TestItem(ICON_ITEM_NAME);
+        confirmCmdItem = new TestItem(CONFIRM_CMD_ITEM_NAME);
 
         when(localeServiceMock.getLocale(null)).thenReturn(Locale.US);
 
@@ -406,6 +409,22 @@ public class SitemapResourceTest extends JavaTest {
         assertThat(pageDTO.timeout, is(false));
     }
 
+    @Test
+    public void whenLongPollingShouldObserveItemsFromConfirmCmdConditions() {
+        ItemEvent itemEvent = mock(ItemEvent.class);
+        when(itemEvent.getItemName()).thenReturn(confirmCmdItem.getName());
+        executeWithDelay(() -> sitemapResource.receive(itemEvent));
+
+        // non-null is sufficient here.
+        when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(List.of());
+
+        Response response = sitemapResource.getPageData(headersMock, null, SITEMAP_NAME, SITEMAP_NAME, null, false);
+
+        PageDTO pageDTO = (PageDTO) response.getEntity();
+        // assert that the item state change did trigger the blocking method to return
+        assertThat(pageDTO.timeout, is(false));
+    }
+
     private static void executeWithDelay(Runnable executionWithDelay) {
         new Thread(() -> {
             try {
@@ -515,6 +534,7 @@ public class SitemapResourceTest extends JavaTest {
         when(itemUIRegistryMock.getItem(VALUE_COLOR_ITEM_NAME)).thenReturn(valueColorItem);
         when(itemUIRegistryMock.getItem(ICON_COLOR_ITEM_NAME)).thenReturn(iconColorItem);
         when(itemUIRegistryMock.getItem(ICON_ITEM_NAME)).thenReturn(iconItem);
+        when(itemUIRegistryMock.getItem(CONFIRM_CMD_ITEM_NAME)).thenReturn(confirmCmdItem);
     }
 
     private void configureWidgetStatesPage1(State state1, State state2) {
@@ -560,73 +580,84 @@ public class SitemapResourceTest extends JavaTest {
         // add icon rules to the mock widget:
         Class<Rule> classToMock = Rule.class;
         Rule iconRule = mock(classToMock);
-        Condition conditon0 = mock(Condition.class);
-        when(conditon0.getItem()).thenReturn(ICON_ITEM_NAME);
+        Condition condition0 = mock(Condition.class);
+        when(condition0.getItem()).thenReturn(ICON_ITEM_NAME);
         List<Condition> conditions0 = new ArrayList<>();
-        conditions0.add(conditon0);
+        conditions0.add(condition0);
         when(iconRule.getConditions()).thenReturn(conditions0);
         List<Rule> iconRulesW1 = new ArrayList<>();
         iconRulesW1.add(iconRule);
 
         // add visibility rules to the mock widget:
         Rule visibilityRule = mock(Rule.class);
-        Condition conditon = mock(Condition.class);
-        when(conditon.getItem()).thenReturn(VISIBILITY_RULE_ITEM_NAME);
+        Condition condition = mock(Condition.class);
+        when(condition.getItem()).thenReturn(VISIBILITY_RULE_ITEM_NAME);
         List<Condition> conditions = new ArrayList<>();
-        conditions.add(conditon);
+        conditions.add(condition);
         when(visibilityRule.getConditions()).thenReturn(conditions);
         List<Rule> visibilityRulesW1 = new ArrayList<>(1);
         visibilityRulesW1.add(visibilityRule);
 
         // add label color conditions to the item:
         Rule labelColor = mock(Rule.class);
-        Condition conditon1 = mock(Condition.class);
-        when(conditon1.getItem()).thenReturn(LABEL_COLOR_ITEM_NAME);
+        Condition condition1 = mock(Condition.class);
+        when(condition1.getItem()).thenReturn(LABEL_COLOR_ITEM_NAME);
         List<Condition> conditions1 = new ArrayList<>();
-        conditions1.add(conditon1);
+        conditions1.add(condition1);
         when(labelColor.getConditions()).thenReturn(conditions1);
         List<Rule> labelColorsW1 = new ArrayList<>();
         labelColorsW1.add(labelColor);
 
         // add value color conditions to the item:
         Rule valueColor = mock(Rule.class);
-        Condition conditon2 = mock(Condition.class);
-        when(conditon2.getItem()).thenReturn(VALUE_COLOR_ITEM_NAME);
+        Condition condition2 = mock(Condition.class);
+        when(condition2.getItem()).thenReturn(VALUE_COLOR_ITEM_NAME);
         List<Condition> conditions2 = new ArrayList<>();
-        conditions2.add(conditon2);
+        conditions2.add(condition2);
         when(valueColor.getConditions()).thenReturn(conditions2);
         List<Rule> valueColorsW1 = new ArrayList<>();
         valueColorsW1.add(valueColor);
 
         // add icon color conditions to the item:
         Rule iconColor = mock(Rule.class);
-        Condition conditon3 = mock(Condition.class);
-        when(conditon3.getItem()).thenReturn(ICON_COLOR_ITEM_NAME);
+        Condition condition3 = mock(Condition.class);
+        when(condition3.getItem()).thenReturn(ICON_COLOR_ITEM_NAME);
         List<Condition> conditions3 = new ArrayList<>();
-        conditions3.add(conditon3);
+        conditions3.add(condition3);
         when(iconColor.getConditions()).thenReturn(conditions3);
         List<Rule> iconColorsW1 = new ArrayList<>();
         iconColorsW1.add(iconColor);
 
+        // add confirm command conditions to the item:
+        Rule confirmCmd = mock(Rule.class);
+        Condition conditon4 = mock(Condition.class);
+        when(conditon4.getItem()).thenReturn(CONFIRM_CMD_ITEM_NAME);
+        List<Condition> conditions4 = new ArrayList<>();
+        conditions4.add(conditon4);
+        when(confirmCmd.getConditions()).thenReturn(conditions4);
+        List<Rule> confirmCmdRulesW1 = new ArrayList<>();
+        confirmCmdRulesW1.add(confirmCmd);
+
         String sliderType = "Slider";
 
-        Widget w1 = mockWidget(iconRulesW1, visibilityRulesW1, labelColorsW1, valueColorsW1, iconColorsW1, sliderType,
-                WIDGET1_LABEL, null, false);
+        Widget w1 = mockWidget(iconRulesW1, visibilityRulesW1, labelColorsW1, valueColorsW1, iconColorsW1,
+                confirmCmdRulesW1, sliderType, WIDGET1_LABEL, null, false);
 
         List<Rule> iconRules = new ArrayList<>();
         List<Rule> visibilityRules = new ArrayList<>();
         List<Rule> labelColors = new ArrayList<>();
         List<Rule> valueColors = new ArrayList<>();
         List<Rule> iconColors = new ArrayList<>();
+        List<Rule> confirmCmdRules = new ArrayList<>();
 
         String switchType = "Switch";
 
-        Widget w2 = mockWidget(iconRules, visibilityRules, labelColors, valueColors, iconColors, switchType, null,
-                WIDGET2_ICON, false);
+        Widget w2 = mockWidget(iconRules, visibilityRules, labelColors, valueColors, iconColors, confirmCmdRules,
+                switchType, null, WIDGET2_ICON, false);
         mock(Widget.class);
 
-        Widget w3 = mockWidget(iconRules, visibilityRules, labelColors, valueColors, iconColors, switchType,
-                WIDGET3_LABEL, WIDGET3_ICON, true);
+        Widget w3 = mockWidget(iconRules, visibilityRules, labelColors, valueColors, iconColors, confirmCmdRules,
+                switchType, WIDGET3_LABEL, WIDGET3_ICON, true);
 
         List<Widget> widgets = new ArrayList<>(3);
         widgets.add(w1);
@@ -645,17 +676,18 @@ public class SitemapResourceTest extends JavaTest {
         List<Rule> labelColors = new ArrayList<>();
         List<Rule> valueColors = new ArrayList<>();
         List<Rule> iconColors = new ArrayList<>();
+        List<Rule> confirmCmdRules = new ArrayList<>();
 
-        Widget group1 = mockGroup(iconRules, visibilityRules, labelColors, valueColors, iconColors, groupType,
-                GROUP_LABEL, GROUP_ICON, true, baseWidgets);
+        Widget group1 = mockGroup(iconRules, visibilityRules, labelColors, valueColors, iconColors, confirmCmdRules,
+                groupType, GROUP_LABEL, GROUP_ICON, true, baseWidgets);
 
         String switchType = "Switch";
 
-        Widget w4 = mockWidget(iconRules, visibilityRules, labelColors, valueColors, iconColors, switchType,
-                WIDGET4_LABEL, WIDGET4_ICON, true);
+        Widget w4 = mockWidget(iconRules, visibilityRules, labelColors, valueColors, iconColors, confirmCmdRules,
+                switchType, WIDGET4_LABEL, WIDGET4_ICON, true);
 
-        Widget group2 = mockGroup(iconRules, visibilityRules, labelColors, valueColors, iconColors, groupType,
-                GROUP_LABEL, GROUP_ICON, true, new ArrayList<>(List.of(w4)));
+        Widget group2 = mockGroup(iconRules, visibilityRules, labelColors, valueColors, iconColors, confirmCmdRules,
+                groupType, GROUP_LABEL, GROUP_ICON, true, new ArrayList<>(List.of(w4)));
 
         List<Widget> allWidgets = new ArrayList<>();
         allWidgets.add(group1);
@@ -666,28 +698,28 @@ public class SitemapResourceTest extends JavaTest {
     }
 
     private static Widget mockWidget(List<Rule> iconRules1, List<Rule> visibilityRules1, List<Rule> labelColors1,
-            List<Rule> valueColors1, List<Rule> iconColors1, String widgetType, String widgetLabel, String widgetIcon,
-            boolean widgetStaticIcon) {
+            List<Rule> valueColors1, List<Rule> iconColors1, List<Rule> confirmCmdRules1, String widgetType,
+            String widgetLabel, String widgetIcon, boolean widgetStaticIcon) {
         Widget w = mock(Widget.class);
-        mockWidgetMethods(iconRules1, visibilityRules1, labelColors1, valueColors1, iconColors1, widgetType,
-                widgetLabel, widgetIcon, widgetStaticIcon, w);
+        mockWidgetMethods(iconRules1, visibilityRules1, labelColors1, valueColors1, iconColors1, confirmCmdRules1,
+                widgetType, widgetLabel, widgetIcon, widgetStaticIcon, w);
         when(w.getItem()).thenReturn(ITEM_NAME);
         return w;
     }
 
     private static Group mockGroup(List<Rule> iconRules1, List<Rule> visibilityRules1, List<Rule> labelColors1,
-            List<Rule> valueColors1, List<Rule> iconColors1, String widgetType, String widgetLabel, String widgetIcon,
-            boolean widgetStaticIcon, List<Widget> children) {
+            List<Rule> valueColors1, List<Rule> iconColors1, List<Rule> confirmCmdRules1, String widgetType,
+            String widgetLabel, String widgetIcon, boolean widgetStaticIcon, List<Widget> children) {
         Group w = mock(Group.class);
-        mockWidgetMethods(iconRules1, visibilityRules1, labelColors1, valueColors1, iconColors1, widgetType,
-                widgetLabel, widgetIcon, widgetStaticIcon, w);
+        mockWidgetMethods(iconRules1, visibilityRules1, labelColors1, valueColors1, iconColors1, confirmCmdRules1,
+                widgetType, widgetLabel, widgetIcon, widgetStaticIcon, w);
         when(w.getWidgets()).thenReturn(children);
         return w;
     }
 
     private static void mockWidgetMethods(List<Rule> iconRules1, List<Rule> visibilityRules1, List<Rule> labelColors1,
-            List<Rule> valueColors1, List<Rule> iconColors1, String widgetType, String widgetLabel, String widgetIcon,
-            boolean widgetStaticIcon, Widget w) {
+            List<Rule> valueColors1, List<Rule> iconColors1, List<Rule> confirmCmdRules1, String widgetType,
+            String widgetLabel, String widgetIcon, boolean widgetStaticIcon, Widget w) {
         when(w.getWidgetType()).thenReturn(widgetType);
         when(w.getLabel()).thenReturn(widgetLabel);
         when(w.getIcon()).thenReturn(widgetIcon);
@@ -697,6 +729,7 @@ public class SitemapResourceTest extends JavaTest {
         when(w.getLabelColor()).thenReturn(labelColors1);
         when(w.getValueColor()).thenReturn(valueColors1);
         when(w.getIconColor()).thenReturn(iconColors1);
+        when(w.getConfirmCmdRules()).thenReturn(confirmCmdRules1);
     }
 
     private void configureSitemapMock() {

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -25,49 +25,49 @@ ModelLinkableWidget:
 
 ModelFrame:
     {ModelFrame} 'Frame' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
-    ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelVisibilityRuleList))*;
+    ('visibility=' visibility=ModelBooleanRuleList))*;
 
 ModelText:
     {ModelText} 'Text' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
-    ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelVisibilityRuleList))*;
+    ('visibility=' visibility=ModelBooleanRuleList))*;
 
 ModelGroup:
     'Group' (('item=' item=GroupItemRef) | ('label=' label=(ID | STRING)) |
-    ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelVisibilityRuleList))*;
+    ('visibility=' visibility=ModelBooleanRuleList))*;
 
 ModelImage:
     'Image' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
-    ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('url=' url=STRING) | ('refresh=' refresh=INT) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelVisibilityRuleList))*;
+    ('visibility=' visibility=ModelBooleanRuleList))*;
 
 ModelVideo:
     'Video' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
-    ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('url=' url=STRING) | ('encoding=' encoding=STRING) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelVisibilityRuleList))*;
+    ('visibility=' visibility=ModelBooleanRuleList))*;
 
 ModelChart:
     'Chart' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
-    ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('service=' service=STRING) | ('refresh=' refresh=INT) | ('period=' period=Period) |
     ('legend=' legend=BOOLEAN_OBJECT) | ('forceasitem=' forceAsItem=BOOLEAN_OBJECT) |
     ('yAxisDecimalPattern=' yAxisDecimalPattern=(STRING)) |
@@ -75,116 +75,125 @@ ModelChart:
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelVisibilityRuleList))*;
+    ('visibility=' visibility=ModelBooleanRuleList))*;
 
 ModelWebview:
     'Webview' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
-    ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('height=' height=INT) | ('url=' url=STRING) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelVisibilityRuleList))*;
+    ('visibility=' visibility=ModelBooleanRuleList))*;
 
 ModelSwitch:
     'Switch' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
-    ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelBooleanRuleList) |
     ('mappings=' mappings=ModelMappingList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelVisibilityRuleList))*;
+    ('visibility=' visibility=ModelBooleanRuleList))*;
 
 ModelMapview:
     'Mapview' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
-    ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('height=' height=INT) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelVisibilityRuleList))*;
+    ('visibility=' visibility=ModelBooleanRuleList))*;
 
 ModelSlider:
     'Slider' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
-    ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     (switchEnabled?='switchSupport') | (releaseOnly?='releaseOnly') |
     ('minValue=' minValue=Number) | ('maxValue=' maxValue=Number) | ('step=' step=Number) |
+    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelBooleanRuleList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelVisibilityRuleList))*;
+    ('visibility=' visibility=ModelBooleanRuleList))*;
 
 ModelSelection:
     'Selection' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
-    ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('mappings=' mappings=ModelMappingList) |
+    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelBooleanRuleList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelVisibilityRuleList))*;
+    ('visibility=' visibility=ModelBooleanRuleList))*;
 
 ModelSetpoint:
     'Setpoint' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
-    ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('minValue=' minValue=Number) | ('maxValue=' maxValue=Number) | ('step=' step=Number) |
+    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelBooleanRuleList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelVisibilityRuleList))*;
+    ('visibility=' visibility=ModelBooleanRuleList))*;
 
 ModelColorpicker:
     'Colorpicker' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
-    ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelBooleanRuleList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelVisibilityRuleList))*;
+    ('visibility=' visibility=ModelBooleanRuleList))*;
 
 ModelColortemperaturepicker:
     'Colortemperaturepicker' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
-    ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('minValue=' minValue=Number) | ('maxValue=' maxValue=Number) |
+    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelBooleanRuleList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelVisibilityRuleList))*;
+    ('visibility=' visibility=ModelBooleanRuleList))*;
 
 ModelInput:
     'Input' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
-    ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('inputHint=' inputHint=STRING) |
+    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelBooleanRuleList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelVisibilityRuleList))*;
+    ('visibility=' visibility=ModelBooleanRuleList))*;
 
 ModelButtongrid:
     {ModelButtongrid} 'Buttongrid' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
-    ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('buttons=' buttons=ModelButtonDefinitionList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelVisibilityRuleList))*;
+    ('visibility=' visibility=ModelBooleanRuleList))*;
 
 ModelButton:
     'Button' (('row=' row=INT) | ('column=' column=INT) |
     ('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
-    ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     (stateless?='stateless') | ('click=' cmd=Command) | ('release=' releaseCmd=Command) |
+    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelBooleanRuleList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelVisibilityRuleList))*;
+    ('visibility=' visibility=ModelBooleanRuleList))*;
 
 ModelDefault:
     'Default' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
-    ('icon=' icon=Icon) | ('icon=' IconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
+    ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('height=' height=INT) |
+    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelBooleanRuleList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelVisibilityRuleList))*;
+    ('visibility=' visibility=ModelBooleanRuleList))*;
 
 ModelButtonDefinitionList returns ModelButtonDefinitionList:
     '[' elements+=ModelButtonDefinition (',' elements+=ModelButtonDefinition)* ']'
@@ -214,11 +223,11 @@ ModelIconRuleList returns ModelIconRuleList:
 ModelIconRule:
     ((conditions+=ModelCondition ('AND' conditions+=ModelCondition)*) '=')? (arg=Icon);
 
-ModelVisibilityRuleList returns ModelVisibilityRuleList:
-    '[' elements+=ModelVisibilityRule (',' elements+=ModelVisibilityRule)* ']'
+ModelBooleanRuleList returns ModelBooleanRuleList:
+    '[' elements+=ModelBooleanRule (',' elements+=ModelBooleanRule)* ']'
 ;
 
-ModelVisibilityRule:
+ModelBooleanRule:
     conditions+=ModelCondition ('AND' conditions+=ModelCondition)*;
 
 ModelCondition:

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -29,7 +29,7 @@ ModelFrame:
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelBooleanRuleList))*;
+    ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelText:
     {ModelText} 'Text' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
@@ -37,7 +37,7 @@ ModelText:
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelBooleanRuleList))*;
+    ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelGroup:
     'Group' (('item=' item=GroupItemRef) | ('label=' label=(ID | STRING)) |
@@ -45,7 +45,7 @@ ModelGroup:
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelBooleanRuleList))*;
+    ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelImage:
     'Image' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
@@ -54,7 +54,7 @@ ModelImage:
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelBooleanRuleList))*;
+    ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelVideo:
     'Video' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
@@ -63,7 +63,7 @@ ModelVideo:
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelBooleanRuleList))*;
+    ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelChart:
     'Chart' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
@@ -75,7 +75,7 @@ ModelChart:
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelBooleanRuleList))*;
+    ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelWebview:
     'Webview' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
@@ -84,17 +84,17 @@ ModelWebview:
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelBooleanRuleList))*;
+    ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelSwitch:
     'Switch' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
     ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
-    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelBooleanRuleList) |
+    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelConfirmCmdRuleList) |
     ('mappings=' mappings=ModelMappingList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelBooleanRuleList))*;
+    ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelMapview:
     'Mapview' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
@@ -103,67 +103,67 @@ ModelMapview:
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelBooleanRuleList))*;
+    ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelSlider:
     'Slider' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
     ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     (switchEnabled?='switchSupport') | (releaseOnly?='releaseOnly') |
     ('minValue=' minValue=Number) | ('maxValue=' maxValue=Number) | ('step=' step=Number) |
-    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelBooleanRuleList) |
+    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelConfirmCmdRuleList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelBooleanRuleList))*;
+    ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelSelection:
     'Selection' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
     ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('mappings=' mappings=ModelMappingList) |
-    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelBooleanRuleList) |
+    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelConfirmCmdRuleList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelBooleanRuleList))*;
+    ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelSetpoint:
     'Setpoint' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
     ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('minValue=' minValue=Number) | ('maxValue=' maxValue=Number) | ('step=' step=Number) |
-    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelBooleanRuleList) |
+    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelConfirmCmdRuleList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelBooleanRuleList))*;
+    ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelColorpicker:
     'Colorpicker' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
     ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
-    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelBooleanRuleList) |
+    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelConfirmCmdRuleList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelBooleanRuleList))*;
+    ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelColortemperaturepicker:
     'Colortemperaturepicker' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
     ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('minValue=' minValue=Number) | ('maxValue=' maxValue=Number) |
-    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelBooleanRuleList) |
+    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelConfirmCmdRuleList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelBooleanRuleList))*;
+    ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelInput:
     'Input' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
     ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('inputHint=' inputHint=STRING) |
-    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelBooleanRuleList) |
+    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelConfirmCmdRuleList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelBooleanRuleList))*;
+    ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelButtongrid:
     {ModelButtongrid} 'Buttongrid' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
@@ -172,62 +172,63 @@ ModelButtongrid:
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelBooleanRuleList))*;
+    ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelButton:
     'Button' (('row=' row=INT) | ('column=' column=INT) |
     ('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
     ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     (stateless?='stateless') | ('click=' cmd=Command) | ('release=' releaseCmd=Command) |
-    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelBooleanRuleList) |
+    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelConfirmCmdRuleList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelBooleanRuleList))*;
+    ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelDefault:
     'Default' (('item=' item=ItemRef) | ('label=' label=(ID | STRING)) |
     ('icon=' icon=Icon) | ('icon=' iconRules=ModelIconRuleList) | ('staticIcon=' staticIcon=Icon) |
     ('height=' height=INT) |
-    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelBooleanRuleList) |
+    ('confirmCmd=' confirmCmd=BOOLEAN_OBJECT) | ('confirmCmd=' confirmCmdRules=ModelConfirmCmdRuleList) |
     ('labelcolor=' labelColor=ModelColorArrayList) |
     ('valuecolor=' valueColor=ModelColorArrayList) |
     ('iconcolor=' iconColor=ModelColorArrayList) |
-    ('visibility=' visibility=ModelBooleanRuleList))*;
+    ('visibility=' visibility=ModelVisibilityRuleList))*;
 
 ModelButtonDefinitionList returns ModelButtonDefinitionList:
-    '[' elements+=ModelButtonDefinition (',' elements+=ModelButtonDefinition)* ']'
-;
+    '[' elements+=ModelButtonDefinition (',' elements+=ModelButtonDefinition)* ']';
 
 ModelButtonDefinition:
     row=INT ':' column=INT ':' cmd=Command '=' label=(ID | STRING) ('=' icon=Icon)?;
 
 ModelMappingList returns ModelMappingList:
-    '[' elements+=ModelMapping (',' elements+=ModelMapping)* ']'
-;
+    '[' elements+=ModelMapping (',' elements+=ModelMapping)* ']';
 
 ModelMapping:
     cmd=Command (':' releaseCmd=Command)? '=' label=(ID | STRING) ('=' icon=Icon)?;
 
 ModelColorArrayList returns ModelColorArrayList:
-    '[' elements+=ModelColorArray (',' elements+=ModelColorArray)* ']'
-;
+    '[' elements+=ModelColorArray (',' elements+=ModelColorArray)* ']';
 
 ModelColorArray:
     ((conditions+=ModelCondition ('AND' conditions+=ModelCondition)*) '=')? (arg=STRING);
 
 ModelIconRuleList returns ModelIconRuleList:
-    '[' elements+=ModelIconRule (',' elements+=ModelIconRule)* ']'
-;
+    '[' elements+=ModelIconRule (',' elements+=ModelIconRule)* ']';
 
 ModelIconRule:
     ((conditions+=ModelCondition ('AND' conditions+=ModelCondition)*) '=')? (arg=Icon);
 
-ModelBooleanRuleList returns ModelBooleanRuleList:
-    '[' elements+=ModelBooleanRule (',' elements+=ModelBooleanRule)* ']'
-;
+ModelConfirmCmdRuleList returns ModelConfirmCmdRuleList:
+    '[' elements+=ModelConfirmCmdRule (',' elements+=ModelConfirmCmdRule)* ']';
 
-ModelBooleanRule:
+ModelConfirmCmdRule:
+    { ModelConfirmCmdRule } (conditions+=ModelCondition ('AND' conditions+=ModelCondition)*)? ('=' arg=STRING)?;
+
+ModelVisibilityRuleList returns ModelVisibilityRuleList:
+    '[' elements+=ModelVisibilityRule (',' elements+=ModelVisibilityRule)* ']';
+
+ModelVisibilityRule:
     conditions+=ModelCondition ('AND' conditions+=ModelCondition)*;
 
 ModelCondition:

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/formatting/SitemapFormatter.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/formatting/SitemapFormatter.xtend
@@ -47,7 +47,7 @@ class SitemapFormatter extends AbstractDeclarativeFormatter {
         c.setNoSpace().after("item=", "label=", "icon=", "staticIcon=")
         c.setNoSpace().after("url=", "refresh=", "encoding=", "service=", "period=", "legend=", "forceasitem=", "yAxisDecimalPattern=", "interpolation=", "height=")
         c.setNoSpace().after("minValue=", "maxValue=", "step=", "inputHint=", "row=", "column=", "click=", "release=")
-        c.setNoSpace().after("labelcolor=", "valuecolor=", "iconcolor=", "visibility=", "mappings=", "buttons=")
+        c.setNoSpace().after("labelcolor=", "valuecolor=", "iconcolor=", "visibility=", "mappings=", "buttons=", "confirmCmd=")
 
         c.setNoSpace().before(",")
         c.setNoSpace().around(":", "=")

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/internal/DslSitemapProvider.java
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/internal/DslSitemapProvider.java
@@ -32,6 +32,8 @@ import org.openhab.core.common.registry.AbstractProvider;
 import org.openhab.core.model.core.EventType;
 import org.openhab.core.model.core.ModelRepository;
 import org.openhab.core.model.core.ModelRepositoryChangeListener;
+import org.openhab.core.model.sitemap.sitemap.ModelBooleanRule;
+import org.openhab.core.model.sitemap.sitemap.ModelBooleanRuleList;
 import org.openhab.core.model.sitemap.sitemap.ModelButton;
 import org.openhab.core.model.sitemap.sitemap.ModelButtonDefinition;
 import org.openhab.core.model.sitemap.sitemap.ModelButtonDefinitionList;
@@ -39,6 +41,7 @@ import org.openhab.core.model.sitemap.sitemap.ModelButtongrid;
 import org.openhab.core.model.sitemap.sitemap.ModelChart;
 import org.openhab.core.model.sitemap.sitemap.ModelColorArray;
 import org.openhab.core.model.sitemap.sitemap.ModelColorArrayList;
+import org.openhab.core.model.sitemap.sitemap.ModelColorpicker;
 import org.openhab.core.model.sitemap.sitemap.ModelColortemperaturepicker;
 import org.openhab.core.model.sitemap.sitemap.ModelCondition;
 import org.openhab.core.model.sitemap.sitemap.ModelDefault;
@@ -56,14 +59,13 @@ import org.openhab.core.model.sitemap.sitemap.ModelSitemap;
 import org.openhab.core.model.sitemap.sitemap.ModelSlider;
 import org.openhab.core.model.sitemap.sitemap.ModelSwitch;
 import org.openhab.core.model.sitemap.sitemap.ModelVideo;
-import org.openhab.core.model.sitemap.sitemap.ModelVisibilityRule;
-import org.openhab.core.model.sitemap.sitemap.ModelVisibilityRuleList;
 import org.openhab.core.model.sitemap.sitemap.ModelWebview;
 import org.openhab.core.model.sitemap.sitemap.ModelWidget;
 import org.openhab.core.model.sitemap.sitemap.SitemapModel;
 import org.openhab.core.sitemap.Button;
 import org.openhab.core.sitemap.Buttongrid;
 import org.openhab.core.sitemap.Chart;
+import org.openhab.core.sitemap.Colorpicker;
 import org.openhab.core.sitemap.Colortemperaturepicker;
 import org.openhab.core.sitemap.Condition;
 import org.openhab.core.sitemap.Default;
@@ -96,6 +98,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kai Kreuzer - Initial contribution
  * @author Mark Herwege - Separate registry from model
+ * @author Mark Herwege - Add support for confirmation dialog for commands
  */
 @NonNullByDefault
 @Component(service = { SitemapProvider.class, DslSitemapProvider.class }, immediate = true)
@@ -203,6 +206,8 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
                 case Switch switchWidget:
                     ModelSwitch modelSwitch = (ModelSwitch) modelWidget;
                     addWidgetMappings(switchWidget.getMappings(), modelSwitch.getMappings());
+                    widget.setConfirmCmd(Boolean.TRUE.equals(modelSwitch.getConfirmCmd()));
+                    addWidgetBooleanRules(widget.getConfirmCmdRules(), modelSwitch.getConfirmCmdRules());
                     break;
                 case Mapview mapviewWidget:
                     ModelMapview modelMapview = (ModelMapview) modelWidget;
@@ -215,25 +220,41 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
                     sliderWidget.setStep(modelSlider.getStep());
                     sliderWidget.setSwitchEnabled(modelSlider.isSwitchEnabled());
                     sliderWidget.setReleaseOnly(modelSlider.isReleaseOnly());
+                    widget.setConfirmCmd(Boolean.TRUE.equals(modelSlider.getConfirmCmd()));
+                    addWidgetBooleanRules(widget.getConfirmCmdRules(), modelSlider.getConfirmCmdRules());
                     break;
                 case Selection selectionWidget:
                     ModelSelection modelSelection = (ModelSelection) modelWidget;
                     addWidgetMappings(selectionWidget.getMappings(), modelSelection.getMappings());
+                    widget.setConfirmCmd(Boolean.TRUE.equals(modelSelection.getConfirmCmd()));
+                    addWidgetBooleanRules(widget.getConfirmCmdRules(), modelSelection.getConfirmCmdRules());
                     break;
                 case Input inputWidget:
                     ModelInput modelInput = (ModelInput) modelWidget;
                     inputWidget.setInputHint(modelInput.getInputHint());
+                    widget.setConfirmCmd(Boolean.TRUE.equals(modelInput.getConfirmCmd()));
+                    addWidgetBooleanRules(widget.getConfirmCmdRules(), modelInput.getConfirmCmdRules());
                     break;
                 case Setpoint setpointWidget:
                     ModelSetpoint modelSetpoint = (ModelSetpoint) modelWidget;
                     setpointWidget.setMinValue(modelSetpoint.getMinValue());
                     setpointWidget.setMaxValue(modelSetpoint.getMaxValue());
                     setpointWidget.setStep(modelSetpoint.getStep());
+                    widget.setConfirmCmd(Boolean.TRUE.equals(modelSetpoint.getConfirmCmd()));
+                    addWidgetBooleanRules(widget.getConfirmCmdRules(), modelSetpoint.getConfirmCmdRules());
+                    break;
+                case Colorpicker colorpickerWidget:
+                    ModelColorpicker modelColorpicker = (ModelColorpicker) modelWidget;
+                    widget.setConfirmCmd(Boolean.TRUE.equals(modelColorpicker.getConfirmCmd()));
+                    addWidgetBooleanRules(widget.getConfirmCmdRules(), modelColorpicker.getConfirmCmdRules());
                     break;
                 case Colortemperaturepicker colortemperaturepickerWidget:
                     ModelColortemperaturepicker modelColortemperaturepicker = (ModelColortemperaturepicker) modelWidget;
                     colortemperaturepickerWidget.setMinValue(modelColortemperaturepicker.getMinValue());
                     colortemperaturepickerWidget.setMaxValue(modelColortemperaturepicker.getMaxValue());
+                    widget.setConfirmCmd(Boolean.TRUE.equals(modelColortemperaturepicker.getConfirmCmd()));
+                    addWidgetBooleanRules(widget.getConfirmCmdRules(),
+                            modelColortemperaturepicker.getConfirmCmdRules());
                     break;
                 case Buttongrid buttongridWidget:
                     ModelButtongrid modelButtongrid = (ModelButtongrid) modelWidget;
@@ -246,10 +267,14 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
                     buttonWidget.setStateless(modelButton.isStateless());
                     buttonWidget.setCmd(modelButton.getCmd());
                     buttonWidget.setReleaseCmd(modelButton.getReleaseCmd());
+                    widget.setConfirmCmd(Boolean.TRUE.equals(modelButton.getConfirmCmd()));
+                    addWidgetBooleanRules(widget.getConfirmCmdRules(), modelButton.getConfirmCmdRules());
                     break;
                 case Default defaultWidget:
                     ModelDefault modelDefault = (ModelDefault) modelWidget;
                     defaultWidget.setHeight(modelDefault.getHeight());
+                    widget.setConfirmCmd(Boolean.TRUE.equals(modelDefault.getConfirmCmd()));
+                    addWidgetBooleanRules(widget.getConfirmCmdRules(), modelDefault.getConfirmCmdRules());
                     break;
                 default:
                     break;
@@ -273,7 +298,7 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
                         .forEach(childModelWidget -> addWidget(childWidgets, childModelWidget, linkableWidget));
             }
 
-            addWidgetVisibilityRules(widget.getVisibility(), modelWidget.getVisibility());
+            addWidgetBooleanRules(widget.getVisibility(), modelWidget.getVisibility());
             addWidgetColorRules(widget.getLabelColor(), modelWidget.getLabelColor());
             addWidgetColorRules(widget.getValueColor(), modelWidget.getValueColor());
             addWidgetColorRules(widget.getIconColor(), modelWidget.getIconColor());
@@ -330,18 +355,6 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
         return deprecated;
     }
 
-    private void addWidgetVisibilityRules(List<Rule> visibilityRules,
-            @Nullable ModelVisibilityRuleList modelVisibilityRuleList) {
-        if (modelVisibilityRuleList != null) {
-            EList<ModelVisibilityRule> modelVisibilityRules = modelVisibilityRuleList.getElements();
-            modelVisibilityRules.forEach(modelVisibilityRule -> {
-                Rule visibilityRule = sitemapFactory.createRule();
-                addRuleConditions(visibilityRule.getConditions(), modelVisibilityRule.getConditions());
-                visibilityRules.add(visibilityRule);
-            });
-        }
-    }
-
     private void addWidgetColorRules(List<Rule> colorRules, @Nullable ModelColorArrayList modelColorRuleList) {
         if (modelColorRuleList != null) {
             EList<ModelColorArray> modelColorRules = modelColorRuleList.getElements();
@@ -362,6 +375,17 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
                 addRuleConditions(iconRule.getConditions(), modelIconRule.getConditions());
                 iconRule.setArgument(modelIconRule.getArg());
                 iconRules.add(iconRule);
+            });
+        }
+    }
+
+    private void addWidgetBooleanRules(List<Rule> booleanRules, @Nullable ModelBooleanRuleList modelBooleanRuleList) {
+        if (modelBooleanRuleList != null) {
+            EList<ModelBooleanRule> modelBooleanRules = modelBooleanRuleList.getElements();
+            modelBooleanRules.forEach(modelBooleanRule -> {
+                Rule booleanRule = sitemapFactory.createRule();
+                addRuleConditions(booleanRule.getConditions(), modelBooleanRule.getConditions());
+                booleanRules.add(booleanRule);
             });
         }
     }

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/internal/DslSitemapProvider.java
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/internal/DslSitemapProvider.java
@@ -32,8 +32,6 @@ import org.openhab.core.common.registry.AbstractProvider;
 import org.openhab.core.model.core.EventType;
 import org.openhab.core.model.core.ModelRepository;
 import org.openhab.core.model.core.ModelRepositoryChangeListener;
-import org.openhab.core.model.sitemap.sitemap.ModelBooleanRule;
-import org.openhab.core.model.sitemap.sitemap.ModelBooleanRuleList;
 import org.openhab.core.model.sitemap.sitemap.ModelButton;
 import org.openhab.core.model.sitemap.sitemap.ModelButtonDefinition;
 import org.openhab.core.model.sitemap.sitemap.ModelButtonDefinitionList;
@@ -44,6 +42,7 @@ import org.openhab.core.model.sitemap.sitemap.ModelColorArrayList;
 import org.openhab.core.model.sitemap.sitemap.ModelColorpicker;
 import org.openhab.core.model.sitemap.sitemap.ModelColortemperaturepicker;
 import org.openhab.core.model.sitemap.sitemap.ModelCondition;
+import org.openhab.core.model.sitemap.sitemap.ModelConfirmCmdRuleList;
 import org.openhab.core.model.sitemap.sitemap.ModelDefault;
 import org.openhab.core.model.sitemap.sitemap.ModelIconRule;
 import org.openhab.core.model.sitemap.sitemap.ModelIconRuleList;
@@ -59,6 +58,8 @@ import org.openhab.core.model.sitemap.sitemap.ModelSitemap;
 import org.openhab.core.model.sitemap.sitemap.ModelSlider;
 import org.openhab.core.model.sitemap.sitemap.ModelSwitch;
 import org.openhab.core.model.sitemap.sitemap.ModelVideo;
+import org.openhab.core.model.sitemap.sitemap.ModelVisibilityRule;
+import org.openhab.core.model.sitemap.sitemap.ModelVisibilityRuleList;
 import org.openhab.core.model.sitemap.sitemap.ModelWebview;
 import org.openhab.core.model.sitemap.sitemap.ModelWidget;
 import org.openhab.core.model.sitemap.sitemap.SitemapModel;
@@ -207,7 +208,7 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
                     ModelSwitch modelSwitch = (ModelSwitch) modelWidget;
                     addWidgetMappings(switchWidget.getMappings(), modelSwitch.getMappings());
                     widget.setConfirmCmd(Boolean.TRUE.equals(modelSwitch.getConfirmCmd()));
-                    addWidgetBooleanRules(widget.getConfirmCmdRules(), modelSwitch.getConfirmCmdRules());
+                    addWidgetConfirmCmdRules(widget.getConfirmCmdRules(), modelSwitch.getConfirmCmdRules());
                     break;
                 case Mapview mapviewWidget:
                     ModelMapview modelMapview = (ModelMapview) modelWidget;
@@ -221,19 +222,19 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
                     sliderWidget.setSwitchEnabled(modelSlider.isSwitchEnabled());
                     sliderWidget.setReleaseOnly(modelSlider.isReleaseOnly());
                     widget.setConfirmCmd(Boolean.TRUE.equals(modelSlider.getConfirmCmd()));
-                    addWidgetBooleanRules(widget.getConfirmCmdRules(), modelSlider.getConfirmCmdRules());
+                    addWidgetConfirmCmdRules(widget.getConfirmCmdRules(), modelSlider.getConfirmCmdRules());
                     break;
                 case Selection selectionWidget:
                     ModelSelection modelSelection = (ModelSelection) modelWidget;
                     addWidgetMappings(selectionWidget.getMappings(), modelSelection.getMappings());
                     widget.setConfirmCmd(Boolean.TRUE.equals(modelSelection.getConfirmCmd()));
-                    addWidgetBooleanRules(widget.getConfirmCmdRules(), modelSelection.getConfirmCmdRules());
+                    addWidgetConfirmCmdRules(widget.getConfirmCmdRules(), modelSelection.getConfirmCmdRules());
                     break;
                 case Input inputWidget:
                     ModelInput modelInput = (ModelInput) modelWidget;
                     inputWidget.setInputHint(modelInput.getInputHint());
                     widget.setConfirmCmd(Boolean.TRUE.equals(modelInput.getConfirmCmd()));
-                    addWidgetBooleanRules(widget.getConfirmCmdRules(), modelInput.getConfirmCmdRules());
+                    addWidgetConfirmCmdRules(widget.getConfirmCmdRules(), modelInput.getConfirmCmdRules());
                     break;
                 case Setpoint setpointWidget:
                     ModelSetpoint modelSetpoint = (ModelSetpoint) modelWidget;
@@ -241,19 +242,19 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
                     setpointWidget.setMaxValue(modelSetpoint.getMaxValue());
                     setpointWidget.setStep(modelSetpoint.getStep());
                     widget.setConfirmCmd(Boolean.TRUE.equals(modelSetpoint.getConfirmCmd()));
-                    addWidgetBooleanRules(widget.getConfirmCmdRules(), modelSetpoint.getConfirmCmdRules());
+                    addWidgetConfirmCmdRules(widget.getConfirmCmdRules(), modelSetpoint.getConfirmCmdRules());
                     break;
                 case Colorpicker colorpickerWidget:
                     ModelColorpicker modelColorpicker = (ModelColorpicker) modelWidget;
                     widget.setConfirmCmd(Boolean.TRUE.equals(modelColorpicker.getConfirmCmd()));
-                    addWidgetBooleanRules(widget.getConfirmCmdRules(), modelColorpicker.getConfirmCmdRules());
+                    addWidgetConfirmCmdRules(widget.getConfirmCmdRules(), modelColorpicker.getConfirmCmdRules());
                     break;
                 case Colortemperaturepicker colortemperaturepickerWidget:
                     ModelColortemperaturepicker modelColortemperaturepicker = (ModelColortemperaturepicker) modelWidget;
                     colortemperaturepickerWidget.setMinValue(modelColortemperaturepicker.getMinValue());
                     colortemperaturepickerWidget.setMaxValue(modelColortemperaturepicker.getMaxValue());
                     widget.setConfirmCmd(Boolean.TRUE.equals(modelColortemperaturepicker.getConfirmCmd()));
-                    addWidgetBooleanRules(widget.getConfirmCmdRules(),
+                    addWidgetConfirmCmdRules(widget.getConfirmCmdRules(),
                             modelColortemperaturepicker.getConfirmCmdRules());
                     break;
                 case Buttongrid buttongridWidget:
@@ -268,13 +269,13 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
                     buttonWidget.setCmd(modelButton.getCmd());
                     buttonWidget.setReleaseCmd(modelButton.getReleaseCmd());
                     widget.setConfirmCmd(Boolean.TRUE.equals(modelButton.getConfirmCmd()));
-                    addWidgetBooleanRules(widget.getConfirmCmdRules(), modelButton.getConfirmCmdRules());
+                    addWidgetConfirmCmdRules(widget.getConfirmCmdRules(), modelButton.getConfirmCmdRules());
                     break;
                 case Default defaultWidget:
                     ModelDefault modelDefault = (ModelDefault) modelWidget;
                     defaultWidget.setHeight(modelDefault.getHeight());
                     widget.setConfirmCmd(Boolean.TRUE.equals(modelDefault.getConfirmCmd()));
-                    addWidgetBooleanRules(widget.getConfirmCmdRules(), modelDefault.getConfirmCmdRules());
+                    addWidgetConfirmCmdRules(widget.getConfirmCmdRules(), modelDefault.getConfirmCmdRules());
                     break;
                 default:
                     break;
@@ -298,7 +299,7 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
                         .forEach(childModelWidget -> addWidget(childWidgets, childModelWidget, linkableWidget));
             }
 
-            addWidgetBooleanRules(widget.getVisibility(), modelWidget.getVisibility());
+            addWidgetVisibilityRules(widget.getVisibility(), modelWidget.getVisibility());
             addWidgetColorRules(widget.getLabelColor(), modelWidget.getLabelColor());
             addWidgetColorRules(widget.getValueColor(), modelWidget.getValueColor());
             addWidgetColorRules(widget.getIconColor(), modelWidget.getIconColor());
@@ -358,11 +359,11 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
     private void addWidgetColorRules(List<Rule> colorRules, @Nullable ModelColorArrayList modelColorRuleList) {
         if (modelColorRuleList != null) {
             EList<ModelColorArray> modelColorRules = modelColorRuleList.getElements();
-            modelColorRules.forEach(modelColorRule -> {
-                Rule colorRule = sitemapFactory.createRule();
-                addRuleConditions(colorRule.getConditions(), modelColorRule.getConditions());
-                colorRule.setArgument(modelColorRule.getArg());
-                colorRules.add(colorRule);
+            modelColorRules.forEach(modelRule -> {
+                Rule rule = sitemapFactory.createRule();
+                addRuleConditions(rule.getConditions(), modelRule.getConditions());
+                rule.setArgument(modelRule.getArg());
+                colorRules.add(rule);
             });
         }
     }
@@ -370,22 +371,35 @@ public class DslSitemapProvider extends AbstractProvider<Sitemap>
     private void addWidgetIconRules(List<Rule> iconRules, @Nullable ModelIconRuleList modelIconRuleList) {
         if (modelIconRuleList != null) {
             EList<ModelIconRule> modelIconRules = modelIconRuleList.getElements();
-            modelIconRules.forEach(modelIconRule -> {
-                Rule iconRule = sitemapFactory.createRule();
-                addRuleConditions(iconRule.getConditions(), modelIconRule.getConditions());
-                iconRule.setArgument(modelIconRule.getArg());
-                iconRules.add(iconRule);
+            modelIconRules.forEach(modelRule -> {
+                Rule rule = sitemapFactory.createRule();
+                addRuleConditions(rule.getConditions(), modelRule.getConditions());
+                rule.setArgument(modelRule.getArg());
+                iconRules.add(rule);
             });
         }
     }
 
-    private void addWidgetBooleanRules(List<Rule> booleanRules, @Nullable ModelBooleanRuleList modelBooleanRuleList) {
-        if (modelBooleanRuleList != null) {
-            EList<ModelBooleanRule> modelBooleanRules = modelBooleanRuleList.getElements();
-            modelBooleanRules.forEach(modelBooleanRule -> {
-                Rule booleanRule = sitemapFactory.createRule();
-                addRuleConditions(booleanRule.getConditions(), modelBooleanRule.getConditions());
-                booleanRules.add(booleanRule);
+    private void addWidgetConfirmCmdRules(List<Rule> confirmCmdRules,
+            @Nullable ModelConfirmCmdRuleList modelConfirmCmdRuleList) {
+        if (modelConfirmCmdRuleList != null) {
+            modelConfirmCmdRuleList.getElements().forEach(modelRule -> {
+                Rule rule = sitemapFactory.createRule();
+                addRuleConditions(rule.getConditions(), modelRule.getConditions());
+                rule.setArgument(modelRule.getArg());
+                confirmCmdRules.add(rule);
+            });
+        }
+    }
+
+    private void addWidgetVisibilityRules(List<Rule> visibilityRules,
+            @Nullable ModelVisibilityRuleList ModelVisibilityRuleList) {
+        if (ModelVisibilityRuleList != null) {
+            EList<ModelVisibilityRule> ModelVisibilityRules = ModelVisibilityRuleList.getElements();
+            ModelVisibilityRules.forEach(modelRule -> {
+                Rule rule = sitemapFactory.createRule();
+                addRuleConditions(rule.getConditions(), modelRule.getConditions());
+                visibilityRules.add(rule);
             });
         }
     }

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/internal/fileconverter/DslSitemapConverter.java
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/internal/fileconverter/DslSitemapConverter.java
@@ -25,8 +25,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.model.core.ModelRepository;
 import org.openhab.core.model.sitemap.internal.DslSitemapProvider;
-import org.openhab.core.model.sitemap.sitemap.ModelBooleanRule;
-import org.openhab.core.model.sitemap.sitemap.ModelBooleanRuleList;
 import org.openhab.core.model.sitemap.sitemap.ModelButton;
 import org.openhab.core.model.sitemap.sitemap.ModelButtongrid;
 import org.openhab.core.model.sitemap.sitemap.ModelChart;
@@ -35,6 +33,8 @@ import org.openhab.core.model.sitemap.sitemap.ModelColorArrayList;
 import org.openhab.core.model.sitemap.sitemap.ModelColorpicker;
 import org.openhab.core.model.sitemap.sitemap.ModelColortemperaturepicker;
 import org.openhab.core.model.sitemap.sitemap.ModelCondition;
+import org.openhab.core.model.sitemap.sitemap.ModelConfirmCmdRule;
+import org.openhab.core.model.sitemap.sitemap.ModelConfirmCmdRuleList;
 import org.openhab.core.model.sitemap.sitemap.ModelDefault;
 import org.openhab.core.model.sitemap.sitemap.ModelFrame;
 import org.openhab.core.model.sitemap.sitemap.ModelGroup;
@@ -53,6 +53,8 @@ import org.openhab.core.model.sitemap.sitemap.ModelSlider;
 import org.openhab.core.model.sitemap.sitemap.ModelSwitch;
 import org.openhab.core.model.sitemap.sitemap.ModelText;
 import org.openhab.core.model.sitemap.sitemap.ModelVideo;
+import org.openhab.core.model.sitemap.sitemap.ModelVisibilityRule;
+import org.openhab.core.model.sitemap.sitemap.ModelVisibilityRuleList;
 import org.openhab.core.model.sitemap.sitemap.ModelWebview;
 import org.openhab.core.model.sitemap.sitemap.ModelWidget;
 import org.openhab.core.model.sitemap.sitemap.SitemapFactory;
@@ -86,12 +88,10 @@ import org.openhab.core.sitemap.fileconverter.SitemapSerializer;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * {@link SitemapSerializer} is the DSL file converter for {@link Sitemap} object
- * with the capabilities of parsing and generating file.
+ * {@link SitemapSerializer} is the DSL file converter for {@link Sitemap} object with the capabilities of parsing and
+ * generating file.
  *
  * @author Mark Herwege - Initial contribution
  * @author Mark Herwege - Add support for confirmation dialog for commands
@@ -99,8 +99,6 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 @Component(immediate = true, service = { SitemapSerializer.class, SitemapParser.class })
 public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
-
-    private final Logger logger = LoggerFactory.getLogger(DslSitemapConverter.class);
 
     private final ModelRepository modelRepository;
     private final DslSitemapProvider sitemapProvider;
@@ -179,7 +177,7 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
                     modelSwitch.setConfirmCmd(confirmCmd);
                 }
                 if (!confirmCmdRules.isEmpty()) {
-                    modelSwitch.setConfirmCmdRules(modelBooleanRules(confirmCmdRules));
+                    modelSwitch.setConfirmCmdRules(modelConfirmCmdRules(confirmCmdRules));
                 }
                 modelWidget = modelSwitch;
             }
@@ -198,7 +196,7 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
                     modelButton.setConfirmCmd(confirmCmd);
                 }
                 if (!confirmCmdRules.isEmpty()) {
-                    modelButton.setConfirmCmdRules(modelBooleanRules(confirmCmdRules));
+                    modelButton.setConfirmCmdRules(modelConfirmCmdRules(confirmCmdRules));
                 }
                 modelWidget = modelButton;
             }
@@ -212,7 +210,7 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
                     modelSelection.setConfirmCmd(confirmCmd);
                 }
                 if (!confirmCmdRules.isEmpty()) {
-                    modelSelection.setConfirmCmdRules(modelBooleanRules(confirmCmdRules));
+                    modelSelection.setConfirmCmdRules(modelConfirmCmdRules(confirmCmdRules));
                 }
                 modelWidget = modelSelection;
             }
@@ -225,7 +223,7 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
                     modelSetpoint.setConfirmCmd(confirmCmd);
                 }
                 if (!confirmCmdRules.isEmpty()) {
-                    modelSetpoint.setConfirmCmdRules(modelBooleanRules(confirmCmdRules));
+                    modelSetpoint.setConfirmCmdRules(modelConfirmCmdRules(confirmCmdRules));
                 }
                 modelWidget = modelSetpoint;
             }
@@ -240,7 +238,7 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
                     modelSlider.setConfirmCmd(confirmCmd);
                 }
                 if (!confirmCmdRules.isEmpty()) {
-                    modelSlider.setConfirmCmdRules(modelBooleanRules(confirmCmdRules));
+                    modelSlider.setConfirmCmdRules(modelConfirmCmdRules(confirmCmdRules));
                 }
                 modelWidget = modelSlider;
             }
@@ -250,7 +248,7 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
                     modelColorpicker.setConfirmCmd(confirmCmd);
                 }
                 if (!confirmCmdRules.isEmpty()) {
-                    modelColorpicker.setConfirmCmdRules(modelBooleanRules(confirmCmdRules));
+                    modelColorpicker.setConfirmCmdRules(modelConfirmCmdRules(confirmCmdRules));
                 }
                 modelWidget = modelColorpicker;
             }
@@ -263,7 +261,7 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
                     modelColortemperaturepicker.setConfirmCmd(confirmCmd);
                 }
                 if (!confirmCmdRules.isEmpty()) {
-                    modelColortemperaturepicker.setConfirmCmdRules(modelBooleanRules(confirmCmdRules));
+                    modelColortemperaturepicker.setConfirmCmdRules(modelConfirmCmdRules(confirmCmdRules));
                 }
                 modelWidget = modelColortemperaturepicker;
             }
@@ -274,7 +272,7 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
                     modelInput.setConfirmCmd(confirmCmd);
                 }
                 if (!confirmCmdRules.isEmpty()) {
-                    modelInput.setConfirmCmdRules(modelBooleanRules(confirmCmdRules));
+                    modelInput.setConfirmCmdRules(modelConfirmCmdRules(confirmCmdRules));
                 }
                 modelWidget = modelInput;
             }
@@ -323,7 +321,7 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
                     modelDefault.setConfirmCmd(confirmCmd);
                 }
                 if (!confirmCmdRules.isEmpty()) {
-                    modelDefault.setConfirmCmdRules(modelBooleanRules(confirmCmdRules));
+                    modelDefault.setConfirmCmdRules(modelConfirmCmdRules(confirmCmdRules));
                 }
                 modelWidget = modelDefault;
             }
@@ -344,7 +342,7 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
         }
         List<Rule> visibilityRules = widget.getVisibility();
         if (!visibilityRules.isEmpty()) {
-            modelWidget.setVisibility(modelBooleanRules(visibilityRules));
+            modelWidget.setVisibility(modelVisibilityRules(visibilityRules));
         }
         List<Rule> labelColorRules = widget.getLabelColor();
         if (!labelColorRules.isEmpty()) {
@@ -398,16 +396,16 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
         return modelRuleList;
     }
 
-    private ModelBooleanRuleList modelBooleanRules(List<Rule> rules) {
-        ModelBooleanRuleList modelRuleList = SitemapFactory.eINSTANCE.createModelBooleanRuleList();
-        EList<ModelBooleanRule> modelRules = modelRuleList.getElements();
-        setBooleanRules(modelRules, rules);
+    private ModelVisibilityRuleList modelVisibilityRules(List<Rule> rules) {
+        ModelVisibilityRuleList modelRuleList = SitemapFactory.eINSTANCE.createModelVisibilityRuleList();
+        EList<ModelVisibilityRule> modelRules = modelRuleList.getElements();
+        setVisibilityRules(modelRules, rules);
         return modelRuleList;
     }
 
-    private void setBooleanRules(EList<ModelBooleanRule> modelRules, List<Rule> rules) {
+    private void setVisibilityRules(EList<ModelVisibilityRule> modelRules, List<Rule> rules) {
         rules.forEach(rule -> {
-            ModelBooleanRule modelRule = SitemapFactory.eINSTANCE.createModelBooleanRule();
+            ModelVisibilityRule modelRule = SitemapFactory.eINSTANCE.createModelVisibilityRule();
             EList<ModelCondition> modelConditions = modelRule.getConditions();
             List<Condition> conditions = rule.getConditions();
             setModelConditions(modelConditions, conditions);
@@ -423,6 +421,18 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
             EList<ModelCondition> modelConditions = modelRule.getConditions();
             List<Condition> conditions = rule.getConditions();
             setModelConditions(modelConditions, conditions);
+            modelRule.setArg(rule.getArgument());
+            modelRules.add(modelRule);
+        });
+        return modelRuleList;
+    }
+
+    private ModelConfirmCmdRuleList modelConfirmCmdRules(List<Rule> rules) {
+        ModelConfirmCmdRuleList modelRuleList = SitemapFactory.eINSTANCE.createModelConfirmCmdRuleList();
+        EList<ModelConfirmCmdRule> modelRules = modelRuleList.getElements();
+        rules.forEach(rule -> {
+            ModelConfirmCmdRule modelRule = SitemapFactory.eINSTANCE.createModelConfirmCmdRule();
+            setModelConditions(modelRule.getConditions(), rule.getConditions());
             modelRule.setArg(rule.getArgument());
             modelRules.add(modelRule);
         });

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/internal/fileconverter/DslSitemapConverter.java
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/internal/fileconverter/DslSitemapConverter.java
@@ -25,6 +25,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.model.core.ModelRepository;
 import org.openhab.core.model.sitemap.internal.DslSitemapProvider;
+import org.openhab.core.model.sitemap.sitemap.ModelBooleanRule;
+import org.openhab.core.model.sitemap.sitemap.ModelBooleanRuleList;
 import org.openhab.core.model.sitemap.sitemap.ModelButton;
 import org.openhab.core.model.sitemap.sitemap.ModelButtongrid;
 import org.openhab.core.model.sitemap.sitemap.ModelChart;
@@ -51,8 +53,6 @@ import org.openhab.core.model.sitemap.sitemap.ModelSlider;
 import org.openhab.core.model.sitemap.sitemap.ModelSwitch;
 import org.openhab.core.model.sitemap.sitemap.ModelText;
 import org.openhab.core.model.sitemap.sitemap.ModelVideo;
-import org.openhab.core.model.sitemap.sitemap.ModelVisibilityRule;
-import org.openhab.core.model.sitemap.sitemap.ModelVisibilityRuleList;
 import org.openhab.core.model.sitemap.sitemap.ModelWebview;
 import org.openhab.core.model.sitemap.sitemap.ModelWidget;
 import org.openhab.core.model.sitemap.sitemap.SitemapFactory;
@@ -94,6 +94,7 @@ import org.slf4j.LoggerFactory;
  * with the capabilities of parsing and generating file.
  *
  * @author Mark Herwege - Initial contribution
+ * @author Mark Herwege - Add support for confirmation dialog for commands
  */
 @NonNullByDefault
 @Component(immediate = true, service = { SitemapSerializer.class, SitemapParser.class })
@@ -153,6 +154,8 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
 
     private ModelWidget buildModelWidget(Widget widget) {
         ModelWidget modelWidget;
+        boolean confirmCmd = widget.getConfirmCmd();
+        List<Rule> confirmCmdRules = widget.getConfirmCmdRules();
         switch (widget) {
             case Frame frameWidget -> {
                 ModelFrame modelFrame = SitemapFactory.eINSTANCE.createModelFrame();
@@ -172,6 +175,12 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
                 if (!mappings.isEmpty()) {
                     modelSwitch.setMappings(modelMappings(mappings));
                 }
+                if (confirmCmd) {
+                    modelSwitch.setConfirmCmd(confirmCmd);
+                }
+                if (!confirmCmdRules.isEmpty()) {
+                    modelSwitch.setConfirmCmdRules(modelBooleanRules(confirmCmdRules));
+                }
                 modelWidget = modelSwitch;
             }
             case Buttongrid buttongridWidget -> {
@@ -185,6 +194,12 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
                 modelButton.setCmd(buttonWidget.getCmd());
                 modelButton.setReleaseCmd(buttonWidget.getReleaseCmd());
                 modelButton.setStateless(buttonWidget.isStateless());
+                if (confirmCmd) {
+                    modelButton.setConfirmCmd(confirmCmd);
+                }
+                if (!confirmCmdRules.isEmpty()) {
+                    modelButton.setConfirmCmdRules(modelBooleanRules(confirmCmdRules));
+                }
                 modelWidget = modelButton;
             }
             case Selection selectionWidget -> {
@@ -193,6 +208,12 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
                 if (!mappings.isEmpty()) {
                     modelSelection.setMappings(modelMappings(mappings));
                 }
+                if (confirmCmd) {
+                    modelSelection.setConfirmCmd(confirmCmd);
+                }
+                if (!confirmCmdRules.isEmpty()) {
+                    modelSelection.setConfirmCmdRules(modelBooleanRules(confirmCmdRules));
+                }
                 modelWidget = modelSelection;
             }
             case Setpoint setpointWidget -> {
@@ -200,6 +221,12 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
                 modelSetpoint.setMinValue(setpointWidget.getMinValue());
                 modelSetpoint.setMaxValue(setpointWidget.getMaxValue());
                 modelSetpoint.setStep(setpointWidget.getStep());
+                if (confirmCmd) {
+                    modelSetpoint.setConfirmCmd(confirmCmd);
+                }
+                if (!confirmCmdRules.isEmpty()) {
+                    modelSetpoint.setConfirmCmdRules(modelBooleanRules(confirmCmdRules));
+                }
                 modelWidget = modelSetpoint;
             }
             case Slider sliderWidget -> {
@@ -209,10 +236,22 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
                 modelSlider.setStep(sliderWidget.getStep());
                 modelSlider.setSwitchEnabled(sliderWidget.isSwitchEnabled());
                 modelSlider.setReleaseOnly(sliderWidget.isReleaseOnly());
+                if (confirmCmd) {
+                    modelSlider.setConfirmCmd(confirmCmd);
+                }
+                if (!confirmCmdRules.isEmpty()) {
+                    modelSlider.setConfirmCmdRules(modelBooleanRules(confirmCmdRules));
+                }
                 modelWidget = modelSlider;
             }
             case Colorpicker colorpickerWidget -> {
                 ModelColorpicker modelColorpicker = SitemapFactory.eINSTANCE.createModelColorpicker();
+                if (confirmCmd) {
+                    modelColorpicker.setConfirmCmd(confirmCmd);
+                }
+                if (!confirmCmdRules.isEmpty()) {
+                    modelColorpicker.setConfirmCmdRules(modelBooleanRules(confirmCmdRules));
+                }
                 modelWidget = modelColorpicker;
             }
             case Colortemperaturepicker colortemperaturepickerWidget -> {
@@ -220,11 +259,23 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
                         .createModelColortemperaturepicker();
                 modelColortemperaturepicker.setMinValue(colortemperaturepickerWidget.getMinValue());
                 modelColortemperaturepicker.setMaxValue(colortemperaturepickerWidget.getMaxValue());
+                if (confirmCmd) {
+                    modelColortemperaturepicker.setConfirmCmd(confirmCmd);
+                }
+                if (!confirmCmdRules.isEmpty()) {
+                    modelColortemperaturepicker.setConfirmCmdRules(modelBooleanRules(confirmCmdRules));
+                }
                 modelWidget = modelColortemperaturepicker;
             }
             case Input inputWidget -> {
                 ModelInput modelInput = SitemapFactory.eINSTANCE.createModelInput();
                 modelInput.setInputHint(inputWidget.getInputHint());
+                if (confirmCmd) {
+                    modelInput.setConfirmCmd(confirmCmd);
+                }
+                if (!confirmCmdRules.isEmpty()) {
+                    modelInput.setConfirmCmdRules(modelBooleanRules(confirmCmdRules));
+                }
                 modelWidget = modelInput;
             }
             case Webview webviewWidget -> {
@@ -268,6 +319,12 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
                 if (widget instanceof Default defaultWidget) {
                     modelDefault.setHeight(defaultWidget.getHeight());
                 }
+                if (confirmCmd) {
+                    modelDefault.setConfirmCmd(confirmCmd);
+                }
+                if (!confirmCmdRules.isEmpty()) {
+                    modelDefault.setConfirmCmdRules(modelBooleanRules(confirmCmdRules));
+                }
                 modelWidget = modelDefault;
             }
         }
@@ -287,7 +344,7 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
         }
         List<Rule> visibilityRules = widget.getVisibility();
         if (!visibilityRules.isEmpty()) {
-            modelWidget.setVisibility(modelVisibilityRules(visibilityRules));
+            modelWidget.setVisibility(modelBooleanRules(visibilityRules));
         }
         List<Rule> labelColorRules = widget.getLabelColor();
         if (!labelColorRules.isEmpty()) {
@@ -341,17 +398,21 @@ public class DslSitemapConverter implements SitemapSerializer, SitemapParser {
         return modelRuleList;
     }
 
-    private ModelVisibilityRuleList modelVisibilityRules(List<Rule> rules) {
-        ModelVisibilityRuleList modelRuleList = SitemapFactory.eINSTANCE.createModelVisibilityRuleList();
-        EList<ModelVisibilityRule> modelRules = modelRuleList.getElements();
+    private ModelBooleanRuleList modelBooleanRules(List<Rule> rules) {
+        ModelBooleanRuleList modelRuleList = SitemapFactory.eINSTANCE.createModelBooleanRuleList();
+        EList<ModelBooleanRule> modelRules = modelRuleList.getElements();
+        setBooleanRules(modelRules, rules);
+        return modelRuleList;
+    }
+
+    private void setBooleanRules(EList<ModelBooleanRule> modelRules, List<Rule> rules) {
         rules.forEach(rule -> {
-            ModelVisibilityRule modelRule = SitemapFactory.eINSTANCE.createModelVisibilityRule();
+            ModelBooleanRule modelRule = SitemapFactory.eINSTANCE.createModelBooleanRule();
             EList<ModelCondition> modelConditions = modelRule.getConditions();
             List<Condition> conditions = rule.getConditions();
             setModelConditions(modelConditions, conditions);
             modelRules.add(modelRule);
         });
-        return modelRuleList;
     }
 
     private ModelColorArrayList modelColorRules(List<Rule> rules) {

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
@@ -268,7 +268,7 @@ class SitemapValidator extends AbstractSitemapValidator {
                     error(buildMsgWithLineNb("Button widget doens't have click command defined", w, null, null),
                         w, SitemapPackage.Literals.MODEL_BUTTON.getEStructuralFeature(SitemapPackage.MODEL_BUTTON__CMD))
                 }
-                if (w.confirmCmd && w.releaseCmd !== null) {
+                if (w.confirmCmd != null && w.releaseCmd !== null) {
                     warning(buildMsgWithLineNb("Button widget has both confirmCmd and release command defined", w, null, null), w, null)
                 }
             } else {

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
@@ -268,7 +268,7 @@ class SitemapValidator extends AbstractSitemapValidator {
                     error(buildMsgWithLineNb("Button widget doens't have click command defined", w, null, null),
                         w, SitemapPackage.Literals.MODEL_BUTTON.getEStructuralFeature(SitemapPackage.MODEL_BUTTON__CMD))
                 }
-                if (w.confirmCmd != null && w.releaseCmd !== null) {
+                if ((w.confirmCmd == true || w.confirmCmdRules != null) && w.releaseCmd !== null) {
                     warning(buildMsgWithLineNb("Button widget has both confirmCmd and release command defined", w, null, null), w, null)
                 }
             } else {

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
@@ -268,6 +268,9 @@ class SitemapValidator extends AbstractSitemapValidator {
                     error(buildMsgWithLineNb("Button widget doens't have click command defined", w, null, null),
                         w, SitemapPackage.Literals.MODEL_BUTTON.getEStructuralFeature(SitemapPackage.MODEL_BUTTON__CMD))
                 }
+                if (w.confirmCmd && w.releaseCmd !== null) {
+                    warning(buildMsgWithLineNb("Button widget has both confirmCmd and release command defined", w, null, null), w, null)
+                }
             } else {
                 warning(buildMsgWithLineNb("Buttongrid must contain only Buttons", w, null, null),
                     SitemapPackage.Literals.MODEL_BUTTONGRID.getEStructuralFeature(SitemapPackage.MODEL_BUTTONGRID__CHILDREN))

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
@@ -38,6 +38,10 @@ import org.openhab.core.model.sitemap.sitemap.ModelWebview
 import org.openhab.core.model.sitemap.sitemap.ModelVideo
 import org.openhab.core.model.sitemap.sitemap.ModelWidget
 import org.openhab.core.model.sitemap.sitemap.SitemapPackage
+import org.openhab.core.model.sitemap.sitemap.ModelSelection
+import org.openhab.core.model.sitemap.sitemap.ModelDefault
+import org.openhab.core.model.sitemap.sitemap.ModelColorpicker
+import org.openhab.core.model.sitemap.sitemap.ModelSwitch
 
 /**
  * Custom validation rules.
@@ -268,9 +272,14 @@ class SitemapValidator extends AbstractSitemapValidator {
                     error(buildMsgWithLineNb("Button widget doens't have click command defined", w, null, null),
                         w, SitemapPackage.Literals.MODEL_BUTTON.getEStructuralFeature(SitemapPackage.MODEL_BUTTON__CMD))
                 }
-                if ((w.confirmCmd == true || w.confirmCmdRules != null) && w.releaseCmd !== null) {
+                if ((w.confirmCmd == true || w.confirmCmdRules !== null) && w.releaseCmd !== null) {
                     warning(buildMsgWithLineNb("Button widget has both confirmCmd and release command defined", w, null, null), w, null)
                 }
+                w.confirmCmdRules?.elements?.forEach[ rule |
+                    if (rule.conditions.isEmpty && rule.arg === null) {
+                        error(buildMsgWithLineNb("confirmCmd rule has neither a condition nor a message", w, null, null), w, null)
+                    }
+                ]
             } else {
                 warning(buildMsgWithLineNb("Buttongrid must contain only Buttons", w, null, null),
                     SitemapPackage.Literals.MODEL_BUTTONGRID.getEStructuralFeature(SitemapPackage.MODEL_BUTTONGRID__CHILDREN))
@@ -296,6 +305,11 @@ class SitemapValidator extends AbstractSitemapValidator {
                 sp, SitemapPackage.Literals.MODEL_SETPOINT__MIN_VALUE, SitemapPackage.Literals.MODEL_SETPOINT__MAX_VALUE),
                 SitemapPackage.Literals.MODEL_SETPOINT.getEStructuralFeature(SitemapPackage.MODEL_SETPOINT__MIN_VALUE))
         }
+        sp.confirmCmdRules?.elements?.forEach[ rule |
+            if (rule.conditions.isEmpty && rule.arg === null) {
+                error(buildMsgWithLineNb("confirmCmd rule has neither a condition nor a message", sp, null, null), sp, null)
+            }
+        ]
     }
 
     @Check
@@ -315,6 +329,20 @@ class SitemapValidator extends AbstractSitemapValidator {
                 s, SitemapPackage.Literals.MODEL_SLIDER__MIN_VALUE, SitemapPackage.Literals.MODEL_SLIDER__MAX_VALUE),
                 SitemapPackage.Literals.MODEL_SLIDER.getEStructuralFeature(SitemapPackage.MODEL_SLIDER__MIN_VALUE))
         }
+        s.confirmCmdRules?.elements?.forEach[ rule |
+            if (rule.conditions.isEmpty && rule.arg === null) {
+                error(buildMsgWithLineNb("confirmCmd rule has neither a condition nor a message", s, null, null), s, null)
+            }
+        ]
+    }
+
+    @Check
+    def void checkColorpickerParameters(ModelColorpicker c) {
+        c.confirmCmdRules?.elements?.forEach[ rule |
+            if (rule.conditions.isEmpty && rule.arg === null) {
+                error(buildMsgWithLineNb("confirmCmd rule has neither a condition nor a message", c, null, null), c, null)
+            }
+        ]
     }
 
     @Check
@@ -324,6 +352,11 @@ class SitemapValidator extends AbstractSitemapValidator {
                 ctp, SitemapPackage.Literals.MODEL_COLORTEMPERATUREPICKER__MIN_VALUE, SitemapPackage.Literals.MODEL_COLORTEMPERATUREPICKER__MAX_VALUE),
                 SitemapPackage.Literals.MODEL_COLORTEMPERATUREPICKER.getEStructuralFeature(SitemapPackage.MODEL_COLORTEMPERATUREPICKER__MIN_VALUE))
         }
+        ctp.confirmCmdRules?.elements?.forEach[ rule |
+            if (rule.conditions.isEmpty && rule.arg === null) {
+                error(buildMsgWithLineNb("confirmCmd rule has neither a condition nor a message", ctp, null, null), ctp, null)
+            }
+        ]
     }
 
     @Check
@@ -333,6 +366,38 @@ class SitemapValidator extends AbstractSitemapValidator {
                 i, SitemapPackage.Literals.MODEL_INPUT__INPUT_HINT, null),
                 SitemapPackage.Literals.MODEL_INPUT.getEStructuralFeature(SitemapPackage.MODEL_INPUT__INPUT_HINT))
         }
+        i.confirmCmdRules?.elements?.forEach[ rule |
+            if (rule.conditions.isEmpty && rule.arg === null) {
+                error(buildMsgWithLineNb("confirmCmd rule has neither a condition nor a message", i, null, null), i, null)
+            }
+        ]
+    }
+
+    @Check
+    def void checkSwitchParameters(ModelSwitch s) {
+        s.confirmCmdRules?.elements?.forEach[ rule |
+            if (rule.conditions.isEmpty && rule.arg === null) {
+                error(buildMsgWithLineNb("confirmCmd rule has neither a condition nor a message", s, null, null), s, null)
+            }
+        ]
+    }
+
+    @Check
+    def void checkSelectionParameters(ModelSelection s) {
+        s.confirmCmdRules?.elements?.forEach[ rule |
+            if (rule.conditions.isEmpty && rule.arg === null) {
+                error(buildMsgWithLineNb("confirmCmd rule has neither a condition nor a message", s, null, null), s, null)
+            }
+        ]
+    }
+
+    @Check
+    def void checkDefaultParameters(ModelDefault d) {
+        d.confirmCmdRules?.elements?.forEach[ rule |
+            if (rule.conditions.isEmpty && rule.arg === null) {
+                error(buildMsgWithLineNb("confirmCmd rule has neither a condition nor a message", d, null, null), d, null)
+            }
+        ]
     }
 
     @Check

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlConditionDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlConditionDTO.java
@@ -37,6 +37,10 @@ public class YamlConditionDTO {
     }
 
     public boolean isValid(@NonNull List<@NonNull String> errors, @NonNull List<@NonNull String> warnings) {
+        if (item == null && operator == null && argument == null) {
+            return true; // empty condition may be valid when there is a rule value, condition will be ignored for rule
+                         // with unique condition
+        }
         boolean ok = true;
         if (item != null && !ItemUtil.isValidItemName(item)) {
             addToList(errors,
@@ -48,7 +52,7 @@ public class YamlConditionDTO {
             addToList(errors, "invalid value \"%s\" for \"operator\" field in condition".formatted(operator));
             ok = false;
         }
-        if ((item != null || operator != null) && argument == null) {
+        if (argument == null) {
             addToList(errors, "\"argument\" field missing while mandatory in condition");
             ok = false;
         }

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlSitemapDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlSitemapDTO.java
@@ -262,6 +262,16 @@ public class YamlSitemapDTO implements ModularDTO<YamlSitemapDTO, ObjectMapper, 
             }
         }
 
+        if (partial.confirmCmd != null) {
+            if (partial.confirmCmd.isValueNode()) {
+                result.confirmCmd = partial.confirmCmd.asBoolean();
+            } else if (partial.confirmCmd.isArray()) {
+                result.confirmCmd = toRulesDto(partial.confirmCmd);
+            } else {
+                result.confirmCmd = toRuleDto(partial.confirmCmd);
+            }
+        }
+
         if (partial.widgets != null) {
             List<YamlWidgetDTO> widgets = new ArrayList<>(partial.widgets.size());
             for (YamlPartialWidgetDTO widget : partial.widgets) {
@@ -381,6 +391,7 @@ public class YamlSitemapDTO implements ModularDTO<YamlSitemapDTO, ObjectMapper, 
         public String releaseCommand;
         public Boolean stateless;
         public JsonNode visibility;
+        public JsonNode confirmCmd;
         public List<YamlPartialWidgetDTO> widgets;
     }
 }

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlSitemapDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlSitemapDTO.java
@@ -293,6 +293,9 @@ public class YamlSitemapDTO implements ModularDTO<YamlSitemapDTO, ObjectMapper, 
 
     private @NonNull Object toRuleDto(@NonNull JsonNode ruleNode) throws SerializationException {
         JsonNode conditionsNode, conditionNode;
+        if (ruleNode.isTextual()) {
+            return ruleNode.asText();
+        }
         if (!ruleNode.isObject()) {
             throw new SerializationException("Expected rule to be an object node");
         }

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlSitemapDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlSitemapDTO.java
@@ -263,7 +263,7 @@ public class YamlSitemapDTO implements ModularDTO<YamlSitemapDTO, ObjectMapper, 
         }
 
         if (partial.confirmCmd != null) {
-            if (partial.confirmCmd.isValueNode()) {
+            if (partial.confirmCmd.isBoolean()) {
                 result.confirmCmd = partial.confirmCmd.asBoolean();
             } else if (partial.confirmCmd.isArray()) {
                 result.confirmCmd = toRulesDto(partial.confirmCmd);

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlSitemapProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlSitemapProvider.java
@@ -64,6 +64,7 @@ import org.slf4j.LoggerFactory;
  * These sitemaps are automatically exposed to the {@link SitemapRegistry}.
  *
  * @author Laurent Garnier - Initial contribution
+ * @author Mark Herwege - Add support for confirmation dialog for commands
  */
 @NonNullByDefault
 @Component(immediate = true, service = { SitemapProvider.class, YamlSitemapProvider.class, YamlModelListener.class })
@@ -238,6 +239,12 @@ public class YamlSitemapProvider extends AbstractProvider<Sitemap>
             widget.setStaticIcon(staticIcon);
 
             addWidgetRules(widget.getVisibility(), widgetDTO.visibility, true);
+
+            if (widgetDTO.confirmCmd instanceof Boolean confirmCmd) {
+                widget.setConfirmCmd(confirmCmd);
+            } else {
+                addWidgetRules(widget.getConfirmCmdRules(), widgetDTO.confirmCmd, true);
+            }
 
             switch (widget) {
                 case Image imageWidget:

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlSitemapProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlSitemapProvider.java
@@ -243,7 +243,7 @@ public class YamlSitemapProvider extends AbstractProvider<Sitemap>
             if (widgetDTO.confirmCmd instanceof Boolean confirmCmd) {
                 widget.setConfirmCmd(confirmCmd);
             } else {
-                addWidgetRules(widget.getConfirmCmdRules(), widgetDTO.confirmCmd, true);
+                addWidgetRules(widget.getConfirmCmdRules(), widgetDTO.confirmCmd, false);
             }
 
             switch (widget) {

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlSitemapProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlSitemapProvider.java
@@ -338,11 +338,11 @@ public class YamlSitemapProvider extends AbstractProvider<Sitemap>
 
     private void addWidgetRules(List<Rule> rules, @Nullable Object rulesDTO, boolean ignoreValue) {
         if (rulesDTO instanceof String value) {
-            Rule rule = sitemapFactory.createRule();
             if (!ignoreValue) {
+                Rule rule = sitemapFactory.createRule();
                 rule.setArgument(value);
+                rules.add(rule);
             }
-            rules.add(rule);
         } else if (rulesDTO instanceof YamlRuleWithAndConditionsDTO ruleDTO) {
             Rule rule = sitemapFactory.createRule();
             addRuleConditions(rule.getConditions(), ruleDTO.and);
@@ -385,6 +385,9 @@ public class YamlSitemapProvider extends AbstractProvider<Sitemap>
     private void addRuleConditions(List<Condition> conditions, @Nullable List<YamlConditionDTO> conditionsDTO) {
         if (conditionsDTO != null) {
             conditionsDTO.forEach(dto -> {
+                if (dto.item == null && dto.operator == null && dto.argument == null) {
+                    return; // empty condition is ignored
+                }
                 Condition condition = sitemapFactory.createCondition();
                 condition.setItem(dto.item);
                 condition.setCondition(dto.operator);

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTO.java
@@ -178,10 +178,10 @@ public class YamlWidgetDTO {
                     .formatted(minValue.doubleValue(), maxValue.doubleValue()));
         }
 
-        ok &= isValidRule(errors, warnings, visibility, "visibility");
+        ok &= isValidRule(errors, warnings, visibility, "visibility", true);
         ok &= isValidField("confirmCmd", confirmCmd, errors, warnings); // Check if field is allowed for the widget type
         if (!(confirmCmd instanceof Boolean)) {
-            ok &= isValidRule(errors, warnings, confirmCmd, "confirmCmd"); // Check if valid rule
+            ok &= isValidRule(errors, warnings, confirmCmd, "confirmCmd", false); // Check if valid rule
         }
 
         if (widgets != null) {
@@ -306,7 +306,7 @@ public class YamlWidgetDTO {
     }
 
     private boolean isValidRule(@NonNull List<@NonNull String> errors, @NonNull List<@NonNull String> warnings,
-            Object parameter, String parameterName) {
+            Object parameter, String parameterName, boolean ignoreValue) {
         boolean ok = true;
         List<String> ruleErrors = new ArrayList<>();
         List<String> ruleWarnings = new ArrayList<>();
@@ -314,7 +314,7 @@ public class YamlWidgetDTO {
             for (Object r : rules) {
                 if (r instanceof YamlRuleWithAndConditionsDTO rule) {
                     ok &= rule.isValid(ruleErrors, ruleWarnings);
-                    if (rule.value != null) {
+                    if (ignoreValue && rule.value != null) {
                         addToList(warnings,
                                 "rule in \"%s\" field: unexpected \"value\" field is ignored".formatted(parameterName));
                     }
@@ -326,7 +326,7 @@ public class YamlWidgetDTO {
                                         .formatted(parameterName));
                         ok = false;
                     }
-                    if (rule.value != null) {
+                    if (ignoreValue && rule.value != null) {
                         addToList(warnings,
                                 "rule in \"%s\" field: unexpected \"value\" field is ignored".formatted(parameterName));
                     }
@@ -337,7 +337,7 @@ public class YamlWidgetDTO {
             }
         } else if (parameter instanceof YamlRuleWithAndConditionsDTO rule) {
             ok &= rule.isValid(ruleErrors, ruleWarnings);
-            if (rule.value != null) {
+            if (ignoreValue && rule.value != null) {
                 addToList(warnings,
                         "rule in \"%s\" field: unexpected \"value\" field is ignored".formatted(parameterName));
             }
@@ -349,7 +349,7 @@ public class YamlWidgetDTO {
                                 .formatted(parameterName));
                 ok = false;
             }
-            if (rule.value != null) {
+            if (ignoreValue && rule.value != null) {
                 addToList(warnings,
                         "rule in \"%s\" field: unexpected \"value\" field is ignored".formatted(parameterName));
             }

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTO.java
@@ -306,7 +306,7 @@ public class YamlWidgetDTO {
     }
 
     private boolean isValidRules(@NonNull List<@NonNull String> errors, @NonNull List<@NonNull String> warnings,
-            Object parameter, String parameterName, boolean ignoreValue) {
+            @Nullable Object parameter, String parameterName, boolean ignoreValue) {
         boolean ok = true;
         if (parameter instanceof List<?> rules) {
             for (Object r : rules) {
@@ -318,50 +318,41 @@ public class YamlWidgetDTO {
         return ok;
     }
 
-    private boolean isValidRule(List<@NonNull String> errors, List<@NonNull String> warnings, Object rule,
+    private boolean isValidRule(List<@NonNull String> errors, List<@NonNull String> warnings, @Nullable Object rule,
             String parameterName, boolean ignoreValue) {
+        if (rule == null) {
+            return true;
+        }
         boolean ok = true;
         List<String> ruleErrors = new ArrayList<>();
         List<String> ruleWarnings = new ArrayList<>();
         if (rule instanceof YamlRuleWithAndConditionsDTO andConditionRule) {
             ok &= andConditionRule.isValid(ruleErrors, ruleWarnings);
             if (ignoreValue) {
-                if (andConditionRule.and == null || andConditionRule.and.isEmpty()) {
-                    addToList(errors,
-                            "invalid rule in \"%s\" field: \"and\" empty, no conditions defined while mandatory in condition"
-                                    .formatted(parameterName));
-                    ok = false;
-                } else if (andConditionRule.value != null) {
-                    addToList(warnings,
-                            "rule in \"%s\" field: unexpected \"value\" field is ignored".formatted(parameterName));
+                if (andConditionRule.value != null) {
+                    addToList(ruleWarnings, "unexpected \"value\" field is ignored");
                 }
-            } else if ((andConditionRule.and == null || andConditionRule.and.isEmpty())
-                    && andConditionRule.value == null) {
-                addToList(errors,
-                        "invalid rule in \"%s\" field: \"and\" field and \"value\" field should not both be empty"
-                                .formatted(parameterName));
+            }
+        } else if (rule instanceof YamlRuleWithUniqueConditionDTO uniqueConditionRule) {
+            ok &= uniqueConditionRule.isValid(ruleErrors, ruleWarnings);
+            if (ignoreValue) {
+                if (uniqueConditionRule.item == null && uniqueConditionRule.operator == null
+                        && uniqueConditionRule.argument == null) {
+                    addToList(ruleErrors, "\"argument\" field missing while mandatory in condition");
+                    ok = false;
+                } else if (uniqueConditionRule.value != null) {
+                    addToList(ruleWarnings, "unexpected \"value\" field is ignored");
+                }
+            } else if (uniqueConditionRule.argument == null && uniqueConditionRule.value == null) {
+                addToList(ruleErrors, "\"argument\" field and \"value\" field should not both be empty");
                 ok = false;
             }
-        } else if (rule instanceof YamlRuleWithUniqueConditionDTO uniqueCondtionRule) {
-            ok &= uniqueCondtionRule.isValid(ruleErrors, ruleWarnings);
+        } else if (rule instanceof String) {
             if (ignoreValue) {
-                if (uniqueCondtionRule.argument == null) {
-                    addToList(errors,
-                            "invalid rule in \"%s\" field: \"argument\" field missing while mandatory in condition"
-                                    .formatted(parameterName));
-                    ok = false;
-                } else if (uniqueCondtionRule.value != null) {
-                    addToList(warnings,
-                            "rule in \"%s\" field: unexpected \"value\" field is ignored".formatted(parameterName));
-                }
-            } else if (uniqueCondtionRule.argument == null && uniqueCondtionRule.value == null) {
-                addToList(errors,
-                        "invalid rule in \"%s\" field: \"argument\" field and \"value\" field should not both be empty"
-                                .formatted(parameterName));
-                ok = false;
+                addToList(ruleWarnings, "unexpected string value is ignored");
             }
         } else {
-            addToList(errors, "invalid type for rule in \"%s\" field".formatted(parameterName));
+            addToList(ruleErrors, "invalid rule type");
             ok = false;
         }
         ruleErrors.forEach(error -> {

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTO.java
@@ -180,7 +180,9 @@ public class YamlWidgetDTO {
 
         ok &= isValidRule(errors, warnings, visibility, "visibility");
         ok &= isValidField("confirmCmd", confirmCmd, errors, warnings); // Check if field is allowed for the widget type
-        ok &= isValidRule(errors, warnings, confirmCmd, "confirmCmd"); // Check if valid rule
+        if (!(confirmCmd instanceof Boolean)) {
+            ok &= isValidRule(errors, warnings, confirmCmd, "confirmCmd"); // Check if valid rule
+        }
 
         if (widgets != null) {
             if (!LINKABLE_WIDGETS.contains(type)) {

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTO.java
@@ -330,6 +330,12 @@ public class YamlWidgetDTO {
                             addToList(warnings, "rule in \"%s\" field: unexpected \"value\" field is ignored"
                                     .formatted(parameterName));
                         }
+                    } else if (rule.item == null && rule.operator == null && rule.argument == null
+                            && rule.value == null) {
+                        addToList(errors,
+                                "invalid rule in \"%s\" field: \"argument\" field and \"value\" field should not both be empty"
+                                        .formatted(parameterName));
+                        ok = false;
                     }
                 } else {
                     addToList(errors, "invalid type for rule in \"%s\" field".formatted(parameterName));
@@ -355,6 +361,11 @@ public class YamlWidgetDTO {
                     addToList(warnings,
                             "rule in \"%s\" field: unexpected \"value\" field is ignored".formatted(parameterName));
                 }
+            } else if (rule.item == null && rule.operator == null && rule.argument == null && rule.value == null) {
+                addToList(errors,
+                        "invalid rule in \"%s\" field: \"argument\" field and \"value\" field should not both be empty"
+                                .formatted(parameterName));
+                ok = false;
             }
         }
         ruleErrors.forEach(error -> {

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTO.java
@@ -178,10 +178,10 @@ public class YamlWidgetDTO {
                     .formatted(minValue.doubleValue(), maxValue.doubleValue()));
         }
 
-        ok &= isValidRule(errors, warnings, visibility, "visibility", true);
+        ok &= isValidRules(errors, warnings, visibility, "visibility", true);
         ok &= isValidField("confirmCmd", confirmCmd, errors, warnings); // Check if field is allowed for the widget type
         if (!(confirmCmd instanceof Boolean)) {
-            ok &= isValidRule(errors, warnings, confirmCmd, "confirmCmd", false); // Check if valid rule
+            ok &= isValidRules(errors, warnings, confirmCmd, "confirmCmd", false); // Check if valid rule
         }
 
         if (widgets != null) {
@@ -305,68 +305,64 @@ public class YamlWidgetDTO {
         return ok;
     }
 
-    private boolean isValidRule(@NonNull List<@NonNull String> errors, @NonNull List<@NonNull String> warnings,
+    private boolean isValidRules(@NonNull List<@NonNull String> errors, @NonNull List<@NonNull String> warnings,
             Object parameter, String parameterName, boolean ignoreValue) {
+        boolean ok = true;
+        if (parameter instanceof List<?> rules) {
+            for (Object r : rules) {
+                ok &= isValidRule(errors, warnings, r, parameterName, ignoreValue);
+            }
+        } else {
+            ok &= isValidRule(errors, warnings, parameter, parameterName, ignoreValue);
+        }
+        return ok;
+    }
+
+    private boolean isValidRule(List<@NonNull String> errors, List<@NonNull String> warnings, Object rule,
+            String parameterName, boolean ignoreValue) {
         boolean ok = true;
         List<String> ruleErrors = new ArrayList<>();
         List<String> ruleWarnings = new ArrayList<>();
-        if (parameter instanceof List<?> rules) {
-            for (Object r : rules) {
-                if (r instanceof YamlRuleWithAndConditionsDTO rule) {
-                    ok &= rule.isValid(ruleErrors, ruleWarnings);
-                    if (ignoreValue && rule.value != null) {
-                        addToList(warnings,
-                                "rule in \"%s\" field: unexpected \"value\" field is ignored".formatted(parameterName));
-                    }
-                } else if (r instanceof YamlRuleWithUniqueConditionDTO rule) {
-                    ok &= rule.isValid(ruleErrors, ruleWarnings);
-                    if (ignoreValue) {
-                        if (rule.item == null && rule.operator == null && rule.argument == null) {
-                            addToList(errors,
-                                    "invalid rule in \"%s\" field: \"argument\" field missing while mandatory in condition"
-                                            .formatted(parameterName));
-                            ok = false;
-                        } else if (rule.value != null) {
-                            addToList(warnings, "rule in \"%s\" field: unexpected \"value\" field is ignored"
-                                    .formatted(parameterName));
-                        }
-                    } else if (rule.item == null && rule.operator == null && rule.argument == null
-                            && rule.value == null) {
-                        addToList(errors,
-                                "invalid rule in \"%s\" field: \"argument\" field and \"value\" field should not both be empty"
-                                        .formatted(parameterName));
-                        ok = false;
-                    }
-                } else {
-                    addToList(errors, "invalid type for rule in \"%s\" field".formatted(parameterName));
-                    ok = false;
-                }
-            }
-        } else if (parameter instanceof YamlRuleWithAndConditionsDTO rule) {
-            ok &= rule.isValid(ruleErrors, ruleWarnings);
-            if (ignoreValue && rule.value != null) {
-                addToList(warnings,
-                        "rule in \"%s\" field: unexpected \"value\" field is ignored".formatted(parameterName));
-            }
-        } else if (parameter instanceof YamlRuleWithUniqueConditionDTO rule) {
-            ok &= rule.isValid(ruleErrors, ruleWarnings);
+        if (rule instanceof YamlRuleWithAndConditionsDTO andConditionRule) {
+            ok &= andConditionRule.isValid(ruleErrors, ruleWarnings);
             if (ignoreValue) {
-                if (rule.item == null && rule.operator == null && rule.argument == null) {
+                if (andConditionRule.and == null || andConditionRule.and.isEmpty()) {
+                    addToList(errors,
+                            "invalid rule in \"%s\" field: \"and\" empty, no conditions defined while mandatory in condition"
+                                    .formatted(parameterName));
+                    ok = false;
+                } else if (andConditionRule.value != null) {
+                    addToList(warnings,
+                            "rule in \"%s\" field: unexpected \"value\" field is ignored".formatted(parameterName));
+                }
+            } else if ((andConditionRule.and == null || andConditionRule.and.isEmpty())
+                    && andConditionRule.value == null) {
+                addToList(errors,
+                        "invalid rule in \"%s\" field: \"and\" field and \"value\" field should not both be empty"
+                                .formatted(parameterName));
+                ok = false;
+            }
+        } else if (rule instanceof YamlRuleWithUniqueConditionDTO uniqueCondtionRule) {
+            ok &= uniqueCondtionRule.isValid(ruleErrors, ruleWarnings);
+            if (ignoreValue) {
+                if (uniqueCondtionRule.argument == null) {
                     addToList(errors,
                             "invalid rule in \"%s\" field: \"argument\" field missing while mandatory in condition"
                                     .formatted(parameterName));
                     ok = false;
-                }
-                if (rule.value != null) {
+                } else if (uniqueCondtionRule.value != null) {
                     addToList(warnings,
                             "rule in \"%s\" field: unexpected \"value\" field is ignored".formatted(parameterName));
                 }
-            } else if (rule.item == null && rule.operator == null && rule.argument == null && rule.value == null) {
+            } else if (uniqueCondtionRule.argument == null && uniqueCondtionRule.value == null) {
                 addToList(errors,
                         "invalid rule in \"%s\" field: \"argument\" field and \"value\" field should not both be empty"
                                 .formatted(parameterName));
                 ok = false;
             }
+        } else {
+            addToList(errors, "invalid type for rule in \"%s\" field".formatted(parameterName));
+            ok = false;
         }
         ruleErrors.forEach(error -> {
             addToList(errors, "invalid rule in \"%s\" field: %s".formatted(parameterName, error));

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTO.java
@@ -30,9 +30,10 @@ import org.openhab.core.items.ItemUtil;
 import com.fasterxml.jackson.annotation.JsonAlias;
 
 /**
- * This is a data transfer object that is used to serialize widgets.
+ * This is a data transfer object that is used to serialize sitemap widgets.
  *
  * @author Laurent Garnier - Initial contribution
+ * @author Mark Herwege - Add support for confirmation dialog for commands
  */
 public class YamlWidgetDTO {
 
@@ -65,23 +66,23 @@ public class YamlWidgetDTO {
 
         OPTIONAL_FIELDS.put(FRAME, Set.of("item"));
         OPTIONAL_FIELDS.put(BUTTON_GRID, Set.of());
-        OPTIONAL_FIELDS.put(BUTTON, Set.of("releaseCommand", "stateless"));
+        OPTIONAL_FIELDS.put(BUTTON, Set.of("releaseCommand", "stateless", "confirmCmd"));
         OPTIONAL_FIELDS.put(GROUP, Set.of());
         OPTIONAL_FIELDS.put(TEXT, Set.of("item"));
-        OPTIONAL_FIELDS.put(COLOR_PICKER, Set.of());
-        OPTIONAL_FIELDS.put(COLOR_TEMPERATURE_PICKER, Set.of("min", "max"));
-        OPTIONAL_FIELDS.put(INPUT, Set.of("hint"));
-        OPTIONAL_FIELDS.put(SWITCH, Set.of("mappings"));
-        OPTIONAL_FIELDS.put(SELECTION, Set.of("mappings"));
-        OPTIONAL_FIELDS.put(SETPOINT, Set.of("min", "max", "step"));
-        OPTIONAL_FIELDS.put(SLIDER, Set.of("switchSupport", "releaseOnly", "min", "max", "step"));
+        OPTIONAL_FIELDS.put(COLOR_PICKER, Set.of("confirmCmd"));
+        OPTIONAL_FIELDS.put(COLOR_TEMPERATURE_PICKER, Set.of("min", "max", "confirmCmd"));
+        OPTIONAL_FIELDS.put(INPUT, Set.of("hint", "confirmCmd"));
+        OPTIONAL_FIELDS.put(SWITCH, Set.of("mappings", "confirmCmd"));
+        OPTIONAL_FIELDS.put(SELECTION, Set.of("mappings", "confirmCmd"));
+        OPTIONAL_FIELDS.put(SETPOINT, Set.of("min", "max", "step", "confirmCmd"));
+        OPTIONAL_FIELDS.put(SLIDER, Set.of("switchSupport", "releaseOnly", "min", "max", "step", "confirmCmd"));
         OPTIONAL_FIELDS.put(IMAGE, Set.of("item", "url", "refresh"));
         OPTIONAL_FIELDS.put(CHART,
                 Set.of("refresh", "service", "legend", "forceAsItem", "yAxisDecimalPattern", "interpolation"));
         OPTIONAL_FIELDS.put(VIDEO, Set.of("item", "encoding"));
         OPTIONAL_FIELDS.put(MAPVIEW, Set.of("height"));
         OPTIONAL_FIELDS.put(WEBVIEW, Set.of("item", "height"));
-        OPTIONAL_FIELDS.put(DEFAULT, Set.of("height"));
+        OPTIONAL_FIELDS.put(DEFAULT, Set.of("height", "confirmCmd"));
     }
 
     public String type;
@@ -115,6 +116,7 @@ public class YamlWidgetDTO {
     public Boolean stateless;
 
     public Object visibility;
+    public Object confirmCmd;
 
     public List<YamlWidgetDTO> widgets;
 
@@ -176,52 +178,9 @@ public class YamlWidgetDTO {
                     .formatted(minValue.doubleValue(), maxValue.doubleValue()));
         }
 
-        List<String> ruleErrors = new ArrayList<>();
-        List<String> ruleWarnings = new ArrayList<>();
-        if (visibility instanceof List<?> rules) {
-            for (Object r : rules) {
-                if (r instanceof YamlRuleWithAndConditionsDTO rule) {
-                    ok &= rule.isValid(ruleErrors, ruleWarnings);
-                    if (rule.value != null) {
-                        addToList(warnings, "rule in \"visibility\" field: unexpected \"value\" field is ignored");
-                    }
-                } else if (r instanceof YamlRuleWithUniqueConditionDTO rule) {
-                    ok &= rule.isValid(ruleErrors, ruleWarnings);
-                    if (rule.item == null && rule.operator == null && rule.argument == null) {
-                        addToList(errors,
-                                "invalid rule in \"visibility\" field: \"argument\" field missing while mandatory in condition");
-                        ok = false;
-                    }
-                    if (rule.value != null) {
-                        addToList(warnings, "rule in \"visibility\" field: unexpected \"value\" field is ignored");
-                    }
-                } else {
-                    addToList(errors, "invalid type for rule in \"visibility\" field");
-                    ok = false;
-                }
-            }
-        } else if (visibility instanceof YamlRuleWithAndConditionsDTO rule) {
-            ok &= rule.isValid(ruleErrors, ruleWarnings);
-            if (rule.value != null) {
-                addToList(warnings, "rule in \"visibility\" field: unexpected \"value\" field is ignored");
-            }
-        } else if (visibility instanceof YamlRuleWithUniqueConditionDTO rule) {
-            ok &= rule.isValid(ruleErrors, ruleWarnings);
-            if (rule.item == null && rule.operator == null && rule.argument == null) {
-                addToList(errors,
-                        "invalid rule in \"visibility\" field: \"argument\" field missing while mandatory in condition");
-                ok = false;
-            }
-            if (rule.value != null) {
-                addToList(warnings, "rule in \"visibility\" field: unexpected \"value\" field is ignored");
-            }
-        }
-        ruleErrors.forEach(error -> {
-            addToList(errors, "invalid rule in \"visibility\" field: %s".formatted(error));
-        });
-        ruleWarnings.forEach(warning -> {
-            addToList(warnings, "rule in \"visibility\" field: %s".formatted(warning));
-        });
+        ok &= isValidRule(errors, warnings, visibility, "visibility");
+        ok &= isValidField("confirmCmd", confirmCmd, errors, warnings); // Check if field is allowed for the widget type
+        ok &= isValidRule(errors, warnings, confirmCmd, "confirmCmd"); // Check if valid rule
 
         if (widgets != null) {
             if (!LINKABLE_WIDGETS.contains(type)) {
@@ -344,6 +303,64 @@ public class YamlWidgetDTO {
         return ok;
     }
 
+    private boolean isValidRule(@NonNull List<@NonNull String> errors, @NonNull List<@NonNull String> warnings,
+            Object parameter, String parameterName) {
+        boolean ok = true;
+        List<String> ruleErrors = new ArrayList<>();
+        List<String> ruleWarnings = new ArrayList<>();
+        if (parameter instanceof List<?> rules) {
+            for (Object r : rules) {
+                if (r instanceof YamlRuleWithAndConditionsDTO rule) {
+                    ok &= rule.isValid(ruleErrors, ruleWarnings);
+                    if (rule.value != null) {
+                        addToList(warnings,
+                                "rule in \"%s\" field: unexpected \"value\" field is ignored".formatted(parameterName));
+                    }
+                } else if (r instanceof YamlRuleWithUniqueConditionDTO rule) {
+                    ok &= rule.isValid(ruleErrors, ruleWarnings);
+                    if (rule.item == null && rule.operator == null && rule.argument == null) {
+                        addToList(errors,
+                                "invalid rule in \"%s\" field: \"argument\" field missing while mandatory in condition"
+                                        .formatted(parameterName));
+                        ok = false;
+                    }
+                    if (rule.value != null) {
+                        addToList(warnings,
+                                "rule in \"%s\" field: unexpected \"value\" field is ignored".formatted(parameterName));
+                    }
+                } else {
+                    addToList(errors, "invalid type for rule in \"%s\" field".formatted(parameterName));
+                    ok = false;
+                }
+            }
+        } else if (parameter instanceof YamlRuleWithAndConditionsDTO rule) {
+            ok &= rule.isValid(ruleErrors, ruleWarnings);
+            if (rule.value != null) {
+                addToList(warnings,
+                        "rule in \"%s\" field: unexpected \"value\" field is ignored".formatted(parameterName));
+            }
+        } else if (parameter instanceof YamlRuleWithUniqueConditionDTO rule) {
+            ok &= rule.isValid(ruleErrors, ruleWarnings);
+            if (rule.item == null && rule.operator == null && rule.argument == null) {
+                addToList(errors,
+                        "invalid rule in \"%s\" field: \"argument\" field missing while mandatory in condition"
+                                .formatted(parameterName));
+                ok = false;
+            }
+            if (rule.value != null) {
+                addToList(warnings,
+                        "rule in \"%s\" field: unexpected \"value\" field is ignored".formatted(parameterName));
+            }
+        }
+        ruleErrors.forEach(error -> {
+            addToList(errors, "invalid rule in \"%s\" field: %s".formatted(parameterName, error));
+        });
+        ruleWarnings.forEach(warning -> {
+            addToList(warnings, "rule in \"%s\" field: %s".formatted(parameterName, warning));
+        });
+        return ok;
+    }
+
     private void addToList(@Nullable List<@NonNull String> list, String value) {
         if (list != null) {
             list.add(value);
@@ -354,7 +371,7 @@ public class YamlWidgetDTO {
     public int hashCode() {
         return Objects.hash(type, item, label, icon, mappings, switchSupport, releaseOnly, height, min, max, step, hint,
                 url, refresh, encoding, service, period, legend, forceAsItem, yAxisDecimalPattern, interpolation, row,
-                column, command, releaseCommand, stateless, visibility, widgets);
+                column, command, releaseCommand, stateless, visibility, confirmCmd, widgets);
     }
 
     @Override
@@ -378,7 +395,8 @@ public class YamlWidgetDTO {
                 && Objects.equals(interpolation, other.interpolation) && Objects.equals(row, other.row)
                 && Objects.equals(column, other.column) && Objects.equals(command, other.command)
                 && Objects.equals(releaseCommand, other.releaseCommand) && Objects.equals(stateless, other.stateless)
-                && Objects.equals(visibility, other.visibility) && Objects.equals(widgets, other.widgets);
+                && Objects.equals(visibility, other.visibility) && Objects.equals(confirmCmd, other.confirmCmd)
+                && Objects.equals(widgets, other.widgets);
     }
 
     record ButtonPosition(Integer row, Integer column) {

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTO.java
@@ -332,6 +332,9 @@ public class YamlWidgetDTO {
                 if (andConditionRule.value != null) {
                     addToList(ruleWarnings, "unexpected \"value\" field is ignored");
                 }
+            } else if (andConditionRule.and == null || andConditionRule.and.isEmpty()) {
+                addToList(ruleErrors, "\"and\" field missing while mandatory in rules");
+                ok = false;
             }
         } else if (rule instanceof YamlRuleWithUniqueConditionDTO uniqueConditionRule) {
             ok &= uniqueConditionRule.isValid(ruleErrors, ruleWarnings);

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTO.java
@@ -320,15 +320,16 @@ public class YamlWidgetDTO {
                     }
                 } else if (r instanceof YamlRuleWithUniqueConditionDTO rule) {
                     ok &= rule.isValid(ruleErrors, ruleWarnings);
-                    if (rule.item == null && rule.operator == null && rule.argument == null) {
-                        addToList(errors,
-                                "invalid rule in \"%s\" field: \"argument\" field missing while mandatory in condition"
-                                        .formatted(parameterName));
-                        ok = false;
-                    }
-                    if (ignoreValue && rule.value != null) {
-                        addToList(warnings,
-                                "rule in \"%s\" field: unexpected \"value\" field is ignored".formatted(parameterName));
+                    if (ignoreValue) {
+                        if (rule.item == null && rule.operator == null && rule.argument == null) {
+                            addToList(errors,
+                                    "invalid rule in \"%s\" field: \"argument\" field missing while mandatory in condition"
+                                            .formatted(parameterName));
+                            ok = false;
+                        } else if (rule.value != null) {
+                            addToList(warnings, "rule in \"%s\" field: unexpected \"value\" field is ignored"
+                                    .formatted(parameterName));
+                        }
                     }
                 } else {
                     addToList(errors, "invalid type for rule in \"%s\" field".formatted(parameterName));
@@ -343,15 +344,17 @@ public class YamlWidgetDTO {
             }
         } else if (parameter instanceof YamlRuleWithUniqueConditionDTO rule) {
             ok &= rule.isValid(ruleErrors, ruleWarnings);
-            if (rule.item == null && rule.operator == null && rule.argument == null) {
-                addToList(errors,
-                        "invalid rule in \"%s\" field: \"argument\" field missing while mandatory in condition"
-                                .formatted(parameterName));
-                ok = false;
-            }
-            if (ignoreValue && rule.value != null) {
-                addToList(warnings,
-                        "rule in \"%s\" field: unexpected \"value\" field is ignored".formatted(parameterName));
+            if (ignoreValue) {
+                if (rule.item == null && rule.operator == null && rule.argument == null) {
+                    addToList(errors,
+                            "invalid rule in \"%s\" field: \"argument\" field missing while mandatory in condition"
+                                    .formatted(parameterName));
+                    ok = false;
+                }
+                if (rule.value != null) {
+                    addToList(warnings,
+                            "rule in \"%s\" field: unexpected \"value\" field is ignored".formatted(parameterName));
+                }
             }
         }
         ruleErrors.forEach(error -> {

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/fileconverter/YamlSitemapConverter.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/fileconverter/YamlSitemapConverter.java
@@ -229,7 +229,12 @@ public class YamlSitemapConverter implements SitemapSerializer, SitemapParser {
         List<Object> confirmCmdRules = buildRules(widget.getConfirmCmdRules(), false);
         if (!confirmCmdRules.isEmpty()) {
             if (confirmCmdRules.size() == 1) {
-                dto.confirmCmd = confirmCmdRules.getFirst();
+                if (confirmCmdRules.getFirst() instanceof YamlRuleWithUniqueConditionDTO rule && rule.item == null
+                        && rule.operator == null && rule.value == null) {
+                    dto.confirmCmd = rule.argument;
+                } else {
+                    dto.confirmCmd = confirmCmdRules.getFirst();
+                }
             } else {
                 dto.confirmCmd = confirmCmdRules;
             }

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/fileconverter/YamlSitemapConverter.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/fileconverter/YamlSitemapConverter.java
@@ -61,6 +61,7 @@ import org.osgi.service.component.annotations.Reference;
  * {@link YamlSitemapConverter} is the YAML converter for {@link Sitemap} objects.
  *
  * @author Laurent Garnier - Initial contribution
+ * @author Mark Herwege - Add support for confirmation dialog for commands
  */
 @NonNullByDefault
 @Component(immediate = true, service = { SitemapSerializer.class, SitemapParser.class })
@@ -223,6 +224,17 @@ public class YamlSitemapConverter implements SitemapSerializer, SitemapParser {
             } else {
                 dto.visibility = visibilityRules;
             }
+        }
+
+        List<Object> confirmCmdRules = buildRules(widget.getConfirmCmdRules(), true);
+        if (!confirmCmdRules.isEmpty()) {
+            if (confirmCmdRules.size() == 1) {
+                dto.confirmCmd = confirmCmdRules.getFirst();
+            } else {
+                dto.confirmCmd = confirmCmdRules;
+            }
+        } else if (widget.getConfirmCmd()) {
+            dto.confirmCmd = true;
         }
 
         switch (widget) {

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/fileconverter/YamlSitemapConverter.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/sitemaps/fileconverter/YamlSitemapConverter.java
@@ -226,7 +226,7 @@ public class YamlSitemapConverter implements SitemapSerializer, SitemapParser {
             }
         }
 
-        List<Object> confirmCmdRules = buildRules(widget.getConfirmCmdRules(), true);
+        List<Object> confirmCmdRules = buildRules(widget.getConfirmCmdRules(), false);
         if (!confirmCmdRules.isEmpty()) {
             if (confirmCmdRules.size() == 1) {
                 dto.confirmCmd = confirmCmdRules.getFirst();

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/sitemaps/YamlSitemapProviderTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/sitemaps/YamlSitemapProviderTest.java
@@ -246,6 +246,8 @@ public class YamlSitemapProviderTest {
         assertThat(widget.getIconRules(), hasSize(0));
         assertThat(widget.getIconColor(), hasSize(0));
         assertThat(widget.getVisibility(), hasSize(0));
+        assertFalse(widget.getConfirmCmd());
+        assertThat(widget.getConfirmCmdRules(), hasSize(0));
         assertTrue(widget instanceof Switch);
         Switch switchWidget = (Switch) widget;
         assertThat(switchWidget.getMappings(), hasSize(0));
@@ -260,6 +262,8 @@ public class YamlSitemapProviderTest {
         assertThat(widget.getIconRules(), hasSize(0));
         assertThat(widget.getIconColor(), hasSize(0));
         assertThat(widget.getVisibility(), hasSize(0));
+        assertFalse(widget.getConfirmCmd());
+        assertThat(widget.getConfirmCmdRules(), hasSize(0));
         assertTrue(widget instanceof Switch);
         switchWidget = (Switch) widget;
         assertThat(switchWidget.getMappings(), hasSize(1));
@@ -280,6 +284,8 @@ public class YamlSitemapProviderTest {
         assertThat(widget.getIconRules(), hasSize(0));
         assertThat(widget.getIconColor(), hasSize(0));
         assertThat(widget.getVisibility(), hasSize(0));
+        assertFalse(widget.getConfirmCmd());
+        assertThat(widget.getConfirmCmdRules(), hasSize(0));
         assertTrue(widget instanceof Selection);
         Selection selectionWidget = (Selection) widget;
         assertThat(selectionWidget.getMappings(), hasSize(2));
@@ -339,6 +345,8 @@ public class YamlSitemapProviderTest {
         assertThat(widget.getIconRules(), hasSize(0));
         assertThat(widget.getIconColor(), hasSize(0));
         assertThat(widget.getVisibility(), hasSize(0));
+        assertTrue(widget.getConfirmCmd());
+        assertThat(widget.getConfirmCmdRules(), hasSize(0));
         assertTrue(widget instanceof Input);
         Input inputWidget = (Input) widget;
         assertEquals("number", inputWidget.getInputHint());
@@ -448,6 +456,11 @@ public class YamlSitemapProviderTest {
         assertThat(rule.getConditions(), hasSize(0));
         assertEquals("blue", rule.getArgument());
         assertThat(widget.getVisibility(), hasSize(0));
+        assertFalse(widget.getConfirmCmd());
+        assertThat(widget.getConfirmCmdRules(), hasSize(1));
+        rule = widget.getConfirmCmdRules().getFirst();
+        assertThat(rule.getConditions(), hasSize(0));
+        assertEquals("Should I change the slider value?", rule.getArgument());
         assertTrue(widget instanceof Slider);
         Slider sliderWidget = (Slider) widget;
         assertEquals(BigDecimal.valueOf(25), sliderWidget.getMinValue());
@@ -466,6 +479,14 @@ public class YamlSitemapProviderTest {
         assertThat(widget.getIconRules(), hasSize(0));
         assertThat(widget.getIconColor(), hasSize(0));
         assertThat(widget.getVisibility(), hasSize(0));
+        assertFalse(widget.getConfirmCmd());
+        assertThat(widget.getConfirmCmdRules(), hasSize(1));
+        rule = widget.getConfirmCmdRules().getFirst();
+        assertThat(rule.getConditions(), hasSize(1));
+        condition = rule.getConditions().getFirst();
+        assertEquals(">", condition.getCondition());
+        assertEquals("20", condition.getValue());
+        assertEquals("Should I change the setpoint value?", rule.getArgument());
         assertTrue(widget instanceof Setpoint);
         Setpoint setpointWidget = (Setpoint) widget;
         assertEquals(BigDecimal.valueOf(12.5), setpointWidget.getMinValue());
@@ -482,6 +503,11 @@ public class YamlSitemapProviderTest {
         assertThat(widget.getIconRules(), hasSize(0));
         assertThat(widget.getIconColor(), hasSize(0));
         assertThat(widget.getVisibility(), hasSize(0));
+        assertFalse(widget.getConfirmCmd());
+        assertThat(widget.getConfirmCmdRules(), hasSize(1));
+        rule = widget.getConfirmCmdRules().getFirst();
+        assertThat(rule.getConditions(), hasSize(0));
+        assertEquals("true", rule.getArgument());
         assertTrue(widget instanceof Colorpicker);
 
         widget = widgets.get(9);
@@ -494,6 +520,11 @@ public class YamlSitemapProviderTest {
         assertThat(widget.getIconRules(), hasSize(0));
         assertThat(widget.getIconColor(), hasSize(0));
         assertThat(widget.getVisibility(), hasSize(0));
+        assertFalse(widget.getConfirmCmd());
+        assertThat(widget.getConfirmCmdRules(), hasSize(1));
+        rule = widget.getConfirmCmdRules().getFirst();
+        assertThat(rule.getConditions(), hasSize(0));
+        assertEquals("true", rule.getArgument());
         assertTrue(widget instanceof Colortemperaturepicker);
         Colortemperaturepicker pickerWidget = (Colortemperaturepicker) widget;
         assertEquals(BigDecimal.valueOf(3000), pickerWidget.getMinValue());
@@ -584,6 +615,8 @@ public class YamlSitemapProviderTest {
         assertEquals("!=", condition.getCondition());
         assertEquals("ON", condition.getValue());
         assertNull(rule.getArgument());
+        assertFalse(widget.getConfirmCmd());
+        assertThat(widget.getConfirmCmdRules(), hasSize(0));
         assertTrue(widget instanceof Button);
         Button buttonWidget = (Button) widget;
         assertEquals(1, buttonWidget.getRow());
@@ -610,6 +643,8 @@ public class YamlSitemapProviderTest {
         assertEquals("==", condition.getCondition());
         assertEquals("ON", condition.getValue());
         assertNull(rule.getArgument());
+        assertFalse(widget.getConfirmCmd());
+        assertThat(widget.getConfirmCmdRules(), hasSize(0));
         assertTrue(widget instanceof Button);
         buttonWidget = (Button) widget;
         assertEquals(1, buttonWidget.getRow());
@@ -695,6 +730,8 @@ public class YamlSitemapProviderTest {
         assertThat(widget.getIconRules(), hasSize(0));
         assertThat(widget.getIconColor(), hasSize(0));
         assertThat(widget.getVisibility(), hasSize(0));
+        assertFalse(widget.getConfirmCmd());
+        assertThat(widget.getConfirmCmdRules(), hasSize(0));
         assertTrue(widget instanceof Default);
         Default defaultWidget = (Default) widget;
         assertEquals(0, defaultWidget.getHeight());

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTOTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTOTest.java
@@ -298,9 +298,17 @@ public class YamlWidgetDTOTest {
 
         rule2 = new YamlRuleWithAndConditionsDTO();
         widget.confirmCmd = rule2;
-        assertTrue(widget.isValid(err, warn));
+        assertFalse(widget.isValid(err, warn));
+        assertEquals(1, err.size());
+        assertEquals("invalid rule in \"confirmCmd\" field: \"and\" field missing while mandatory in rules",
+                err.getFirst());
+        err.clear();
         rule2.and = List.of();
-        assertTrue(widget.isValid(err, warn));
+        assertFalse(widget.isValid(err, warn));
+        assertEquals(1, err.size());
+        assertEquals("invalid rule in \"confirmCmd\" field: \"and\" field missing while mandatory in rules",
+                err.getFirst());
+        err.clear();
         condition = new YamlConditionDTO();
         rule2.and = List.of(condition);
         assertFalse(widget.isValid(err, warn));

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTOTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/sitemaps/YamlWidgetDTOTest.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
@@ -124,6 +125,12 @@ public class YamlWidgetDTOTest {
 
         widget.visibility = List.of();
         assertTrue(widget.isValid(err, warn));
+
+        widget.visibility = "zzz";
+        assertTrue(widget.isValid(err, warn));
+        assertEquals(1, warn.size());
+        assertEquals("rule in \"visibility\" field: unexpected string value is ignored", warn.getFirst());
+        warn.clear();
 
         YamlRuleWithUniqueConditionDTO rule1 = new YamlRuleWithUniqueConditionDTO();
         widget.visibility = rule1;
@@ -237,6 +244,117 @@ public class YamlWidgetDTOTest {
         assertEquals(1, warn.size());
         assertEquals("rule in \"visibility\" field: unexpected \"value\" field is ignored", warn.getFirst());
         warn.clear();
+
+        widget.visibility = null;
+        widget.confirmCmd = true;
+        assertTrue(widget.isValid(err, warn));
+        assertEquals(1, warn.size());
+        assertEquals("unexpected \"confirmCmd\" field is ignored", warn.getFirst());
+        warn.clear();
+        widget.type = "Switch";
+        assertTrue(widget.isValid(err, warn));
+        assertEquals(0, warn.size());
+        widget.confirmCmd = "zzz";
+        assertTrue(widget.isValid(err, warn));
+        assertEquals(0, warn.size());
+
+        rule1 = new YamlRuleWithUniqueConditionDTO();
+        widget.confirmCmd = rule1;
+        assertFalse(widget.isValid(err, warn));
+        assertEquals(1, err.size());
+        assertEquals(
+                "invalid rule in \"confirmCmd\" field: \"argument\" field and \"value\" field should not both be empty",
+                err.getFirst());
+        err.clear();
+        rule1.operator = "<=";
+        assertFalse(widget.isValid(err, warn));
+        assertEquals(2, err.size());
+        assertEquals(Set.copyOf(err), Set.of(
+                "invalid rule in \"confirmCmd\" field: \"argument\" field missing while mandatory in condition",
+                "invalid rule in \"confirmCmd\" field: \"argument\" field and \"value\" field should not both be empty"));
+        err.clear();
+        rule1.argument = "50";
+        assertTrue(widget.isValid(err, warn));
+        rule1.operator = "EQ";
+        assertFalse(widget.isValid(err, warn));
+        assertEquals(1, err.size());
+        assertEquals("invalid rule in \"confirmCmd\" field: invalid value \"EQ\" for \"operator\" field in condition",
+                err.getFirst());
+        err.clear();
+        rule1.operator = null;
+        assertTrue(widget.isValid(err, warn));
+        rule1.item = "@item";
+        assertFalse(widget.isValid(err, warn));
+        assertEquals(1, err.size());
+        assertEquals(
+                "invalid rule in \"confirmCmd\" field: invalid value \"@item\" for \"item\" field in condition; it must begin with a letter or underscore followed by alphanumeric characters and underscores, and must not contain any other symbols",
+                err.getFirst());
+        err.clear();
+        rule1.item = "item";
+        assertTrue(widget.isValid(err, warn));
+        rule1.value = "xxx";
+        assertTrue(widget.isValid(err, warn));
+        assertEquals(0, warn.size());
+
+        rule2 = new YamlRuleWithAndConditionsDTO();
+        widget.confirmCmd = rule2;
+        assertTrue(widget.isValid(err, warn));
+        rule2.and = List.of();
+        assertTrue(widget.isValid(err, warn));
+        condition = new YamlConditionDTO();
+        rule2.and = List.of(condition);
+        assertFalse(widget.isValid(err, warn));
+        assertEquals(1, err.size());
+        assertEquals("invalid rule in \"confirmCmd\" field: \"argument\" field missing while mandatory in condition",
+                err.getFirst());
+        err.clear();
+        condition.operator = ">";
+        assertFalse(widget.isValid(err, warn));
+        assertEquals(1, err.size());
+        assertEquals("invalid rule in \"confirmCmd\" field: \"argument\" field missing while mandatory in condition",
+                err.getFirst());
+        err.clear();
+        condition.argument = "50";
+        assertTrue(widget.isValid(err, warn));
+        condition.operator = "EQ";
+        assertFalse(widget.isValid(err, warn));
+        assertEquals(1, err.size());
+        assertEquals("invalid rule in \"confirmCmd\" field: invalid value \"EQ\" for \"operator\" field in condition",
+                err.getFirst());
+        err.clear();
+        condition.operator = null;
+        assertTrue(widget.isValid(err, warn));
+        condition.item = "@item";
+        assertFalse(widget.isValid(err, warn));
+        assertEquals(1, err.size());
+        assertEquals(
+                "invalid rule in \"confirmCmd\" field: invalid value \"@item\" for \"item\" field in condition; it must begin with a letter or underscore followed by alphanumeric characters and underscores, and must not contain any other symbols",
+                err.getFirst());
+        err.clear();
+        condition.item = "item";
+        assertTrue(widget.isValid(err, warn));
+        rule2.value = "yyy";
+        assertTrue(widget.isValid(err, warn));
+        assertEquals(0, warn.size());
+
+        widget.confirmCmd = List.of(rule1, rule2);
+        assertTrue(widget.isValid(err, warn));
+        rule1.argument = null;
+        assertFalse(widget.isValid(err, warn));
+        assertEquals(1, err.size());
+        assertEquals("invalid rule in \"confirmCmd\" field: \"argument\" field missing while mandatory in condition",
+                err.getFirst());
+        err.clear();
+        rule1.argument = "50";
+        assertTrue(widget.isValid(err, warn));
+        condition.argument = null;
+        assertFalse(widget.isValid(err, warn));
+        assertEquals(1, err.size());
+        assertEquals("invalid rule in \"confirmCmd\" field: \"argument\" field missing while mandatory in condition",
+                err.getFirst());
+        err.clear();
+        condition.argument = "50";
+        assertTrue(widget.isValid(err, warn));
     }
 
     @Test

--- a/bundles/org.openhab.core.model.yaml/src/test/resources/model/sitemaps/bigSitemap.yaml
+++ b/bundles/org.openhab.core.model.yaml/src/test/resources/model/sitemaps/bigSitemap.yaml
@@ -120,14 +120,14 @@ sitemaps:
             max: 22.5
             step: 0.5
             confirmCmd:
-                operator: ">"
-                argument: 20
-                value: "Should I change the setpoint value?"
+              operator: ">"
+              argument: 20
+              value: "Should I change the setpoint value?"
           - type: Colorpicker
             item: DemoColor
             label: Test Colorpicker
             confirmCmd:
-                value: "true"
+              value: "true"
           - type: Colortemperaturepicker
             item: DemoColorTemp
             label: Test Colortemperaturepicker

--- a/bundles/org.openhab.core.model.yaml/src/test/resources/model/sitemaps/bigSitemap.yaml
+++ b/bundles/org.openhab.core.model.yaml/src/test/resources/model/sitemaps/bigSitemap.yaml
@@ -48,6 +48,7 @@ sitemaps:
             item: DemoNumber
             label: Test Input
             hint: number
+            confirmCmd: true
           - type: Text
             item: DemoNumber
             label:
@@ -111,20 +112,28 @@ sitemaps:
             min: 25
             max: 75
             step: 5
+            confirmCmd: Should I change the slider value?
           - type: Setpoint
             item: DemoNumber
             label: Test Setpoint
             min: 12.5
             max: 22.5
             step: 0.5
+            confirmCmd:
+                operator: ">"
+                argument: 20
+                value: "Should I change the setpoint value?"
           - type: Colorpicker
             item: DemoColor
             label: Test Colorpicker
+            confirmCmd:
+                value: "true"
           - type: Colortemperaturepicker
             item: DemoColorTemp
             label: Test Colortemperaturepicker
             min: 3000
             max: 5000
+            confirmCmd: "true"
           - type: Image
             item: DemoImage
             label: Test Image

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/Rule.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/Rule.java
@@ -40,8 +40,8 @@ public interface Rule {
     void setConditions(List<Condition> conditions);
 
     /**
-     * Get the rule argument for icon or color rules. The rule argument is the resulting value if the rule is met.
-     * Visibility rules don't have an argument, always work on the full widget.
+     * Get the rule argument for icon, color or confirmCmd rules. The rule argument is the resulting value if the rule
+     * is met. Visibility rules don't have an argument, always work on the full widget.
      *
      * @return argument
      */

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/Widget.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/Widget.java
@@ -194,8 +194,8 @@ public interface Widget {
     void setConfirmCmd(@Nullable Boolean confirmCmd);
 
     /**
-     * Get the confirm cmd rules. This method should return a modifiable list, allowing commands to the confirm
-     * change rules.
+     * Get the confirm cmd rules. This method should return a modifiable list, allowing updates to the confirm
+     * cmd rules.
      *
      * @return confirm cmd rules
      */

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/Widget.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/Widget.java
@@ -21,6 +21,7 @@ import org.eclipse.jdt.annotation.Nullable;
  * A representation of a sitemap widget.
  *
  * @author Mark Herwege - Initial contribution
+ * @author Mark Herwege - Add support for confirmation dialog for commands
  */
 @NonNullByDefault
 public interface Widget {
@@ -175,6 +176,37 @@ public interface Widget {
      * @param visibilityRules
      */
     void setVisibility(List<Rule> visibilityRules);
+
+    /**
+     * Get the confirm cmd setting for the widget. If true, the user will be prompted to confirm commands.
+     *
+     * @return confirm cmd setting
+     */
+    boolean getConfirmCmd();
+
+    /**
+     * Set the confirm cmd setting for the widget. If true, the user will be prompted to confirm commands. If false
+     * or
+     * null, no confirmation is required.
+     *
+     * @param confirmCmd
+     */
+    void setConfirmCmd(@Nullable Boolean confirmCmd);
+
+    /**
+     * Get the confirm cmd rules. This method should return a modifiable list, allowing commands to the confirm
+     * change rules.
+     *
+     * @return confirm cmd rules
+     */
+    List<Rule> getConfirmCmdRules();
+
+    /**
+     * Replace the widget confirm cmd rules with a new list of confirm cmd rules.
+     *
+     * @param confirmCmdRules
+     */
+    void setConfirmCmdRules(List<Rule> confirmCmdRules);
 
     /**
      * Get type of widget.

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/AbstractWidgetDTO.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/AbstractWidgetDTO.java
@@ -26,6 +26,7 @@ import java.math.BigDecimal;
  * @author Laurent Garnier - Remove field columns
  * @author Laurent Garnier - New fields row, column, command, releaseCommand and stateless for Button element
  * @author Mark Herwege - Created as abstract base class for WidgetDefinitionDTO classes
+ * @author Mark Herwege - Add support for confirmation dialog for commands
  */
 public abstract class AbstractWidgetDTO {
 
@@ -38,6 +39,10 @@ public abstract class AbstractWidgetDTO {
      * with conditional rules.
      */
     public Boolean staticIcon;
+    /**
+     * confirmCmd is a boolean indicating if a widget command must be confirmed before sending the command.
+     */
+    public Boolean confirmCmd;
 
     // widget-specific attributes
     public Boolean switchSupport;

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/AbstractWidgetDTO.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/AbstractWidgetDTO.java
@@ -39,10 +39,6 @@ public abstract class AbstractWidgetDTO {
      * with conditional rules.
      */
     public Boolean staticIcon;
-    /**
-     * confirmCmd is a boolean indicating if a widget command must be confirmed before sending the command.
-     */
-    public Boolean confirmCmd;
 
     // widget-specific attributes
     public Boolean switchSupport;

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/SitemapDTOMapper.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/SitemapDTOMapper.java
@@ -79,6 +79,7 @@ public class SitemapDTOMapper {
         if (widget.isStaticIcon()) {
             widgetDTO.staticIcon = true;
         }
+        widgetDTO.confirmCmd = widget.getConfirmCmd();
 
         List<Rule> iconRules = widget.getIconRules();
         if (!iconRules.isEmpty()) {
@@ -99,6 +100,10 @@ public class SitemapDTOMapper {
         List<Rule> iconColorRules = widget.getIconColor();
         if (!iconColorRules.isEmpty()) {
             widgetDTO.iconColorRules = iconColorRules.stream().map(SitemapDTOMapper::map).toList();
+        }
+        List<Rule> confirmCmdRules = widget.getConfirmCmdRules();
+        if (!confirmCmdRules.isEmpty()) {
+            widgetDTO.confirmCmdRules = confirmCmdRules.stream().map(SitemapDTOMapper::map).toList();
         }
 
         switch (widget) {
@@ -337,6 +342,7 @@ public class SitemapDTOMapper {
         widget.setLabel(widgetDTO.label);
         widget.setIcon(widgetDTO.icon);
         widget.setStaticIcon(widgetDTO.staticIcon);
+        widget.setConfirmCmd(widgetDTO.confirmCmd);
 
         List<RuleDTO> iconRules = widgetDTO.iconRules != null ? widgetDTO.iconRules : List.of();
         widget.setIconRules(iconRules.stream().map(rule -> map(rule, sitemapFactory)).toList());
@@ -348,6 +354,8 @@ public class SitemapDTOMapper {
         widget.setValueColor(valueColorRules.stream().map(rule -> map(rule, sitemapFactory)).toList());
         List<RuleDTO> iconColorRules = widgetDTO.iconColorRules != null ? widgetDTO.iconColorRules : List.of();
         widget.setIconColor(iconColorRules.stream().map(rule -> map(rule, sitemapFactory)).toList());
+        List<RuleDTO> confirmCmdRules = widgetDTO.confirmCmdRules != null ? widgetDTO.confirmCmdRules : List.of();
+        widget.setConfirmCmdRules(confirmCmdRules.stream().map(rule -> map(rule, sitemapFactory)).toList());
 
         if (widget instanceof LinkableWidget linkableWidget) {
             List<WidgetDefinitionDTO> widgets = widgetDTO.widgets != null ? widgetDTO.widgets : List.of();

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/SitemapDTOMapper.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/SitemapDTOMapper.java
@@ -79,7 +79,9 @@ public class SitemapDTOMapper {
         if (widget.isStaticIcon()) {
             widgetDTO.staticIcon = true;
         }
-        widgetDTO.confirmCmd = widget.getConfirmCmd();
+        if (widget.getConfirmCmd()) {
+            widgetDTO.confirmCmd = true;
+        }
 
         List<Rule> iconRules = widget.getIconRules();
         if (!iconRules.isEmpty()) {

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/WidgetDefinitionDTO.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/WidgetDefinitionDTO.java
@@ -27,6 +27,11 @@ public class WidgetDefinitionDTO extends AbstractWidgetDTO {
 
     public String item;
 
+    /**
+     * confirmCmd is a boolean indicating if a widget command must be confirmed before sending the command.
+     */
+    public Boolean confirmCmd;
+
     public List<MappingDTO> mappings;
 
     public List<RuleDTO> visibilityRules;

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/WidgetDefinitionDTO.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/dto/WidgetDefinitionDTO.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * This is a data transfer object that is used to serialize widgets.
  *
  * @author Mark Herwege - Initial contribution
+ * @author Mark Herwege - Add support for confirmation dialog for commands
  */
 @Schema(name = "SitemapWidgetDefinition")
 public class WidgetDefinitionDTO extends AbstractWidgetDTO {
@@ -33,6 +34,7 @@ public class WidgetDefinitionDTO extends AbstractWidgetDTO {
     public List<RuleDTO> labelColorRules;
     public List<RuleDTO> valueColorRules;
     public List<RuleDTO> iconColorRules;
+    public List<RuleDTO> confirmCmdRules;
 
     public List<WidgetDefinitionDTO> widgets;
 }

--- a/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/WidgetImpl.java
+++ b/bundles/org.openhab.core.sitemap/src/main/java/org/openhab/core/sitemap/internal/WidgetImpl.java
@@ -23,6 +23,7 @@ import org.openhab.core.sitemap.Widget;
 
 /**
  * @author Mark Herwege - Initial contribution
+ * @author Mark Herwege - Add support for confirmation dialog for commands
  */
 @NonNullByDefault
 public class WidgetImpl implements Widget {
@@ -40,6 +41,9 @@ public class WidgetImpl implements Widget {
     private List<Rule> valueColorRules = new CopyOnWriteArrayList<>();
     private List<Rule> iconColorRules = new CopyOnWriteArrayList<>();
     private List<Rule> visibilityRules = new CopyOnWriteArrayList<>();
+
+    private boolean confirmCmd;
+    private List<Rule> confirmCmdRules = new CopyOnWriteArrayList<>();
 
     public WidgetImpl() {
     }
@@ -146,6 +150,26 @@ public class WidgetImpl implements Widget {
     @Override
     public void setVisibility(List<Rule> visibilityRules) {
         this.visibilityRules = new CopyOnWriteArrayList<>(visibilityRules);
+    }
+
+    @Override
+    public boolean getConfirmCmd() {
+        return confirmCmd;
+    }
+
+    @Override
+    public void setConfirmCmd(@Nullable Boolean confirmCmd) {
+        this.confirmCmd = confirmCmd == null ? false : confirmCmd;
+    }
+
+    @Override
+    public List<Rule> getConfirmCmdRules() {
+        return confirmCmdRules;
+    }
+
+    @Override
+    public void setConfirmCmdRules(List<Rule> confirmCmdRules) {
+        this.confirmCmdRules = new CopyOnWriteArrayList<>(confirmCmdRules);
     }
 
     @Override

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapMapper.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapMapper.java
@@ -40,18 +40,15 @@ import org.openhab.core.sitemap.Webview;
 import org.openhab.core.sitemap.Widget;
 import org.openhab.core.ui.components.RootUIComponent;
 import org.openhab.core.ui.components.UIComponent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The {@link UIComponentSitemapMapper} is a utility class to map sitemaps into UI Component objects.
  *
  * @author Mark Herwege - Initial contribution
+ * @author Mark Herwege - Add support for confirmation dialog for commands
  */
 @NonNullByDefault
 public class UIComponentSitemapMapper {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(UIComponentSitemapMapper.class);
 
     public static RootUIComponent map(Sitemap element) {
         String sitemapName = element.getName();
@@ -76,12 +73,16 @@ public class UIComponentSitemapMapper {
         if (widget.isStaticIcon()) {
             addConfig(widgetComponent, "staticIcon", true);
         }
+        if (widget.getConfirmCmd()) {
+            addConfig(widgetComponent, "confirmCmd", true);
+        }
 
         addConfig(widgetComponent, "iconrules", map(widget.getIconRules()));
         addConfig(widgetComponent, "visibility", map(widget.getVisibility()));
         addConfig(widgetComponent, "labelcolor", map(widget.getLabelColor()));
         addConfig(widgetComponent, "valuecolor", map(widget.getValueColor()));
         addConfig(widgetComponent, "iconcolor", map(widget.getIconColor()));
+        addConfig(widgetComponent, "confirmcmdrules", map(widget.getConfirmCmdRules()));
 
         switch (widget) {
             case Switch switchWidget -> {

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -368,9 +368,7 @@ public class UIComponentSitemapProvider extends AbstractProvider<Sitemap>
             if (sourceRules instanceof Collection<?> sourceRulesCollection) {
                 for (Object sourceRule : sourceRulesCollection) {
                     if (sourceRule instanceof String) {
-                        String argument = !("visibility".equals(key) || "confirmcmdrules".equals(key))
-                                ? getRuleArgument(sourceRule.toString())
-                                : null;
+                        String argument = !"visibility".equals(key) ? getRuleArgument(sourceRule.toString()) : null;
                         List<String> conditionsString = getRuleConditions(sourceRule.toString(), argument);
                         Rule rule = sitemapFactory.createRule();
                         List<Condition> conditions = getConditions(conditionsString, component, key);

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -80,6 +80,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Herwege - Implement sitemap registry
  * @author Mark Herwege - Make provider managed and add support for adding/updating/removing sitemaps via the provider
  *         interface
+ * @author Mark Herwege - Add support for confirmation dialog for commands
  */
 @NonNullByDefault
 @Component(service = { SitemapProvider.class, ManagedSitemapProvider.class }, immediate = true)
@@ -222,6 +223,7 @@ public class UIComponentSitemapProvider extends AbstractProvider<Sitemap>
         setWidgetPropertyFromComponentConfig(widget, component, "label");
         setWidgetPropertyFromComponentConfig(widget, component, "icon");
         setWidgetPropertyFromComponentConfig(widget, component, "staticIcon");
+        setWidgetPropertyFromComponentConfig(widget, component, "confirmCmd");
 
         if (widget instanceof LinkableWidget linkableWidget) {
             if (component.getSlots() != null && component.getSlots().containsKey("widgets")) {
@@ -239,6 +241,7 @@ public class UIComponentSitemapProvider extends AbstractProvider<Sitemap>
         addWidgetRules(widget.getValueColor(), component, "valuecolor");
         addWidgetRules(widget.getIconColor(), component, "iconcolor");
         addWidgetRules(widget.getIconRules(), component, "iconrules");
+        addWidgetRules(widget.getConfirmCmdRules(), component, "confirmcmdrules");
 
         return widget;
     }
@@ -365,7 +368,9 @@ public class UIComponentSitemapProvider extends AbstractProvider<Sitemap>
             if (sourceRules instanceof Collection<?> sourceRulesCollection) {
                 for (Object sourceRule : sourceRulesCollection) {
                     if (sourceRule instanceof String) {
-                        String argument = !"visibility".equals(key) ? getRuleArgument(sourceRule.toString()) : null;
+                        String argument = !("visibility".equals(key) || "confirmcmdrules".equals(key))
+                                ? getRuleArgument(sourceRule.toString())
+                                : null;
                         List<String> conditionsString = getRuleConditions(sourceRule.toString(), argument);
                         Rule rule = sitemapFactory.createRule();
                         List<Condition> conditions = getConditions(conditionsString, component, key);

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -423,8 +423,8 @@ public class UIComponentSitemapProvider extends AbstractProvider<Sitemap>
         String strippedRule = null;
         int lastEqualsIndex = rule.lastIndexOf("=");
         String charBeforeEquals = lastEqualsIndex > 0 ? rule.substring(lastEqualsIndex - 1, lastEqualsIndex) : null;
-        if (!("=".equals(charBeforeEquals) && "!".equals(charBeforeEquals) && "<".equals(charBeforeEquals)
-                && ">".equals(charBeforeEquals))) {
+        if (!("=".equals(charBeforeEquals) || "!".equals(charBeforeEquals) || "<".equals(charBeforeEquals)
+                || ">".equals(charBeforeEquals))) {
             strippedRule = stripQuotes(rule.substring(lastEqualsIndex + 1).trim());
         }
         return strippedRule;

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -368,7 +368,7 @@ public class UIComponentSitemapProvider extends AbstractProvider<Sitemap>
             if (sourceRules instanceof Collection<?> sourceRulesCollection) {
                 for (Object sourceRule : sourceRulesCollection) {
                     if (sourceRule instanceof String) {
-                        String argument = !"visibility".equals(key) ? getRuleArgument(sourceRule.toString()) : null;
+                        String argument = getRuleArgument(sourceRule.toString());
                         List<String> conditionsString = getRuleConditions(sourceRule.toString(), argument);
                         Rule rule = sitemapFactory.createRule();
                         List<Condition> conditions = getConditions(conditionsString, component, key);
@@ -419,10 +419,15 @@ public class UIComponentSitemapProvider extends AbstractProvider<Sitemap>
         return conditions;
     }
 
-    private String getRuleArgument(String rule) {
-        int argIndex = rule.lastIndexOf("=") + 1;
-        String strippedRule = stripQuotes(rule.substring(argIndex).trim());
-        return strippedRule != null ? strippedRule : "";
+    private @Nullable String getRuleArgument(String rule) {
+        String strippedRule = null;
+        int lastEqualsIndex = rule.lastIndexOf("=");
+        String charBeforeEquals = lastEqualsIndex > 0 ? rule.substring(lastEqualsIndex - 1, lastEqualsIndex) : null;
+        if (!("=".equals(charBeforeEquals) && "!".equals(charBeforeEquals) && "<".equals(charBeforeEquals)
+                && ">".equals(charBeforeEquals))) {
+            strippedRule = stripQuotes(rule.substring(lastEqualsIndex + 1).trim());
+        }
+        return strippedRule;
     }
 
     private List<String> getRuleConditions(String rule, @Nullable String argument) {

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -362,7 +362,16 @@ public class UIComponentSitemapProvider extends AbstractProvider<Sitemap>
         return deprecated;
     }
 
-    private void addWidgetRules(List<Rule> rules, UIComponent component, String key) {
+    /**
+     * Add rules of a specific type to a widget.
+     * This method is package-private for testing purposes, to allow testing adding rules to a widget without having to
+     * mock the whole widget building process.
+     *
+     * @param rules
+     * @param component
+     * @param key
+     */
+    void addWidgetRules(List<Rule> rules, UIComponent component, String key) {
         if (component.getConfig() != null && component.getConfig().containsKey(key)) {
             Object sourceRules = component.getConfig().get(key);
             if (sourceRules instanceof Collection<?> sourceRulesCollection) {
@@ -420,14 +429,24 @@ public class UIComponentSitemapProvider extends AbstractProvider<Sitemap>
     }
 
     private @Nullable String getRuleArgument(String rule) {
-        String strippedRule = null;
-        int lastEqualsIndex = rule.lastIndexOf("=");
-        String charBeforeEquals = lastEqualsIndex > 0 ? rule.substring(lastEqualsIndex - 1, lastEqualsIndex) : null;
-        if (!("=".equals(charBeforeEquals) || "!".equals(charBeforeEquals) || "<".equals(charBeforeEquals)
-                || ">".equals(charBeforeEquals))) {
-            strippedRule = stripQuotes(rule.substring(lastEqualsIndex + 1).trim());
+        String argument = null;
+        String trimmedRule = rule.trim();
+        String strippedRule = trimmedRule;
+        if (strippedRule.endsWith("\"")) {
+            for (int i = strippedRule.length() - 2; i >= 0; i--) {
+                if (strippedRule.charAt(i) == '"') {
+                    strippedRule = i > 0 ? rule.substring(0, i) : "";
+                    break;
+                }
+            }
         }
-        return strippedRule;
+        int lastEqualsIndex = strippedRule.lastIndexOf("=");
+        String charBeforeEquals = lastEqualsIndex > 0 ? rule.substring(lastEqualsIndex - 1, lastEqualsIndex) : null;
+        if (!(lastEqualsIndex == -1 || "=".equals(charBeforeEquals) || "!".equals(charBeforeEquals)
+                || "<".equals(charBeforeEquals) || ">".equals(charBeforeEquals))) {
+            argument = stripQuotes(trimmedRule.substring(lastEqualsIndex + 1).trim());
+        }
+        return argument;
     }
 
     private List<String> getRuleConditions(String rule, @Nullable String argument) {

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -1334,16 +1334,21 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     public boolean getConfirmCmd(Widget w) {
         // Default to confirm cmd parameter if no rules defined
         List<Rule> ruleList = w.getConfirmCmdRules();
-        logger.debug("Checking confirm command parameter for widget '{}'.", w.getLabel());
 
         if (ruleList.isEmpty()) {
             return w.getConfirmCmd();
         }
+
+        logger.debug("Checking confirm command parameter for widget '{}'.", w.getLabel());
+
         for (Rule rule : ruleList) {
             if (allConditionsOk(rule.getConditions(), w)) {
                 return true;
             }
         }
+
+        logger.debug("Widget {} commands don't require confirmation.", w.getLabel());
+
         return false;
     }
 

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -115,6 +115,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Herwege - Implement sitemap registry
  * @author Florian Hotze - Refactor getLabel(Widget w) to use {@link ItemDisplayStateUtil}
  * @author Laurent Garnier - Change widget id coding to support any number of widgets in frame/page
+ * @author Mark Herwege - Add support for confirmation dialog for commands
  */
 @NonNullByDefault
 @Component(immediate = true, configurationPid = "org.openhab.sitemap", //
@@ -1326,6 +1327,23 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
         logger.debug("Widget {} is not visible.", w.getLabel());
 
+        return false;
+    }
+
+    @Override
+    public boolean getConfirmCmd(Widget w) {
+        // Default to confirm cmd parameter if no rules defined
+        List<Rule> ruleList = w.getConfirmCmdRules();
+        logger.debug("Checking confirm command parameter for widget '{}'.", w.getLabel());
+
+        if (ruleList.isEmpty()) {
+            return w.getConfirmCmd();
+        }
+        for (Rule rule : ruleList) {
+            if (allConditionsOk(rule.getConditions(), w)) {
+                return true;
+            }
+        }
         return false;
     }
 

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -137,7 +137,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     protected static final String SEMANTICS_LOCATION = "Location";
     protected static final String SEMANTICS_PARENT_LOCATION_CONFIG = "isPartOf";
 
-    private static final String DEFAULT_CONFIRM_CMD_MESSAGE = "Are you sure?";
+    protected static final String DEFAULT_CONFIRM_CMD_MESSAGE = "Are you sure?";
 
     private final Logger logger = LoggerFactory.getLogger(ItemUIRegistryImpl.class);
 
@@ -1267,9 +1267,9 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return matched;
     }
 
-    private @Nullable String processColorDefinition(Widget w, @Nullable List<Rule> colorList, String colorType) {
+    private @Nullable String processColorDefinition(Widget w, List<Rule> colorList, String colorType) {
         // Sanity check
-        if (colorList == null || colorList.isEmpty()) {
+        if (colorList.isEmpty()) {
             return null;
         }
 
@@ -1394,9 +1394,9 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return icon;
     }
 
-    private boolean allConditionsOk(@Nullable List<org.openhab.core.sitemap.Condition> conditions, Widget w) {
+    private boolean allConditionsOk(List<org.openhab.core.sitemap.Condition> conditions, Widget w) {
         boolean allConditionsOk = true;
-        if (conditions != null) {
+        if (!conditions.isEmpty()) {
             State defaultState = getState(w);
 
             // Go through all AND conditions

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -203,7 +203,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
             if (groupMembersSortingString != null) {
                 groupMembersSorting = groupMembersSortingString;
             }
-            final String confirmCmdMessageString = Objects.toString(config.get("confirmCmdMessage"), null);
+            final String confirmCmdMessageString = Objects.toString(config.get("confirmationDialogMessage"), null);
             if (confirmCmdMessageString != null) {
                 confirmCmdMessage = confirmCmdMessageString;
             }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -137,7 +137,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     protected static final String SEMANTICS_LOCATION = "Location";
     protected static final String SEMANTICS_PARENT_LOCATION_CONFIG = "isPartOf";
 
-    protected static final String DEFAULT_CONFIRM_CMD_MESSAGE = "Are you sure?";
+    protected static final String DEFAULT_COMMAND_CONFIRM_MESSAGE = "Are you sure?";
 
     private final Logger logger = LoggerFactory.getLogger(ItemUIRegistryImpl.class);
 
@@ -151,7 +151,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     private final Map<Widget, Widget> defaultWidgets = Collections.synchronizedMap(new WeakHashMap<>());
 
     private String groupMembersSorting = DEFAULT_SORTING;
-    private String confirmCmdMessage = DEFAULT_CONFIRM_CMD_MESSAGE;
+    private String commandConfirmMessage = DEFAULT_COMMAND_CONFIRM_MESSAGE;
 
     private static class WidgetLabelWithSource {
         public final String label;
@@ -203,9 +203,10 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
             if (groupMembersSortingString != null) {
                 groupMembersSorting = groupMembersSortingString;
             }
-            final String confirmCmdMessageString = Objects.toString(config.get("confirmationDialogMessage"), null);
-            if (confirmCmdMessageString != null) {
-                confirmCmdMessage = confirmCmdMessageString;
+            final String commandConfirmMessageString = Objects.toString(config.get("commandConfirmDialogMessage"),
+                    null);
+            if (commandConfirmMessageString != null) {
+                commandConfirmMessage = commandConfirmMessageString;
             }
         }
     }
@@ -1338,11 +1339,11 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Override
-    public @Nullable String getConfirmCmdMessage(Widget w) {
+    public @Nullable String getCommandConfirmMessage(Widget w) {
         List<Rule> ruleList = w.getConfirmCmdRules();
 
         if (ruleList.isEmpty()) {
-            return w.getConfirmCmd() ? confirmCmdMessage : null;
+            return w.getConfirmCmd() ? commandConfirmMessage : null;
         }
 
         logger.debug("Checking confirm command rules for widget '{}'.", w.getLabel());
@@ -1350,7 +1351,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         for (Rule rule : ruleList) {
             if (allConditionsOk(rule.getConditions(), w)) {
                 String arg = rule.getArgument();
-                return arg != null && !arg.isBlank() ? arg : confirmCmdMessage;
+                return arg != null && !arg.isBlank() ? arg : commandConfirmMessage;
             }
         }
 

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -137,6 +137,8 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     protected static final String SEMANTICS_LOCATION = "Location";
     protected static final String SEMANTICS_PARENT_LOCATION_CONFIG = "isPartOf";
 
+    private static final String DEFAULT_CONFIRM_CMD_MESSAGE = "Are you sure?";
+
     private final Logger logger = LoggerFactory.getLogger(ItemUIRegistryImpl.class);
 
     protected final Set<ItemUIProvider> itemUIProviders = new HashSet<>();
@@ -149,6 +151,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     private final Map<Widget, Widget> defaultWidgets = Collections.synchronizedMap(new WeakHashMap<>());
 
     private String groupMembersSorting = DEFAULT_SORTING;
+    private String confirmCmdMessage = DEFAULT_CONFIRM_CMD_MESSAGE;
 
     private static class WidgetLabelWithSource {
         public final String label;
@@ -199,6 +202,10 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
             final String groupMembersSortingString = Objects.toString(config.get("groupMembersSorting"), null);
             if (groupMembersSortingString != null) {
                 groupMembersSorting = groupMembersSortingString;
+            }
+            final String confirmCmdMessageString = Objects.toString(config.get("confirmCmdMessage"), null);
+            if (confirmCmdMessageString != null) {
+                confirmCmdMessage = confirmCmdMessageString;
             }
         }
     }
@@ -1331,25 +1338,24 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Override
-    public boolean getConfirmCmd(Widget w) {
-        // Default to confirm cmd parameter if no rules defined
+    public @Nullable String getConfirmCmdMessage(Widget w) {
         List<Rule> ruleList = w.getConfirmCmdRules();
 
         if (ruleList.isEmpty()) {
-            return w.getConfirmCmd();
+            return w.getConfirmCmd() ? confirmCmdMessage : null;
         }
 
-        logger.debug("Checking confirm command parameter for widget '{}'.", w.getLabel());
+        logger.debug("Checking confirm command rules for widget '{}'.", w.getLabel());
 
         for (Rule rule : ruleList) {
             if (allConditionsOk(rule.getConditions(), w)) {
-                return true;
+                String arg = rule.getArgument();
+                return arg != null && !arg.isBlank() ? arg : confirmCmdMessage;
             }
         }
 
         logger.debug("Widget {} commands don't require confirmation.", w.getLabel());
-
-        return false;
+        return null;
     }
 
     @Override

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIRegistry.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIRegistry.java
@@ -39,6 +39,7 @@ import org.openhab.core.types.State;
  * @author Laurent Garnier - new method getConditionalIcon
  * @author Danny Baumann - widget label source support
  * @author Mark Herwege - Implement sitemap registry
+ * @author Mark Herwege - Add support for confirmation dialog for commands
  */
 @NonNullByDefault
 public interface ItemUIRegistry extends ItemRegistry, ItemUIProvider {
@@ -213,6 +214,14 @@ public interface ItemUIRegistry extends ItemRegistry, ItemUIProvider {
      * @return true if the item is visible
      */
     boolean getVisiblity(Widget w);
+
+    /**
+     * Gets the widget confirm cmd property based on the item state
+     *
+     * @param w Widget
+     * @return true if the changing the item state requires a confirmation dialog
+     */
+    boolean getConfirmCmd(Widget w);
 
     /**
      * Gets the item state

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIRegistry.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIRegistry.java
@@ -216,12 +216,14 @@ public interface ItemUIRegistry extends ItemRegistry, ItemUIProvider {
     boolean getVisiblity(Widget w);
 
     /**
-     * Gets the widget confirm cmd property based on the item state
+     * Gets the widget confirm cmd message property based on the item state
      *
      * @param w Widget
-     * @return true if changing the item state requires a confirmation dialog
+     * @return message to show in the confirmation dialog or null if no message is defined and no confirmation dialog
+     *         should be shown
      */
-    boolean getConfirmCmd(Widget w);
+    @Nullable
+    String getConfirmCmdMessage(Widget w);
 
     /**
      * Gets the item state

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIRegistry.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIRegistry.java
@@ -223,7 +223,7 @@ public interface ItemUIRegistry extends ItemRegistry, ItemUIProvider {
      *         should be shown
      */
     @Nullable
-    String getConfirmCmdMessage(Widget w);
+    String getCommandConfirmMessage(Widget w);
 
     /**
      * Gets the item state

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIRegistry.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIRegistry.java
@@ -219,7 +219,7 @@ public interface ItemUIRegistry extends ItemRegistry, ItemUIProvider {
      * Gets the widget confirm cmd property based on the item state
      *
      * @param w Widget
-     * @return true if the changing the item state requires a confirmation dialog
+     * @return true if changing the item state requires a confirmation dialog
      */
     boolean getConfirmCmd(Widget w);
 

--- a/bundles/org.openhab.core.ui/src/main/resources/OH-INF/config/sitemap.xml
+++ b/bundles/org.openhab.core.ui/src/main/resources/OH-INF/config/sitemap.xml
@@ -18,6 +18,11 @@
 			</options>
 			<default>NONE</default>
 		</parameter>
+		<parameter name="confirmationDialogMessage" type="text">
+			<label>Confirmation Dialog Message</label>
+			<description>Defines the default message to be shown in confirmation dialogs in the UI.</description>
+			<default>Are you sure?</default>
+		</parameter>
 	</config-description>
 
 </config-description:config-descriptions>

--- a/bundles/org.openhab.core.ui/src/main/resources/OH-INF/config/sitemap.xml
+++ b/bundles/org.openhab.core.ui/src/main/resources/OH-INF/config/sitemap.xml
@@ -18,9 +18,9 @@
 			</options>
 			<default>NONE</default>
 		</parameter>
-		<parameter name="confirmationDialogMessage" type="text">
-			<label>Confirmation Dialog Message</label>
-			<description>Defines the default message to be shown in confirmation dialogs in the UI.</description>
+		<parameter name="commandConfirmDialogMessage" type="text">
+			<label>Command Confirmation Dialog Message</label>
+			<description>Defines the default message to be shown in command confirmation dialogs in the UI.</description>
 			<default>Are you sure?</default>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.core.ui/src/main/resources/OH-INF/i18n/sitemap.properties
+++ b/bundles/org.openhab.core.ui/src/main/resources/OH-INF/i18n/sitemap.properties
@@ -4,5 +4,6 @@ system.config.sitemap.groupMembersSorting.option.NONE = No sorting
 system.config.sitemap.groupMembersSorting.option.LABEL = Sorted by label
 system.config.sitemap.groupMembersSorting.option.NAME = Sorted by name
 system.config.sitemap.groupMembersSorting.option.METADATA = Sorted by item widget order metadata
+system.config.sitemap.confirmationDialogMessage = Are you sure?
 
 service.system.sitemap.label = Sitemap

--- a/bundles/org.openhab.core.ui/src/main/resources/OH-INF/i18n/sitemap.properties
+++ b/bundles/org.openhab.core.ui/src/main/resources/OH-INF/i18n/sitemap.properties
@@ -4,6 +4,6 @@ system.config.sitemap.groupMembersSorting.option.NONE = No sorting
 system.config.sitemap.groupMembersSorting.option.LABEL = Sorted by label
 system.config.sitemap.groupMembersSorting.option.NAME = Sorted by name
 system.config.sitemap.groupMembersSorting.option.METADATA = Sorted by item widget order metadata
-system.config.sitemap.confirmationDialogMessage = Are you sure?
+system.config.sitemap.commandConfirmDialogMessage = Are you sure?
 
 service.system.sitemap.label = Sitemap

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/components/UIComponentSitemapProviderTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/components/UIComponentSitemapProviderTest.java
@@ -15,7 +15,9 @@ package org.openhab.core.ui.internal.components;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
@@ -24,6 +26,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.core.sitemap.Condition;
+import org.openhab.core.sitemap.Rule;
 import org.openhab.core.sitemap.registry.SitemapFactory;
 import org.openhab.core.sitemap.registry.SitemapRegistry;
 import org.openhab.core.ui.components.UIComponent;
@@ -40,6 +43,12 @@ class UIComponentSitemapProviderTest {
     private @Mock @NonNullByDefault({}) UIComponent component;
 
     private @InjectMocks @NonNullByDefault({}) UIComponentSitemapProvider uiComponentSitemapProvider;
+
+    private Rule mockRule() {
+        Rule rule = mock(Rule.class);
+        when(sitemapFactory.createRule()).thenReturn(rule);
+        return rule;
+    }
 
     private Condition mockCondition() {
         Condition condition = mock(Condition.class);
@@ -193,5 +202,79 @@ class UIComponentSitemapProviderTest {
         verify(condition2).setItem("item2");
         verify(condition2).setCondition("==");
         verify(condition2).setValue("10");
+    }
+
+    @Test
+    void testRuleConditionWithArgumentBaseline() {
+        Rule rule = mockRule();
+        Condition condition = mockCondition();
+        List<Rule> rules = new ArrayList<>();
+        when(component.getConfig()).thenReturn(Map.of("confirmcmdrules", List.of("item>=42=\"Confirm?\"")));
+
+        uiComponentSitemapProvider.addWidgetRules(rules, component, "confirmcmdrules");
+
+        assertEquals(1, rules.size());
+        verify(rule).setArgument("Confirm?");
+        verify(rule).setConditions(List.of(condition));
+        verify(condition).setItem("item");
+        verify(condition).setCondition(">=");
+        verify(condition).setValue("42");
+    }
+
+    @Test
+    void testRuleConditionOnlyNoEqualsSignNoArgument() {
+        // confirmCmd=[DemoNumber>"25"] - no argument at all, so lastIndexOf("=")
+        // must not swallow the whole rule as the argument
+        Rule rule = mockRule();
+        Condition condition = mockCondition();
+        List<Rule> rules = new ArrayList<>();
+        when(component.getConfig()).thenReturn(Map.of("confirmcmdrules", List.of("DemoNumber>\"25\"")));
+
+        uiComponentSitemapProvider.addWidgetRules(rules, component, "confirmcmdrules");
+
+        assertEquals(1, rules.size());
+        verify(rule).setArgument(null);
+        verify(rule).setConditions(List.of(condition));
+        verify(condition).setItem("DemoNumber");
+        verify(condition).setCondition(">");
+        verify(condition).setValue("25");
+    }
+
+    @Test
+    void testRuleArgumentWithEqualsSignInsideQuotedMessage() {
+        // confirmCmd=[DemoSwitch==ON="Set x=10?"] - the "=" inside the quoted
+        // message must not be mistaken for the condition/argument separator
+        Rule rule = mockRule();
+        Condition condition = mockCondition();
+        List<Rule> rules = new ArrayList<>();
+        when(component.getConfig()).thenReturn(Map.of("confirmcmdrules", List.of("DemoSwitch==ON=\"Set x=10?\"")));
+
+        uiComponentSitemapProvider.addWidgetRules(rules, component, "confirmcmdrules");
+
+        assertEquals(1, rules.size());
+        verify(rule).setArgument("Set x=10?");
+        verify(rule).setConditions(List.of(condition));
+        verify(condition).setItem("DemoSwitch");
+        verify(condition).setCondition("==");
+        verify(condition).setValue("ON");
+    }
+
+    @Test
+    void testRuleConditionOnlyWithEqualsSignInsideQuotedConditionValue() {
+        // confirmCmd=[DemoString=="a=b"] - condition-only rule where the "="
+        // inside the quoted condition value must not be read as a separator
+        Rule rule = mockRule();
+        Condition condition = mockCondition();
+        List<Rule> rules = new ArrayList<>();
+        when(component.getConfig()).thenReturn(Map.of("confirmcmdrules", List.of("DemoString==\"a=b\"")));
+
+        uiComponentSitemapProvider.addWidgetRules(rules, component, "confirmcmdrules");
+
+        assertEquals(1, rules.size());
+        verify(rule).setArgument(null);
+        verify(rule).setConditions(List.of(condition));
+        verify(condition).setItem("DemoString");
+        verify(condition).setCondition("==");
+        verify(condition).setValue("a=b");
     }
 }

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
@@ -1388,6 +1388,48 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
+    public void getConfirmCmd() {
+        when(widgetMock.getConfirmCmd()).thenReturn(true);
+        assertEquals(ItemUIRegistryImpl.DEFAULT_CONFIRM_CMD_MESSAGE, uiRegistry.getConfirmCmdMessage(widgetMock));
+
+        when(widgetMock.getConfirmCmd()).thenReturn(false);
+        assertNull(uiRegistry.getConfirmCmdMessage(widgetMock));
+
+        String message = "Are you absolutely sure?";
+        Rule rule = mock(Rule.class);
+        List<Rule> rules = new ArrayList<>();
+        rules.add(rule);
+        List<Condition> conditions = new ArrayList<>();
+        when(rule.getConditions()).thenReturn(conditions);
+        when(rule.getArgument()).thenReturn(message);
+        when(widgetMock.getConfirmCmdRules()).thenReturn(rules);
+        assertEquals(message, uiRegistry.getConfirmCmdMessage(widgetMock));
+
+        Condition condition = mock(Condition.class);
+        when(condition.getValue()).thenReturn("21");
+        when(condition.getCondition()).thenReturn(">=");
+        Condition condition2 = mock(Condition.class);
+        when(condition2.getValue()).thenReturn("24");
+        when(condition2.getCondition()).thenReturn("<");
+        conditions.add(condition);
+        conditions.add(condition2);
+        when(rule.getArgument()).thenReturn(null);
+
+        when(itemMock.getState()).thenReturn(new DecimalType(20.9));
+        assertNull(uiRegistry.getConfirmCmdMessage(mapviewMock));
+
+        when(itemMock.getState()).thenReturn(new DecimalType(21.0));
+        assertEquals(ItemUIRegistryImpl.DEFAULT_CONFIRM_CMD_MESSAGE, uiRegistry.getConfirmCmdMessage(widgetMock));
+
+        when(rule.getArgument()).thenReturn(message);
+        when(itemMock.getState()).thenReturn(new DecimalType(23.5));
+        assertEquals(message, uiRegistry.getConfirmCmdMessage(widgetMock));
+
+        when(itemMock.getState()).thenReturn(new DecimalType(24.0));
+        assertNull(uiRegistry.getConfirmCmdMessage(widgetMock));
+    }
+
+    @Test
     public void getCategoryWhenIconSetWithoutRules() {
         when(widgetMock.getWidgetType()).thenReturn("Text");
         when(widgetMock.getIcon()).thenReturn("temperature");

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
@@ -1390,7 +1390,8 @@ public class ItemUIRegistryImplTest {
     @Test
     public void getConfirmCmd() {
         when(widgetMock.getConfirmCmd()).thenReturn(true);
-        assertEquals(ItemUIRegistryImpl.DEFAULT_COMMAND_CONFIRM_MESSAGE, uiRegistry.getCommandConfirmMessage(widgetMock));
+        assertEquals(ItemUIRegistryImpl.DEFAULT_COMMAND_CONFIRM_MESSAGE,
+                uiRegistry.getCommandConfirmMessage(widgetMock));
 
         when(widgetMock.getConfirmCmd()).thenReturn(false);
         assertNull(uiRegistry.getCommandConfirmMessage(widgetMock));
@@ -1419,7 +1420,8 @@ public class ItemUIRegistryImplTest {
         assertNull(uiRegistry.getCommandConfirmMessage(mapviewMock));
 
         when(itemMock.getState()).thenReturn(new DecimalType(21.0));
-        assertEquals(ItemUIRegistryImpl.DEFAULT_COMMAND_CONFIRM_MESSAGE, uiRegistry.getCommandConfirmMessage(widgetMock));
+        assertEquals(ItemUIRegistryImpl.DEFAULT_COMMAND_CONFIRM_MESSAGE,
+                uiRegistry.getCommandConfirmMessage(widgetMock));
 
         when(rule.getArgument()).thenReturn(message);
         when(itemMock.getState()).thenReturn(new DecimalType(23.5));

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
@@ -1390,10 +1390,10 @@ public class ItemUIRegistryImplTest {
     @Test
     public void getConfirmCmd() {
         when(widgetMock.getConfirmCmd()).thenReturn(true);
-        assertEquals(ItemUIRegistryImpl.DEFAULT_CONFIRM_CMD_MESSAGE, uiRegistry.getConfirmCmdMessage(widgetMock));
+        assertEquals(ItemUIRegistryImpl.DEFAULT_COMMAND_CONFIRM_MESSAGE, uiRegistry.getCommandConfirmMessage(widgetMock));
 
         when(widgetMock.getConfirmCmd()).thenReturn(false);
-        assertNull(uiRegistry.getConfirmCmdMessage(widgetMock));
+        assertNull(uiRegistry.getCommandConfirmMessage(widgetMock));
 
         String message = "Are you absolutely sure?";
         Rule rule = mock(Rule.class);
@@ -1403,7 +1403,7 @@ public class ItemUIRegistryImplTest {
         when(rule.getConditions()).thenReturn(conditions);
         when(rule.getArgument()).thenReturn(message);
         when(widgetMock.getConfirmCmdRules()).thenReturn(rules);
-        assertEquals(message, uiRegistry.getConfirmCmdMessage(widgetMock));
+        assertEquals(message, uiRegistry.getCommandConfirmMessage(widgetMock));
 
         Condition condition = mock(Condition.class);
         when(condition.getValue()).thenReturn("21");
@@ -1416,17 +1416,17 @@ public class ItemUIRegistryImplTest {
         when(rule.getArgument()).thenReturn(null);
 
         when(itemMock.getState()).thenReturn(new DecimalType(20.9));
-        assertNull(uiRegistry.getConfirmCmdMessage(mapviewMock));
+        assertNull(uiRegistry.getCommandConfirmMessage(mapviewMock));
 
         when(itemMock.getState()).thenReturn(new DecimalType(21.0));
-        assertEquals(ItemUIRegistryImpl.DEFAULT_CONFIRM_CMD_MESSAGE, uiRegistry.getConfirmCmdMessage(widgetMock));
+        assertEquals(ItemUIRegistryImpl.DEFAULT_COMMAND_CONFIRM_MESSAGE, uiRegistry.getCommandConfirmMessage(widgetMock));
 
         when(rule.getArgument()).thenReturn(message);
         when(itemMock.getState()).thenReturn(new DecimalType(23.5));
-        assertEquals(message, uiRegistry.getConfirmCmdMessage(widgetMock));
+        assertEquals(message, uiRegistry.getCommandConfirmMessage(widgetMock));
 
         when(itemMock.getState()).thenReturn(new DecimalType(24.0));
-        assertNull(uiRegistry.getConfirmCmdMessage(widgetMock));
+        assertNull(uiRegistry.getCommandConfirmMessage(widgetMock));
     }
 
     @Test


### PR DESCRIPTION
The requirement to confirm the command before sending it to the OH server when using a control in a sitemap based UI has come up several times, recently here: https://community.openhab.org/t/announcing-wear-os-app-for-openhab/169918/37

This PR implements a `confirmCmd` parameter on all sitemap widgets, if set should open a confirmation dialog when using the control before committing the new state to OH. This confirmation dialog of course needs to be implemented for each sitemap based UI to take effect.

Here is an example of a sitemap using this parameter on various controls:
```
sitemap demo_confirm label="Confirm Test" icon="group" { 
    Frame label="Confirm" {
        Switch item=DemoSwitch confirmCmd=true
        Switch item=DemoSwitch label="Confirm ON" confirmCmd=[!= ON]
        Switch item=DemoSwitch mappings=[ON=On, OFF=Off] confirmCmd=true
        Selection item=DemoSwitch mappings=[ON="ON", OFF="OFF"] confirmCmd=true
        Input item=DemoNumber confirmCmd=true
        Slider item=DemoNumber confirmCmd=true
        Slider item=DemoNumber label="releaseOnly" releaseOnly confirmCmd=true
        Slider item=DemoNumber label="Confirm DemoSwitch ON" confirmCmd=[DemoSwitch == ON]
        Setpoint item=DemoNumber minValue=25 maxValue=75 step=5 confirmCmd=true
        Colorpicker item=DemoColor confirmCmd=true
        Colortemperaturepicker item=DemoColorTemperature minValue=3000 maxValue=5000 confirmCmd=true
        Buttongrid item=DemoString buttons=[2:2:HOME="Go Home"=material:home] {
            Button row=1 column=1 item=DemoSwitch click=ON label="Off" stateless visibility=[DemoSwitch != ON] confirmCmd=true
            Button row=1 column=1 item=DemoSwitch click=OFF label="On" stateless visibility=[DemoSwitch == ON] confirmCmd=true
            Button row=1 column=2 item=DemoString click=START label="Start" confirmCmd=true
            Button row=1 column=3 item=DemoString click=STOP label="Stop (NC)" stateless
        }
    }
}
```

The `confirmCmd` parameter can be defined as a straight boolean parameter (default is false), or using a rule with the same syntax as visibility rules. This allows making the need for confirmation depend on conditions, as shown in 2 examples in the sitemap above.

This is the core part of the implementation. It is tested with DSL provided sitemaps, but is also implemented for YAML.
I have also implemented this functionality in BasicUI.

In BasicUI, this functionality looks like:
<img width="342" height="685" alt="ConfirmCmd" src="https://github.com/user-attachments/assets/90900bd6-f4cc-4e21-a1b1-6ea5e8103c98" />

As an extra, I now also implemented a variable text for the dialog. Examples:
```
        Switch item=DemoSwitch confirmCmd=[="Shall I do this?"]
        Switch item=DemoSwitch confirmCmd=[!= ON="Should I turn it on?"]
```
One remark, in a DSL rule with a confirmation text, even without conditions, the `=` before the text message is required. This is needed to avoid a syntax ambiguity (you could have a condition with only a condition value, and that would be interpreted the same as the argument). So that is a slight deviation from the requirements for other rules.
There is a configuration property with the default confirmation dialog text, that can be changed system wide. The default can be translated.

Here is a YAML example configuration:
```
version1:
sitemaps:
  demo:
    label: Demo Sitemap
    widgets:
      - type: Frame
        label: Demo Widgets
        widgets:
          - type: Input
            item: DemoNumber
            label: Test Input
            confirmCmd: true
          - type: Slider
            item: DemoNumber
            label: Test Slider
            confirmCmd: Should I change the slider value?
          - type: Setpoint
            item: DemoNumber
            label: Test Setpoint
            confirmCmd:
              operator: ">"
              argument: 20
          - type: Colorpicker
            item: DemoColor
            label: Test Colorpicker
            confirmCmd:
              value: "Should I change the colorpicker value?"
          - type: Colortemperaturepicker
            item: DemoColortemperaturepicker
            label: Test Colortemperaturepicker
            confirmCmd: "true"
```
Notice the last widget example will use the literal `true` as a confirmation message text, while the first example will use the default message text.

The implementation for BasicUI can be found here: https://github.com/openhab/openhab-webui/4448
UI sitemap editor support is in: https://github.com/openhab/openhab-webui/4462

FYI @openhab/android-maintainers @openhab/ios-maintainers @openhab/sailfishos-maintainers @openhab/garmin-maintainers This is potentially interesting to implement in the mobile apps sitemap support. We can still adjust the core functionality if needed, but clients need to implement it. Let me know if you see issues.