### PR TITLE
Move ${ENV:XX} resolution into the Configuration class

### DIFF
--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
@@ -314,7 +314,7 @@ public class RuleResource implements RESTResource {
                     ruleUID);
             return Response.status(Status.NOT_FOUND).build();
         } else {
-            return Response.ok(rule.getConfiguration().getProperties()).build();
+            return Response.ok(rule.getConfiguration().getRawProperties()).build();
         }
     }
 
@@ -526,7 +526,7 @@ public class RuleResource implements RESTResource {
         if (rule != null) {
             Module module = getModule(rule, moduleCategory, id);
             if (module != null) {
-                return Response.ok(module.getConfiguration().getProperties()).build();
+                return Response.ok(module.getConfiguration().getRawProperties()).build();
             }
         }
         return Response.status(Status.NOT_FOUND).build();
@@ -546,7 +546,7 @@ public class RuleResource implements RESTResource {
         if (rule != null) {
             Module module = getModule(rule, moduleCategory, id);
             if (module != null) {
-                return Response.ok(module.getConfiguration().getProperties().get(param)).build();
+                return Response.ok(module.getConfiguration().getRawProperties().get(param)).build();
             }
         }
         return Response.status(Status.NOT_FOUND).build();

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ModuleDTOMapper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ModuleDTOMapper.java
@@ -27,7 +27,7 @@ public class ModuleDTOMapper {
         to.id = from.getId();
         to.label = from.getLabel();
         to.description = from.getDescription();
-        to.configuration = from.getConfiguration().getProperties();
+        to.configuration = from.getConfiguration().getRawProperties();
         to.type = from.getTypeUID();
     }
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/RuleDTOMapper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/RuleDTOMapper.java
@@ -54,7 +54,7 @@ public class RuleDTOMapper {
         to.triggers = TriggerDTOMapper.map(from.getTriggers());
         to.conditions = ConditionDTOMapper.map(from.getConditions());
         to.actions = ActionDTOMapper.map(from.getActions());
-        to.configuration = from.getConfiguration().getProperties();
+        to.configuration = from.getConfiguration().getRawProperties();
         to.configDescriptions = ConfigDescriptionDTOMapper.mapParameters(from.getConfigurationDescriptions());
         to.templateUID = from.getTemplateUID();
         to.templateState = from.getTemplateState().toString();

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleImpl.java
@@ -103,8 +103,7 @@ public class RuleImpl implements Rule {
         this.conditions = conditions == null ? List.of() : List.copyOf(conditions);
         this.actions = actions == null ? List.of() : List.copyOf(actions);
         this.configDescriptions = configDescriptions == null ? List.of() : List.copyOf(configDescriptions);
-        this.configuration = configuration == null ? new Configuration()
-                : new Configuration(configuration.getProperties());
+        this.configuration = configuration == null ? new Configuration() : new Configuration(configuration);
         this.templateUID = templateUID;
         this.templateState = templateState;
         this.visibility = visibility == null ? Visibility.VISIBLE : visibility;

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ConfigurationNormalizer.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ConfigurationNormalizer.java
@@ -91,10 +91,10 @@ public class ConfigurationNormalizer {
                     if (defaultValue == null) {
                         configuration.remove(parameterName);
                     } else {
-                        configuration.put(parameterName, ConfigUtil.normalizeType(defaultValue, parameter));
+                        configuration.putNormalized(parameterName, ConfigUtil.normalizeType(defaultValue, parameter));
                     }
                 } else {
-                    configuration.put(parameterName, ConfigUtil.normalizeType(value, parameter));
+                    configuration.putNormalized(parameterName, ConfigUtil.normalizeType(value, parameter));
                 }
             }
         }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ReferenceResolver.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ReferenceResolver.java
@@ -82,7 +82,7 @@ public class ReferenceResolver {
             Object o = config.get(configKey);
             if (o instanceof String string) {
                 Object result = resolveProperty(config, context, logger, configKey, string);
-                config.put(configKey, result);
+                config.putNormalized(configKey, result);
             } else if (o instanceof List list) {
                 List<Object> resultList = new ArrayList<>();
                 for (Object obj : list) {
@@ -90,7 +90,7 @@ public class ReferenceResolver {
                         resultList.add(resolveProperty(config, context, logger, configKey, string));
                     }
                 }
-                config.put(configKey, resultList);
+                config.putNormalized(configKey, resultList);
             }
         }
     }

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ReferenceResolverUtilTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ReferenceResolverUtilTest.java
@@ -98,17 +98,17 @@ public class ReferenceResolverUtilTest {
         Module trigger = ModuleBuilder.createTrigger().withId("id1").withTypeUID("typeUID1")
                 .withConfiguration(new Configuration(MODULE_CONFIGURATION)).build();
         ReferenceResolver.updateConfiguration(trigger.getConfiguration(), CONTEXT, logger);
-        assertEquals(new Configuration(EXPECTED_MODULE_CONFIGURATION), trigger.getConfiguration());
+        assertEquals(EXPECTED_MODULE_CONFIGURATION, trigger.getConfiguration().getProperties());
         // test condition configuration.
         Module condition = ModuleBuilder.createCondition().withId("id2").withTypeUID("typeUID2")
                 .withConfiguration(new Configuration(MODULE_CONFIGURATION)).build();
         ReferenceResolver.updateConfiguration(condition.getConfiguration(), CONTEXT, logger);
-        assertEquals(new Configuration(EXPECTED_MODULE_CONFIGURATION), condition.getConfiguration());
+        assertEquals(EXPECTED_MODULE_CONFIGURATION, condition.getConfiguration().getProperties());
         // test action configuration.
         Module action = ModuleBuilder.createAction().withId("id3").withTypeUID("typeUID3")
                 .withConfiguration(new Configuration(MODULE_CONFIGURATION)).build();
         ReferenceResolver.updateConfiguration(action.getConfiguration(), CONTEXT, logger);
-        assertEquals(new Configuration(EXPECTED_MODULE_CONFIGURATION), action.getConfiguration());
+        assertEquals(EXPECTED_MODULE_CONFIGURATION, action.getConfiguration().getProperties());
     }
 
     @Test

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
@@ -65,7 +65,7 @@ public class ConfigUtil {
      * <p>
      * This <strong>MUST NOT</strong> be called in production environments as it can break environment variable
      * resolving.
-     * 
+     *
      * @param provider the env provider to use for resolving environment variables
      */
     protected static void setEnvProvider(EnvProvider provider) {
@@ -147,7 +147,7 @@ public class ConfigUtil {
 
     /**
      * Applies the default values from a give {@link ConfigDescription} to the given configuration {@link Map}.
-     * 
+     *
      * @param configuration the configuration {@link Map} where the default values should be added (must not be null)
      * @param configDescription the {@link ConfigDescription} where the default values are located (may be null, but
      *            method won't have any effect then)
@@ -178,7 +178,7 @@ public class ConfigUtil {
             @Nullable ConfigDescription configDescription) {
         Map<String, @Nullable Object> properties = new HashMap<>(configuration.getProperties());
         applyDefaultConfiguration(properties, configDescription);
-        configuration.setProperties(properties);
+        properties.forEach(configuration::putNormalized);
     }
 
     /**
@@ -416,9 +416,10 @@ public class ConfigUtil {
      * @return the resolved configuration
      * @throws IllegalArgumentException if a variable fails to resolve
      */
-    public static Configuration resolveVariables(Configuration configuration) throws IllegalArgumentException {
-        return new Configuration(resolveVariables(configuration.getProperties()));
-    }
+    // @Deprecated
+    // public static Configuration resolveVariables(Configuration configuration) throws IllegalArgumentException {
+    // return new Configuration(resolveVariables(configuration.getRawProperties()));
+    // }
 
     /**
      * Resolve variables and normalize the results in the given {@link Configuration}.
@@ -432,11 +433,11 @@ public class ConfigUtil {
      * @return the normalized configuration
      * @throws IllegalArgumentException if a variable fails to refresh or the given config description is null
      */
-    public static Configuration resolveVariablesAndNormalizeTypes(Configuration configuration,
-            List<ConfigDescription> configDescriptions) throws IllegalArgumentException {
-        final Map<String, @Nullable Object> resolvedConfiguration = resolveVariables(configuration.getProperties());
-        return new Configuration(normalizeTypes(resolvedConfiguration, configDescriptions));
-    }
+    // public static Configuration resolveVariablesAndNormalizeTypes(Configuration configuration,
+    // List<ConfigDescription> configDescriptions) throws IllegalArgumentException {
+    // final Map<String, @Nullable Object> resolvedConfiguration = resolveVariables(configuration.getRawProperties());
+    // return new Configuration(normalizeTypes(resolvedConfiguration, configDescriptions));
+    // }
 
     /**
      * A provider for environment variables.

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/Configuration.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/Configuration.java
@@ -13,7 +13,6 @@
 package org.openhab.core.config.core;
 
 import static java.util.Collections.synchronizedMap;
-import static org.openhab.core.config.core.ConfigUtil.normalizeTypes;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,9 +37,10 @@ import org.eclipse.jdt.annotation.Nullable;
  */
 public class Configuration {
     private final Map<String, Object> properties;
+    private final Map<String, Object> normalizedProperties;
 
     public Configuration() {
-        this(Map.of(), true);
+        this(Map.of(), Map.of());
     }
 
     /**
@@ -52,31 +52,34 @@ public class Configuration {
      * @param configuration the configuration that should be cloned (may be null)
      */
     public Configuration(final @Nullable Configuration configuration) {
-        this(configuration == null ? Map.of() : configuration.properties, true);
+        this(configuration == null ? Map.of() : configuration.properties,
+                configuration == null ? Map.of() : configuration.normalizedProperties);
     }
 
     /**
      * Create a new configuration.
      *
-     * @param properties the properties the configuration should be filled. If null, an empty configuration is created.
+     * @param properties the raw properties the configuration should be filled. If null, an empty configuration is
+     *            created.
      */
     public Configuration(@Nullable Map<String, Object> properties) {
-        this(properties == null ? Map.of() : properties, false);
+        this(properties == null ? Map.of() : properties, Map.of());
     }
 
     /**
      * Create a new configuration.
      *
-     * @param properties the properties to initialize (may be null)
-     * @param alreadyNormalized flag if the properties are already normalized
+     * @param properties the properties to initialize
+     * @param normalizedProperties the normalized properties to initialize
      */
-    private Configuration(final Map<String, Object> properties, final boolean alreadyNormalized) {
-        this.properties = synchronizedMap(alreadyNormalized ? new HashMap<>(properties) : normalizeTypes(properties));
+    private Configuration(final Map<String, Object> properties, final Map<String, Object> normalizedProperties) {
+        this.properties = synchronizedMap(new HashMap<>(properties));
+        this.normalizedProperties = synchronizedMap(new HashMap<>(normalizedProperties));
     }
 
     public <T> T as(Class<T> configurationClass) {
         synchronized (properties) {
-            return ConfigParser.configurationAs(properties, configurationClass);
+            return ConfigParser.configurationAs(resolvedProperties(), configurationClass);
         }
     }
 
@@ -91,16 +94,47 @@ public class Configuration {
     }
 
     public Object get(String key) {
-        return properties.get(key);
+        synchronized (properties) {
+            if (!properties.containsKey(key)) {
+                normalizedProperties.remove(key);
+                return null;
+            } else if (normalizedProperties.containsKey(key)) {
+                return normalizedProperties.get(key);
+            }
+
+            Object rawValue = properties.get(key);
+            if (rawValue == null) {
+                return null;
+            }
+
+            Object resolvedValue = resolveValue(rawValue);
+            Object normalizedValue = ConfigUtil.normalizeType(resolvedValue);
+            normalizedProperties.put(key, normalizedValue);
+            return normalizedValue;
+        }
     }
 
     public Object put(String key, @Nullable Object value) {
-        Object normalizedValue = value == null ? null : ConfigUtil.normalizeType(value, null);
-        return properties.put(key, normalizedValue);
+        synchronized (properties) {
+            normalizedProperties.remove(key);
+            return properties.put(key, value);
+        }
+    }
+
+    public Object putNormalized(String key, @Nullable Object value) {
+        synchronized (properties) {
+            if (!properties.containsKey(key)) {
+                properties.put(key, value);
+            }
+            return normalizedProperties.put(key, value);
+        }
     }
 
     public Object remove(String key) {
-        return properties.remove(key);
+        synchronized (properties) {
+            normalizedProperties.remove(key);
+            return properties.remove(key);
+        }
     }
 
     public Set<String> keySet() {
@@ -111,11 +145,22 @@ public class Configuration {
 
     public Collection<Object> values() {
         synchronized (properties) {
-            return Collections.unmodifiableCollection(new ArrayList<>(properties.values()));
+            return Collections.unmodifiableCollection(new ArrayList<>(resolvedProperties().values()));
         }
     }
 
     public Map<String, Object> getProperties() {
+        synchronized (properties) {
+            return Collections.unmodifiableMap(resolvedProperties());
+        }
+    }
+
+    /**
+     * Returns a copy of the raw, uninterpolated configuration properties.
+     *
+     * @return raw configuration properties
+     */
+    public Map<String, Object> getRawProperties() {
         synchronized (properties) {
             return Collections.unmodifiableMap(new HashMap<>(properties));
         }
@@ -123,9 +168,23 @@ public class Configuration {
 
     public void setProperties(Map<String, Object> newProperties) {
         synchronized (properties) {
+            this.normalizedProperties.clear();
             this.properties.clear();
-            newProperties.entrySet().forEach(e -> put(e.getKey(), e.getValue()));
+            this.properties.putAll(newProperties);
         }
+    }
+
+    private Map<String, Object> resolvedProperties() {
+        Map<String, Object> copy = new HashMap<>(properties.size());
+        properties.keySet().forEach(key -> copy.put(key, get(key)));
+        return copy;
+    }
+
+    private static @Nullable Object resolveValue(@Nullable Object value) {
+        if (value == null) {
+            return value;
+        }
+        return ConfigUtil.resolveVariables(value);
     }
 
     @Override

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurationSerializer.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurationSerializer.java
@@ -35,8 +35,9 @@ public class ConfigurationSerializer implements JsonSerializer<Configuration> {
     @Override
     public JsonElement serialize(Configuration src, Type typeOfSrc, JsonSerializationContext context) {
         JsonObject result = new JsonObject();
-        src.keySet().stream().sorted().forEachOrdered((String propName) -> {
-            Object value = src.get(propName);
+        var rawProperties = src.getRawProperties();
+        rawProperties.keySet().stream().sorted().forEachOrdered((String propName) -> {
+            Object value = rawProperties.get(propName);
             if (value instanceof List list) {
                 JsonArray array = new JsonArray();
                 for (Object element : list) {

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigUtilTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigUtilTest.java
@@ -285,29 +285,29 @@ public class ConfigUtilTest {
         assertEquals(3.14159, resolvedConfig.get("p5"));
     }
 
-    @Test
-    public void resolveVariablesAndNormalizeTypesResolvesThenNormalizedConfiguration() {
-        String hostname = mockEnv.get("HOSTNAME");
-        when(mockEnv.get("BOOLEAN")).thenReturn("true");
-        when(mockEnv.get("INTEGER")).thenReturn("42");
-        when(mockEnv.get("DECIMAL")).thenReturn("3.14159");
+    // @Test
+    // public void resolveVariablesAndNormalizeTypesResolvesThenNormalizedConfiguration() {
+    // String hostname = mockEnv.get("HOSTNAME");
+    // when(mockEnv.get("BOOLEAN")).thenReturn("true");
+    // when(mockEnv.get("INTEGER")).thenReturn("42");
+    // when(mockEnv.get("DECIMAL")).thenReturn("3.14159");
 
-        Map<String, @Nullable Object> config = Map.of("p1", "plain", "p2", "${ENV:HOSTNAME}", "p3", "${ENV:BOOLEAN}",
-                "p4", "${ENV:INTEGER}", "p5", "${ENV:DECIMAL}");
-        ConfigDescription configDescription = ConfigDescriptionBuilder.create(URI.create("thingType:fooThing"))
-                .withParameter(ConfigDescriptionParameterBuilder.create("p1", TEXT).build())
-                .withParameter(ConfigDescriptionParameterBuilder.create("p2", TEXT).build())
-                .withParameter(ConfigDescriptionParameterBuilder.create("p3", BOOLEAN).build())
-                .withParameter(ConfigDescriptionParameterBuilder.create("p4", INTEGER).build())
-                .withParameter(ConfigDescriptionParameterBuilder.create("p5", DECIMAL).build()).build();
+    // Map<String, @Nullable Object> config = Map.of("p1", "plain", "p2", "${ENV:HOSTNAME}", "p3", "${ENV:BOOLEAN}",
+    // "p4", "${ENV:INTEGER}", "p5", "${ENV:DECIMAL}");
+    // ConfigDescription configDescription = ConfigDescriptionBuilder.create(URI.create("thingType:fooThing"))
+    // .withParameter(ConfigDescriptionParameterBuilder.create("p1", TEXT).build())
+    // .withParameter(ConfigDescriptionParameterBuilder.create("p2", TEXT).build())
+    // .withParameter(ConfigDescriptionParameterBuilder.create("p3", BOOLEAN).build())
+    // .withParameter(ConfigDescriptionParameterBuilder.create("p4", INTEGER).build())
+    // .withParameter(ConfigDescriptionParameterBuilder.create("p5", DECIMAL).build()).build();
 
-        Configuration normalizedAndResolvedConfig = ConfigUtil
-                .resolveVariablesAndNormalizeTypes(new Configuration(config), List.of(configDescription));
+    // Configuration normalizedAndResolvedConfig = ConfigUtil
+    // .resolveVariablesAndNormalizeTypes(new Configuration(config), List.of(configDescription));
 
-        assertEquals("plain", normalizedAndResolvedConfig.get("p1"));
-        assertEquals(hostname, normalizedAndResolvedConfig.get("p2"));
-        assertEquals(true, normalizedAndResolvedConfig.get("p3"));
-        assertEquals(new BigDecimal("42"), normalizedAndResolvedConfig.get("p4"));
-        assertEquals(new BigDecimal("3.14159"), normalizedAndResolvedConfig.get("p5"));
-    }
+    // assertEquals("plain", normalizedAndResolvedConfig.get("p1"));
+    // assertEquals(hostname, normalizedAndResolvedConfig.get("p2"));
+    // assertEquals(true, normalizedAndResolvedConfig.get("p3"));
+    // assertEquals(new BigDecimal("42"), normalizedAndResolvedConfig.get("p4"));
+    // assertEquals(new BigDecimal("3.14159"), normalizedAndResolvedConfig.get("p5"));
+    // }
 }

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurationTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurationTest.java
@@ -15,6 +15,7 @@ package org.openhab.core.config.core;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsIterableContaining.hasItems;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -25,7 +26,16 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 /**
  * Test for Configuration class.
@@ -34,7 +44,19 @@ import org.junit.jupiter.api.Test;
  * @author Wouter Born - Migrate tests from Groovy to Java
  */
 @NonNullByDefault
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = "org.openhab.core.config.core.ConfigUtil", mode = ResourceAccessMode.READ_WRITE)
 public class ConfigurationTest {
+
+    private static class ConfigUtilAccessor extends ConfigUtil {
+        static void setEnv(Map<String, String> values) {
+            setEnvProvider(values::get);
+        }
+
+        static void resetEnv() {
+            setEnvProvider(System::getenv);
+        }
+    }
 
     public static class ConfigClass {
         public enum MyEnum {
@@ -62,6 +84,16 @@ public class ConfigurationTest {
             Set<String> setField, org.openhab.core.config.core.ConfigurationTest.ConfigClass.MyEnum enumField) {
         @SuppressWarnings("unused")
         private static final String CONSTANT = "SOME_CONSTANT";
+    }
+
+    @BeforeEach
+    public void setUp() {
+        ConfigUtilAccessor.setEnv(Map.of("HOSTNAME", "openhab-host", "PORT", "8080"));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        ConfigUtilAccessor.resetEnv();
     }
 
     @Test
@@ -233,5 +265,45 @@ public class ConfigurationTest {
         ConfigClass configClass = configuration.as(ConfigClass.class);
 
         assertThat(configClass.listField, is(hasItems("one")));
+    }
+
+    @Test
+    public void assertGetResolvesEnvVariablesAndGetRawKeepsSource() {
+        Configuration configuration = new Configuration(Map.of("host", "${ENV:HOSTNAME}", "port", "${ENV:PORT}"));
+
+        assertThat(configuration.get("host"), is(equalTo("openhab-host")));
+        assertThat(configuration.get("port"), is(equalTo("8080")));
+        assertThat(configuration.getRawProperties().get("host"), is(equalTo("${ENV:HOSTNAME}")));
+        assertThat(configuration.getRawProperties().get("port"), is(equalTo("${ENV:PORT}")));
+    }
+
+    @Test
+    public void assertGetPropertiesAndAsResolveEnvVariables() {
+        Configuration configuration = new Configuration(
+                Map.of("stringField", "${ENV:HOSTNAME}", "listField", List.of("${ENV:HOSTNAME}", "plain")));
+
+        assertThat(configuration.getProperties().get("stringField"), is(equalTo("openhab-host")));
+        assertThat(configuration.getRawProperties().get("stringField"), is(equalTo("${ENV:HOSTNAME}")));
+
+        ConfigClass configClass = configuration.as(ConfigClass.class);
+        assertThat(configClass.stringField, is(equalTo("openhab-host")));
+        assertThat(configClass.listField, is(hasItems("openhab-host", "plain")));
+    }
+
+    @Test
+    public void assertConfigurationSerializerUsesRawValues() {
+        Gson gson = new GsonBuilder().registerTypeAdapter(Configuration.class, new ConfigurationSerializer()).create();
+        Configuration configuration = new Configuration(Map.of("host", "${ENV:HOSTNAME}", "port", "${ENV:PORT}"));
+
+        assertEquals("{\"host\":\"${ENV:HOSTNAME}\",\"port\":\"${ENV:PORT}\"}", gson.toJson(configuration));
+    }
+
+    @Test
+    public void assertConstructorPreservesSourceValuesAndNormalizesTypes() {
+        Configuration configuration = new Configuration(Map.of("host", "${ENV:HOSTNAME}", "count", 1));
+
+        assertThat(configuration.get("host"), is(equalTo("openhab-host")));
+        assertThat(configuration.getRawProperties().get("host"), is(equalTo("${ENV:HOSTNAME}")));
+        assertThat(configuration.get("count"), is(equalTo(BigDecimal.ONE)));
     }
 }

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/fileformat/FileFormatItemDTOMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/fileformat/FileFormatItemDTOMapper.java
@@ -73,9 +73,9 @@ public class FileFormatItemDTOMapper {
         List<FileFormatChannelLinkDTO> channelLinksDTO = new ArrayList<>();
         channelLinks.forEach(link -> {
             if (item.getName().equals(link.getItemName())) {
+                Map<String, Object> rawConfiguration = link.getConfiguration().getRawProperties();
                 channelLinksDTO.add(new FileFormatChannelLinkDTO(link.getLinkedUID().getAsString(),
-                        link.getConfiguration().getProperties().isEmpty() ? null
-                                : link.getConfiguration().getProperties()));
+                        rawConfiguration.isEmpty() ? null : rawConfiguration));
             }
         });
         if (!channelLinksDTO.isEmpty()) {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/fileformat/FileFormatResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/fileformat/FileFormatResource.java
@@ -1425,7 +1425,7 @@ public class FileFormatResource implements RESTResource {
             itemChannelLinkRegistry.getLinks(itemName).forEach(link -> {
                 MetadataKey key = new MetadataKey("channel", itemName);
                 Metadata md = new Metadata(key, link.getLinkedUID().getAsString(),
-                        link.getConfiguration().getProperties());
+                        link.getConfiguration().getRawProperties());
                 metadata.add(md);
             });
         }
@@ -1839,37 +1839,6 @@ public class FileFormatResource implements RESTResource {
         if (!things.isEmpty()) {
             dto.things = new ArrayList<>();
             things.forEach(thing -> {
-                // Normalize thing configuration
-                @Nullable
-                Map<String, @Nullable Object> normalizedThingConfig = normalizeConfiguration(
-                        thing.getConfiguration().getProperties(), thing.getThingTypeUID(), thing.getUID());
-                if (normalizedThingConfig != null) {
-                    thing.getConfiguration().keySet().forEach(paramName -> {
-                        @Nullable
-                        Object normalizedValue = normalizedThingConfig.get(paramName);
-                        if (normalizedValue != null) {
-                            thing.getConfiguration().put(paramName, normalizedValue);
-                        }
-                    });
-                }
-                // Normalize channel configuration
-                thing.getChannels().forEach(channel -> {
-                    ChannelTypeUID channelTypeUID = channel.getChannelTypeUID();
-                    if (channelTypeUID != null) {
-                        @Nullable
-                        Map<String, @Nullable Object> normalizedChannelConfig = normalizeConfiguration(
-                                channel.getConfiguration().getProperties(), channelTypeUID, channel.getUID());
-                        if (normalizedChannelConfig != null) {
-                            channel.getConfiguration().keySet().forEach(paramName -> {
-                                @Nullable
-                                Object normalizedValue = normalizedChannelConfig.get(paramName);
-                                if (normalizedValue != null) {
-                                    channel.getConfiguration().put(paramName, normalizedValue);
-                                }
-                            });
-                        }
-                    }
-                });
                 dto.things.add(ThingDTOMapper.map(thing));
             });
         }

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
@@ -534,7 +534,7 @@ public class ThingResource implements RESTResource {
             thingRegistry.updateConfiguration(thingUIDObject,
                     new Configuration(
                             normalizeConfiguration(configurationParameters, thing.getThingTypeUID(), thing.getUID()))
-                            .getProperties());
+                            .getRawProperties());
         } catch (ConfigValidationException ex) {
             logger.debug("Config description validation exception occurred for thingUID {} - Messages: {}", thingUID,
                     ex.getValidationMessages());

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/link/EnrichedItemChannelLinkDTOMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/link/EnrichedItemChannelLinkDTOMapper.java
@@ -32,6 +32,6 @@ public class EnrichedItemChannelLinkDTOMapper {
      */
     public static EnrichedItemChannelLinkDTO map(ItemChannelLink link, boolean editable) {
         return new EnrichedItemChannelLinkDTO(link.getItemName(), link.getLinkedUID().toString(),
-                link.getConfiguration().getProperties(), editable);
+                link.getConfiguration().getRawProperties(), editable);
     }
 }

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/fileformat/FileFormatResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/fileformat/FileFormatResourceTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.io.rest.core.internal.fileformat;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.automation.RuleRegistry;
+import org.openhab.core.automation.converter.RuleSerializer.RuleSerializationOption;
+import org.openhab.core.automation.template.TemplateRegistry;
+import org.openhab.core.config.core.ConfigDescriptionRegistry;
+import org.openhab.core.config.core.ConfigUtil;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.config.discovery.inbox.Inbox;
+import org.openhab.core.io.rest.core.fileformat.FileFormatDTO;
+import org.openhab.core.items.ItemBuilderFactory;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.MetadataRegistry;
+import org.openhab.core.library.CoreItemFactory;
+import org.openhab.core.semantics.SemanticTagRegistry;
+import org.openhab.core.sitemap.registry.SitemapFactory;
+import org.openhab.core.sitemap.registry.SitemapRegistry;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingRegistry;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.dto.ChannelDTO;
+import org.openhab.core.thing.dto.ThingDTO;
+import org.openhab.core.thing.fileconverter.ThingSerializer;
+import org.openhab.core.thing.link.ItemChannelLinkRegistry;
+import org.openhab.core.thing.type.ChannelTypeRegistry;
+import org.openhab.core.thing.type.ThingTypeRegistry;
+
+/**
+ * Tests for raw configuration handling in the file-format create endpoint.
+ */
+@NonNullByDefault
+@ExtendWith(MockitoExtension.class)
+public class FileFormatResourceTest {
+
+    private static final String RAW_PLACEHOLDER = "${ENV:HOSTNAME}";
+    private static final String ACCEPT_DSL_THING = "text/vnd.openhab.dsl.thing";
+
+    private static class ConfigUtilAccessor extends ConfigUtil {
+        static void setEnv(Map<String, String> values) {
+            setEnvProvider(values::get);
+        }
+
+        static void resetEnv() {
+            setEnvProvider(System::getenv);
+        }
+    }
+
+    private @Mock @NonNullByDefault({}) SemanticTagRegistry semanticTagRegistry;
+    private @Mock @NonNullByDefault({}) ItemBuilderFactory itemBuilderFactory;
+    private @Mock @NonNullByDefault({}) ItemRegistry itemRegistry;
+    private @Mock @NonNullByDefault({}) MetadataRegistry metadataRegistry;
+    private @Mock @NonNullByDefault({}) ItemChannelLinkRegistry itemChannelLinkRegistry;
+    private @Mock @NonNullByDefault({}) ThingRegistry thingRegistry;
+    private @Mock @NonNullByDefault({}) Inbox inbox;
+    private @Mock @NonNullByDefault({}) ThingTypeRegistry thingTypeRegistry;
+    private @Mock @NonNullByDefault({}) ChannelTypeRegistry channelTypeRegistry;
+    private @Mock @NonNullByDefault({}) ConfigDescriptionRegistry configDescRegistry;
+    private @Mock @NonNullByDefault({}) RuleRegistry ruleRegistry;
+    @SuppressWarnings("rawtypes")
+    private @Mock @NonNullByDefault({}) TemplateRegistry templateRegistry;
+    private @Mock @NonNullByDefault({}) SitemapFactory sitemapFactory;
+    private @Mock @NonNullByDefault({}) SitemapRegistry sitemapRegistry;
+    private @Mock @NonNullByDefault({}) ThingSerializer thingSerializer;
+    private @Mock @NonNullByDefault({}) HttpHeaders httpHeaders;
+
+    private @NonNullByDefault({}) FileFormatResource resource;
+
+    @BeforeEach
+    public void setUp() {
+        ConfigUtilAccessor.setEnv(Map.of("HOSTNAME", "openhab-host"));
+        resource = new FileFormatResource(semanticTagRegistry, itemBuilderFactory, itemRegistry, metadataRegistry,
+                itemChannelLinkRegistry, thingRegistry, inbox, thingTypeRegistry, channelTypeRegistry,
+                configDescRegistry, ruleRegistry, templateRegistry, sitemapFactory, sitemapRegistry);
+        when(thingSerializer.getGeneratedFormat()).thenReturn("DSL");
+        resource.addThingSerializer(thingSerializer);
+        when(httpHeaders.getHeaderString(HttpHeaders.ACCEPT)).thenReturn(ACCEPT_DSL_THING);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        ConfigUtilAccessor.resetEnv();
+    }
+
+    @Test
+    public void createUsesRawValuesWhenFallingBackToThingDTOMapper() {
+        ThingTypeUID thingTypeUID = new ThingTypeUID("binding", "type");
+        ThingUID thingUID = new ThingUID(thingTypeUID, "thing");
+
+        ThingDTO thingDTO = new ThingDTO();
+        thingDTO.thingTypeUID = thingTypeUID.getAsString();
+        thingDTO.UID = thingUID.getAsString();
+        thingDTO.configuration = Map.of("thingParam", RAW_PLACEHOLDER);
+
+        ChannelDTO channelDTO = new ChannelDTO();
+        channelDTO.uid = new ChannelUID(thingUID, "channel1").getAsString();
+        channelDTO.itemType = CoreItemFactory.STRING;
+        channelDTO.kind = "STATE";
+        channelDTO.configuration = Map.of("channelParam", RAW_PLACEHOLDER);
+        channelDTO.properties = Map.of();
+        channelDTO.defaultTags = Set.of();
+        thingDTO.channels = List.of(channelDTO);
+
+        FileFormatDTO data = new FileFormatDTO();
+        data.things = List.of(thingDTO);
+
+        when(thingRegistry.createThingOfType(any(), any(), any(), any(), any())).thenReturn(null);
+
+        try (Response response = resource.create(httpHeaders, false, false, false, RuleSerializationOption.NORMAL,
+                data)) {
+            assertThat(response.getStatus(), is(200));
+        }
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Thing>> captor = (ArgumentCaptor<List<Thing>>) (ArgumentCaptor<?>) ArgumentCaptor
+                .forClass(List.class);
+        verify(thingSerializer).setThingsToBeSerialized(anyString(), captor.capture(), anyBoolean(), anyBoolean());
+        Thing serializedThing = captor.getValue().getFirst();
+        assertThat(serializedThing.getConfiguration().get("thingParam"), is("openhab-host"));
+        assertThat(serializedThing.getConfiguration().getRawProperties().get("thingParam"), is(RAW_PLACEHOLDER));
+        assertThat(serializedThing.getChannels().getFirst().getConfiguration().get("channelParam"), is("openhab-host"));
+        assertThat(serializedThing.getChannels().getFirst().getConfiguration().getRawProperties().get("channelParam"),
+                is(RAW_PLACEHOLDER));
+    }
+
+    @Test
+    public void createPassesRawConfigurationToThingFactoryPath() {
+        ThingTypeUID thingTypeUID = new ThingTypeUID("binding", "type");
+        ThingUID thingUID = new ThingUID(thingTypeUID, "thing");
+
+        ThingDTO thingDTO = new ThingDTO();
+        thingDTO.thingTypeUID = thingTypeUID.getAsString();
+        thingDTO.UID = thingUID.getAsString();
+        thingDTO.configuration = Map.of("thingParam", RAW_PLACEHOLDER);
+
+        FileFormatDTO data = new FileFormatDTO();
+        data.things = List.of(thingDTO);
+
+        when(thingRegistry.createThingOfType(any(), any(), any(), any(), any())).thenReturn(mock(Thing.class));
+
+        try (Response response = resource.create(httpHeaders, false, false, false, RuleSerializationOption.NORMAL,
+                data)) {
+            assertThat(response.getStatus(), is(200));
+        }
+
+        ArgumentCaptor<Configuration> configCaptor = ArgumentCaptor.forClass(Configuration.class);
+        verify(thingRegistry).createThingOfType(any(ThingTypeUID.class), any(ThingUID.class), any(), any(),
+                configCaptor.capture());
+        assertThat(configCaptor.getValue().get("thingParam"), is("openhab-host"));
+        assertThat(configCaptor.getValue().getRawProperties().get("thingParam"), is(RAW_PLACEHOLDER));
+    }
+}

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResourceTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -25,19 +26,30 @@ import java.util.Map;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.openhab.core.config.core.ConfigUtil;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingRegistry;
 import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.link.ItemChannelLink;
 import org.openhab.core.thing.link.ItemChannelLinkRegistry;
 import org.openhab.core.thing.link.ManagedItemChannelLinkProvider;
+import org.openhab.core.thing.link.dto.ItemChannelLinkDTO;
 import org.openhab.core.thing.profiles.ProfileTypeRegistry;
+import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelTypeRegistry;
 
 /**
@@ -60,13 +72,29 @@ public class ItemChannelLinkResourceTest {
     private @Mock @NonNullByDefault({}) ManagedItemChannelLinkProvider managedItemChannelLinkProviderMock;
     private @NonNullByDefault({}) ItemChannelLinkResource itemChannelLinkResource;
 
+    private static class ConfigUtilAccessor extends ConfigUtil {
+        static void setEnv(Map<String, String> values) {
+            setEnvProvider(values::get);
+        }
+
+        static void resetEnv() {
+            setEnvProvider(System::getenv);
+        }
+    }
+
     @BeforeEach
     public void setup() {
         itemChannelLinkResource = new ItemChannelLinkResource(itemRegistryMock, thingRegistryMock,
                 channelTypeRegistryMock, profileTypeRegistryMock, itemChannelLinkRegistryMock,
                 managedItemChannelLinkProviderMock);
+        ConfigUtilAccessor.setEnv(Map.of("HOSTNAME", "openhab-host"));
         when(itemChannelLinkRegistryMock.removeLinksForItem(any())).thenReturn(EXPECTED_REMOVED_LINKS);
         when(itemChannelLinkRegistryMock.removeLinksForThing(any())).thenReturn(EXPECTED_REMOVED_LINKS);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        ConfigUtilAccessor.resetEnv();
     }
 
     @Test
@@ -91,5 +119,30 @@ public class ItemChannelLinkResourceTest {
         }
 
         verify(itemChannelLinkRegistryMock).removeLinksForThing(eq(new ThingUID("binding:type:thing")));
+    }
+
+    @Test
+    public void testLinkUsesRawConfigurationValues() throws ItemNotFoundException {
+        String itemName = "testItem";
+        ChannelUID channelUID = new ChannelUID("binding:type:thing:channel");
+        ItemChannelLinkDTO dto = new ItemChannelLinkDTO(itemName, channelUID.getAsString(),
+                Map.of("host", "${ENV:HOSTNAME}"));
+
+        when(itemRegistryMock.getItem(itemName)).thenReturn(mock(Item.class));
+
+        Channel channel = mock(Channel.class);
+        when(channel.getKind()).thenReturn(ChannelKind.STATE);
+        Thing thing = mock(Thing.class);
+        when(thing.getChannel(channelUID)).thenReturn(channel);
+        when(thingRegistryMock.get(channelUID.getThingUID())).thenReturn(thing);
+
+        try (Response response = itemChannelLinkResource.link(itemName, channelUID.getAsString(), dto)) {
+            assertThat(response.getStatus(), is(200));
+        }
+
+        ArgumentCaptor<ItemChannelLink> captor = ArgumentCaptor.forClass(ItemChannelLink.class);
+        verify(itemChannelLinkRegistryMock).add(captor.capture());
+        assertThat(captor.getValue().getConfiguration().get("host"), is("openhab-host"));
+        assertThat(captor.getValue().getConfiguration().getRawProperties().get("host"), is("${ENV:HOSTNAME}"));
     }
 }

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/thing/EnrichedThingDTOMapperTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/thing/EnrichedThingDTOMapperTest.java
@@ -67,6 +67,7 @@ public class EnrichedThingDTOMapperTest {
         when(thingMock.getLabel()).thenReturn(THING_LABEL);
         when(thingMock.getChannels()).thenReturn(mockChannels());
         when(thingMock.getConfiguration()).thenReturn(configurationMock);
+        when(configurationMock.getRawProperties()).thenReturn(Map.of());
         when(thingMock.getProperties()).thenReturn(propertiesMock);
         when(thingMock.getLocation()).thenReturn(LOCATION);
     }

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
@@ -64,13 +64,13 @@ import org.slf4j.LoggerFactory
 
 /**
  * {@link ThingProvider} implementation which computes *.things files.
- * 
+ *
  * @author Oliver Libutzki - Initial contribution
  * @author niehues - Fix ESH Bug 450236
  *         https://bugs.eclipse.org/bugs/show_bug.cgi?id=450236 - Considering
  *         ThingType Description
- * @author Simon Kaufmann - Added asynchronous retry in case the handler 
- *         factory cannot load a thing yet (bug 470368), 
+ * @author Simon Kaufmann - Added asynchronous retry in case the handler
+ *         factory cannot load a thing yet (bug 470368),
  *         added delay until ThingTypes are fully loaded
  * @author Markus Rathgeb - Add locale provider support
  * @author Laurent Garnier - Add method getAllFromModel + do not notify the thing registry for isolated models
@@ -198,8 +198,8 @@ class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implement
             return #[]
         }
 
-        // construct the thingUID up front: this will ensure that short notation things with reference to a bridge 
-        // do not end up with the bridge id in their id. 
+        // construct the thingUID up front: this will ensure that short notation things with reference to a bridge
+        // do not end up with the bridge id in their id.
         things.forEach([thingId = thingId ?: constructThingUID.toString])
         things.filter(typeof(ModelBridge)).forEach([
             val bridge = it;
@@ -342,8 +342,8 @@ class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implement
         if (keepSourceConfig) {
             target.setProperties(Map.of())
         }
-        source.keySet.forEach [
-            target.put(it, source.get(it))
+        source.rawProperties.keySet.forEach [
+            target.put(it, source.rawProperties.get(it))
         ]
     }
 
@@ -436,15 +436,15 @@ class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implement
     }
 
     def private createConfiguration(ModelPropertyContainer propertyContainer) {
-        val configuration = new Configuration
+        val properties = <String, Object>newHashMap
         propertyContainer.properties.forEach [
             if (value.size === 1) {
-                configuration.put(key, value.get(0))
+                properties.put(key, value.get(0))
             } else {
-                configuration.put(key, value)
+                properties.put(key, value)
             }
         ]
-        configuration
+        new Configuration(properties)
     }
 
     def private getThingType(ThingTypeUID thingTypeUID) {

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/rules/YamlModuleDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/rules/YamlModuleDTO.java
@@ -51,7 +51,7 @@ public class YamlModuleDTO {
         this.label = module.getLabel();
         this.description = module.getDescription();
         this.type = ModuleTypeAliases.typeToAlias(module.getClass(), module.getTypeUID());
-        this.config = new LinkedHashMap<>(module.getConfiguration().getProperties());
+        this.config = new LinkedHashMap<>(module.getConfiguration().getRawProperties());
         if (this.config.containsKey("script") && this.config.get("type") instanceof String type) {
             String typeAlias = MIMETypeAliases.mimeTypeToAlias(type);
             if (!type.equals(typeAlias)) {

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/rules/YamlRuleDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/rules/YamlRuleDTO.java
@@ -100,7 +100,7 @@ public class YamlRuleDTO implements ModularDTO<YamlRuleDTO, ObjectMapper, JsonNo
                 ? rule.getVisibility()
                 : null;
         if (option != RuleSerializationOption.STRIP_TEMPLATE) {
-            this.config = new LinkedHashMap<>(rule.getConfiguration().getProperties());
+            this.config = new LinkedHashMap<>(rule.getConfiguration().getRawProperties());
             if (option != RuleSerializationOption.INCLUDE_ALL) {
                 this.config.remove(Rule.SOURCE);
                 this.config.remove(Rule.SOURCE_TYPE);

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlThingProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlThingProvider.java
@@ -14,7 +14,6 @@ package org.openhab.core.model.yaml.internal.things;
 
 import static org.openhab.core.model.yaml.YamlModelUtils.isIsolatedModel;
 
-import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -514,28 +513,26 @@ public class YamlThingProvider extends AbstractProvider<Thing>
         target.setLocation(source.getLocation());
         target.setBridgeUID(source.getBridgeUID());
 
+        Configuration targetConfig = target.getConfiguration();
         if (keepSourceConfig) {
-            target.getConfiguration().setProperties(Map.of());
+            targetConfig.setProperties(Map.of());
         }
-        Configuration thingConfig = processThingConfiguration(target.getThingTypeUID(), target.getUID(),
+        Configuration processedSourceConfig = processThingConfiguration(target.getThingTypeUID(), target.getUID(),
                 source.getConfiguration());
-        thingConfig.keySet().forEach(paramName -> {
-            target.getConfiguration().put(paramName, thingConfig.get(paramName));
-        });
+        processedSourceConfig.getRawProperties().forEach(targetConfig::put);
 
         List<Channel> channelsToAdd = new ArrayList<>();
         source.getChannels().forEach(channel -> {
             Channel targetChannel = target.getChannels().stream().filter(c -> c.getUID().equals(channel.getUID()))
                     .findFirst().orElse(null);
             if (targetChannel != null) {
+                Configuration targetChannelConfig = targetChannel.getConfiguration();
                 if (keepSourceConfig) {
-                    targetChannel.getConfiguration().setProperties(Map.of());
+                    targetChannelConfig.setProperties(Map.of());
                 }
                 Configuration channelConfig = processChannelConfiguration(targetChannel.getChannelTypeUID(),
                         targetChannel.getUID(), channel.getConfiguration());
-                channelConfig.keySet().forEach(paramName -> {
-                    targetChannel.getConfiguration().put(paramName, channelConfig.get(paramName));
-                });
+                channelConfig.getRawProperties().forEach(targetChannelConfig::put);
             } else {
                 Channel newChannel = channel;
                 if (channel.getChannelTypeUID() != null) {
@@ -607,11 +604,12 @@ public class YamlThingProvider extends AbstractProvider<Thing>
     }
 
     private Object processSingleTextParam(UID uid, String name, Object param) {
-        if (param instanceof Number || param instanceof Boolean) {
+        Object normalizedParam = ConfigUtil.normalizeType(param);
+        if (normalizedParam instanceof Number || normalizedParam instanceof Boolean) {
             logger.info(
                     "\"{}\": the value of TEXT configuration parameter \"{}\" has been interpreted as a {}, and will "
                             + "be converted to a string. Enclose your value in double quotes to prevent conversion.",
-                    uid, name, param instanceof Boolean ? "boolean" : "number");
+                    uid, name, normalizedParam instanceof Boolean ? "boolean" : "number");
             // if the value in YAML is an unquoted number, the value resulting of the parsing can then be
             // of type BigDecimal or BigInteger.
             // If the value is of type BigDecimal, we convert it into a String. If there is no decimal,
@@ -621,18 +619,18 @@ public class YamlThingProvider extends AbstractProvider<Thing>
             // - Value 1.5 in YAML is converted into String "1.5"
             // If the value is not of type BigDecimal, it is kept unchanged. Conversion to a String will
             // be applied at a next step during configuration normalization.
-            if (param instanceof BigDecimal bigDecimalValue) {
+            if (normalizedParam instanceof BigDecimal bigDecimalValue) {
                 try {
                     Object result = bigDecimalValue.stripTrailingZeros().scale() <= 0
                             ? String.valueOf(bigDecimalValue.toBigIntegerExact().longValue())
                             : bigDecimalValue.toString();
-                    logger.trace("config param {}: {} ({}) converted into {} ({})", name, param,
-                            param.getClass().getSimpleName(), result, result.getClass().getSimpleName());
+                    logger.trace("config param {}: {} ({}) converted into {} ({})", name, normalizedParam,
+                            normalizedParam.getClass().getSimpleName(), result, result.getClass().getSimpleName());
                     return result;
                 } catch (ArithmeticException e) {
                     // Ignore error and return the original value
                 }
-            } else if (param instanceof Boolean bool) {
+            } else if (normalizedParam instanceof Boolean bool) {
                 return bool.booleanValue() ? "true" : "false";
             }
         }
@@ -640,34 +638,41 @@ public class YamlThingProvider extends AbstractProvider<Thing>
     }
 
     private Configuration processConfiguration(UID uid, Configuration configuration, Set<String> textParameters) {
-        Map<String, Object> params = new HashMap<>();
-        Object value;
-        String name;
-        for (Entry<String, Object> entry : configuration.getProperties().entrySet()) {
-            name = entry.getKey();
-            value = entry.getValue();
-            if (textParameters.contains(name)) {
-                if (value instanceof Iterable<?> iterable) {
-                    List<Object> elements = new ArrayList<>();
-                    for (Object element : iterable) {
-                        elements.add(processSingleTextParam(uid, name, element));
-                    }
-                    value = elements;
-                } else if (value instanceof Object && value.getClass().isArray()) {
-                    List<Object> elements = new ArrayList<>();
-                    int length = Array.getLength(value);
-                    for (int i = 0; i < length; i++) {
-                        elements.add(processSingleTextParam(uid, name, Array.get(value, i)));
-                    }
-                    value = elements;
-                } else {
-                    value = processSingleTextParam(uid, name, value);
-                }
+        Configuration processedConfig = new Configuration(configuration);
+        for (Entry<String, Object> entry : configuration.getRawProperties().entrySet()) {
+            String name = entry.getKey();
+            Object value = entry.getValue();
+            if (value == null || !textParameters.contains(name)) {
+                continue; // Skip entirely if it's not a text parameter
             }
-            params.put(name, value);
+            processedConfig.put(name, processValue(uid, name, value, textParameters));
+        }
+        return processedConfig;
+    }
+
+    private @Nullable Object processValue(UID uid, String name, @Nullable Object value, Set<String> textParameters) {
+        if (value == null) {
+            return null;
         }
 
-        return new Configuration(params);
+        if (value instanceof Map<?, ?> map) {
+            Map<String, @Nullable Object> processedMap = new HashMap<>();
+            for (Entry<?, ?> entry : map.entrySet()) {
+                String subKey = String.valueOf(entry.getKey());
+                processedMap.put(subKey, processValue(uid, subKey, entry.getValue(), textParameters));
+            }
+            return processedMap;
+        } else if (value instanceof Iterable<?> iterable) {
+            List<@Nullable Object> elements = new ArrayList<>();
+            for (Object element : iterable) {
+                elements.add(processValue(uid, name, element, textParameters));
+            }
+            return elements;
+        }
+
+        // Since processConfiguration already checked textParameters.contains(name),
+        // any leaf node reaching here is guaranteed to be a target text parameter.
+        return processSingleTextParam(uid, name, value);
     }
 
     private Set<String> getThingConfigTextParameters(ThingTypeUID thingTypeUID, ThingUID thingUID) {

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/rules/YamlRuleProviderTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/rules/YamlRuleProviderTest.java
@@ -49,6 +49,7 @@ import org.openhab.core.common.registry.Provider;
 import org.openhab.core.common.registry.ProviderChangeListener;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
+import org.openhab.core.config.core.ConfigUtil;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.config.core.FilterCriteria;
 import org.openhab.core.config.core.ParameterOption;
@@ -75,10 +76,26 @@ public class YamlRuleProviderTest {
     private @TempDir @NonNullByDefault({}) Path watchPath;
     private @NonNullByDefault({}) Path rulesPath;
 
+    private static class ConfigUtilAccessor extends ConfigUtil {
+        static void setEnv(Map<String, String> values) {
+            setEnvProvider(values::get);
+        }
+
+        static void resetEnv() {
+            setEnvProvider(System::getenv);
+        }
+    }
+
     @BeforeEach
     public void setup() {
         rulesPath = watchPath.resolve(RULES_PATH);
+        ConfigUtilAccessor.setEnv(Map.of("OPENHAB_TEST_DO_NOT_SET", "openhab-host"));
         when(watchServiceMock.getWatchPath()).thenReturn(watchPath);
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    public void tearDown() {
+        ConfigUtilAccessor.resetEnv();
     }
 
     @Test
@@ -199,6 +216,46 @@ public class YamlRuleProviderTest {
         assertThat(action.getConfiguration().getProperties(), hasEntry("text", "The sleep temperature has been set"));
         assertThat(action.getConfiguration().getProperties(), is(aMapWithSize(2)));
         assertThat(action.getInputs(), is(anEmptyMap()));
+    }
+
+    @Test
+    public void rawPlaceholdersArePreservedInRuleConfigurationsTest() throws IOException {
+        String model = """
+                version: 1
+                rules:
+                  raw:test:
+                    label: Raw Placeholder Rule
+                    config:
+                      sourceItem: '${ENV:OPENHAB_TEST_DO_NOT_SET}'
+                    triggers:
+                      - id: "1"
+                        config:
+                          time: "14:05"
+                        type: timer.TimeOfDayTrigger
+                    actions:
+                      - id: "2"
+                        config:
+                          sink: webaudio
+                          text: '${ENV:OPENHAB_TEST_DO_NOT_SET}'
+                        type: media.SayAction
+                """;
+        Files.writeString(rulesPath, model);
+
+        YamlModelRepositoryImpl modelRepository = new YamlModelRepositoryImpl(watchServiceMock, readyServiceMock);
+        YamlRuleProvider ruleProvider = new YamlRuleProvider();
+        TestRuleChangeListener ruleListener = new TestRuleChangeListener();
+        ruleProvider.addProviderChangeListener(ruleListener);
+        modelRepository.addYamlModelListener(ruleProvider);
+        modelRepository.processWatchEvent(WatchService.Kind.CREATE, rulesPath);
+
+        assertThat(ruleListener.rules, is(aMapWithSize(1)));
+        Rule rule = ruleListener.rules.values().iterator().next();
+        assertThat(rule.getConfiguration().get("sourceItem"), is("openhab-host"));
+        assertThat(rule.getConfiguration().getRawProperties().get("sourceItem"), is("${ENV:OPENHAB_TEST_DO_NOT_SET}"));
+
+        Action action = rule.getActions().getFirst();
+        assertThat(action.getConfiguration().get("text"), is("openhab-host"));
+        assertThat(action.getConfiguration().getRawProperties().get("text"), is("${ENV:OPENHAB_TEST_DO_NOT_SET}"));
     }
 
     @Test

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/rules/YamlRuleTemplateProviderTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/rules/YamlRuleTemplateProviderTest.java
@@ -48,6 +48,7 @@ import org.openhab.core.common.registry.Provider;
 import org.openhab.core.common.registry.ProviderChangeListener;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
+import org.openhab.core.config.core.ConfigUtil;
 import org.openhab.core.config.core.FilterCriteria;
 import org.openhab.core.config.core.ParameterOption;
 import org.openhab.core.model.yaml.YamlModelUtils;
@@ -73,10 +74,26 @@ public class YamlRuleTemplateProviderTest {
     private @TempDir @NonNullByDefault({}) Path watchPath;
     private @NonNullByDefault({}) Path templatesPath;
 
+    private static class ConfigUtilAccessor extends ConfigUtil {
+        static void setEnv(Map<String, String> values) {
+            setEnvProvider(values::get);
+        }
+
+        static void resetEnv() {
+            setEnvProvider(System::getenv);
+        }
+    }
+
     @BeforeEach
     public void setup() {
         templatesPath = watchPath.resolve(TEMPLATES_PATH);
+        ConfigUtilAccessor.setEnv(Map.of("OPENHAB_TEST_DO_NOT_SET", "openhab-host"));
         when(watchServiceMock.getWatchPath()).thenReturn(watchPath);
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    public void tearDown() {
+        ConfigUtilAccessor.resetEnv();
     }
 
     @Test
@@ -199,6 +216,41 @@ public class YamlRuleTemplateProviderTest {
         assertThat(action.getConfiguration().getProperties(), hasEntry("text", "The sleep temperature has been set"));
         assertThat(action.getConfiguration().getProperties(), is(aMapWithSize(2)));
         assertThat(action.getInputs(), is(anEmptyMap()));
+    }
+
+    @Test
+    public void rawPlaceholdersArePreservedInRuleTemplateConfigurationsTest() throws IOException {
+        String model = """
+                version: 1
+                ruleTemplates:
+                  raw:test-template:
+                    label: Raw Placeholder Template
+                    triggers:
+                      - id: "1"
+                        config:
+                          startlevel: 100
+                        type: core.SystemStartlevelTrigger
+                    actions:
+                      - id: "2"
+                        config:
+                          sink: webaudio
+                          text: '${ENV:OPENHAB_TEST_DO_NOT_SET}'
+                        type: media.SayAction
+                """;
+        Files.writeString(templatesPath, model);
+
+        YamlModelRepositoryImpl modelRepository = new YamlModelRepositoryImpl(watchServiceMock, readyServiceMock);
+        YamlRuleTemplateProvider ruleTemplateProvider = new YamlRuleTemplateProvider();
+        TestRuleTemplateChangeListener templateListener = new TestRuleTemplateChangeListener();
+        ruleTemplateProvider.addProviderChangeListener(templateListener);
+        modelRepository.addYamlModelListener(ruleTemplateProvider);
+        modelRepository.processWatchEvent(WatchService.Kind.CREATE, templatesPath);
+
+        assertThat(templateListener.templates, is(aMapWithSize(1)));
+        RuleTemplate template = templateListener.templates.values().iterator().next();
+        Action action = template.getActions().getFirst();
+        assertThat(action.getConfiguration().get("text"), is("openhab-host"));
+        assertThat(action.getConfiguration().getRawProperties().get("text"), is("${ENV:OPENHAB_TEST_DO_NOT_SET}"));
     }
 
     @Test

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/things/YamlThingProviderTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/things/YamlThingProviderTest.java
@@ -39,6 +39,7 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -149,8 +150,19 @@ public class YamlThingProviderTest {
     private @NonNullByDefault({}) TestThingChangeListener thingListener;
     private @NonNullByDefault({}) NtpThingHandlerFactory thingHandlerFactory;
 
+    private static class ConfigUtilAccessor extends ConfigUtil {
+        static void setEnv(Map<String, String> values) {
+            setEnvProvider(values::get);
+        }
+
+        static void resetEnv() {
+            setEnvProvider(System::getenv);
+        }
+    }
+
     @BeforeEach
     public void setup() {
+        ConfigUtilAccessor.setEnv(Map.of("OPENHAB_TEST_DO_NOT_SET", "openhab-host"));
         fullModelPath = watchPath.resolve(MODEL_PATH);
         when(watchServiceMock.getWatchPath()).thenReturn(watchPath);
 
@@ -243,6 +255,11 @@ public class YamlThingProviderTest {
 
         modelRepository = new YamlModelRepositoryImpl(watchServiceMock, readyServiceMock);
         modelRepository.addYamlModelListener(thingProvider);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        ConfigUtilAccessor.resetEnv();
     }
 
     @Test
@@ -560,6 +577,40 @@ public class YamlThingProviderTest {
         assertEquals(new ChannelUID(NTP_THING_UID2, "date-only-string"), channel.getUID());
         assertThat(channel.getConfiguration().keySet(), contains("DateTimeFormat"));
         assertEquals("true", channel.getConfiguration().get("DateTimeFormat"));
+    }
+
+    @Test
+    public void testRawPlaceholdersArePreservedInThingAndChannelConfigurations() throws IOException {
+        String model = """
+                version: 1
+                things:
+                  ntp:ntp:local:
+                    config:
+                      hostname: '${ENV:OPENHAB_TEST_DO_NOT_SET}'
+                      timeZone: '${ENV:OPENHAB_TEST_DO_NOT_SET}'
+                    channels:
+                      string:
+                        type: string-channel
+                        config:
+                          DateTimeFormat: '${ENV:OPENHAB_TEST_DO_NOT_SET}'
+                """;
+        Files.writeString(fullModelPath, model);
+        modelRepository.processWatchEvent(WatchService.Kind.CREATE, fullModelPath);
+
+        Collection<Thing> things = thingProvider.getAll();
+        assertThat(things, hasSize(1));
+        Thing thing = things.iterator().next();
+
+        assertEquals("openhab-host", thing.getConfiguration().get("hostname"));
+        assertEquals("openhab-host", thing.getConfiguration().get("timeZone"));
+        assertEquals("${ENV:OPENHAB_TEST_DO_NOT_SET}", thing.getConfiguration().getRawProperties().get("hostname"));
+        assertEquals("${ENV:OPENHAB_TEST_DO_NOT_SET}", thing.getConfiguration().getRawProperties().get("timeZone"));
+
+        Channel channel = thing.getChannels().stream().filter(c -> "string".equals(c.getUID().getId())).findFirst()
+                .orElseThrow();
+        assertEquals("openhab-host", channel.getConfiguration().get("DateTimeFormat"));
+        assertEquals("${ENV:OPENHAB_TEST_DO_NOT_SET}",
+                channel.getConfiguration().getRawProperties().get("DateTimeFormat"));
     }
 
     @Test

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
@@ -23,7 +23,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.config.core.ConfigDescription;
-import org.openhab.core.config.core.ConfigUtil;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.config.core.validation.ConfigValidationException;
 import org.openhab.core.thing.Bridge;
@@ -75,8 +74,6 @@ public abstract class BaseThingHandler implements ThingHandler {
             .getScheduledPool(THING_HANDLER_THREADPOOL_NAME);
 
     protected Thing thing;
-
-    private volatile @Nullable Configuration resolvedConfig;
 
     private @Nullable ThingHandlerCallback callback;
 
@@ -135,7 +132,7 @@ public abstract class BaseThingHandler implements ThingHandler {
      * @return true if the parameters would result in a modified configuration, false otherwise
      */
     protected boolean isModifyingCurrentConfig(Map<String, Object> configurationParameters) {
-        Configuration currentConfig = getRawConfig();
+        Map<String, Object> currentConfig = getConfig().getRawProperties();
         for (Entry<String, Object> entry : configurationParameters.entrySet()) {
             if (!Objects.equals(currentConfig.get(entry.getKey()), entry.getValue())) {
                 return true;
@@ -157,18 +154,7 @@ public abstract class BaseThingHandler implements ThingHandler {
     @Override
     public void thingUpdated(Thing thing) {
         dispose();
-        Configuration resolvedConfiguration;
-        try {
-            resolvedConfiguration = ConfigUtil.resolveVariables(thing.getConfiguration());
-        } catch (IllegalArgumentException e) {
-            logger.warn("Updated thing '{}' with a thing containing invalid configuration '{}': {}", thing.getUID(),
-                    thing.getConfiguration(), e.getMessage());
-            resolvedConfiguration = thing.getConfiguration();
-        }
-        synchronized (this) {
-            this.thing = thing;
-            this.resolvedConfig = resolvedConfiguration;
-        }
+        this.thing = thing;
         initialize();
     }
 
@@ -253,16 +239,6 @@ public abstract class BaseThingHandler implements ThingHandler {
     }
 
     /**
-     * Returns the raw configuration of the thing.
-     * Variable patterns are not resolved.
-     *
-     * @return raw configuration of the thing
-     */
-    private Configuration getRawConfig() {
-        return getThing().getConfiguration();
-    }
-
-    /**
      * Returns the configuration of the thing.
      * Variable patterns are automatically resolved to the variable value.
      *
@@ -273,22 +249,7 @@ public abstract class BaseThingHandler implements ThingHandler {
      * @return configuration of the thing
      */
     protected Configuration getConfig() {
-        Configuration resolvedConfig = this.resolvedConfig;
-        if (resolvedConfig == null) {
-            synchronized (this) {
-                resolvedConfig = this.resolvedConfig;
-                if (resolvedConfig == null) {
-                    try {
-                        this.resolvedConfig = resolvedConfig = ConfigUtil.resolveVariables(getRawConfig());
-                    } catch (IllegalArgumentException e) {
-                        logger.warn("Failed to resolve variables for configuration '{}' of thing '{}': {}",
-                                getRawConfig(), getThing().getUID(), e.getMessage());
-                        return new Configuration(getRawConfig());
-                    }
-                }
-            }
-        }
-        return new Configuration(resolvedConfig);
+        return getThing().getConfiguration();
     }
 
     /**
@@ -520,18 +481,14 @@ public abstract class BaseThingHandler implements ThingHandler {
                     this.getClass().getSimpleName(), thing.getUID());
             return;
         }
-        Configuration resolvedConfiguration;
         try {
-            resolvedConfiguration = ConfigUtil.resolveVariables(thing.getConfiguration());
+            callback.validateConfigurationParameters(thing, thing.getConfiguration().getProperties());
+            thing.getChannels().forEach(channel -> callback.validateConfigurationParameters(channel,
+                    channel.getConfiguration().getProperties()));
         } catch (IllegalArgumentException e) {
             logger.warn("Attempt to update thing '{}' with a thing containing invalid configuration '{}' blocked: {}",
                     thing.getUID(), thing.getConfiguration(), e.getMessage());
             return;
-        }
-        try {
-            callback.validateConfigurationParameters(thing, resolvedConfiguration.getProperties());
-            thing.getChannels().forEach(channel -> callback.validateConfigurationParameters(channel,
-                    channel.getConfiguration().getProperties()));
         } catch (ConfigValidationException e) {
             logger.warn(
                     "Attempt to update thing '{}' with a thing containing invalid configuration '{}' blocked. This is most likely a bug: {}",
@@ -539,7 +496,6 @@ public abstract class BaseThingHandler implements ThingHandler {
             return;
         }
         synchronized (this) {
-            this.resolvedConfig = resolvedConfiguration;
             this.thing = thing;
             callback.thingUpdated(thing);
         }
@@ -552,8 +508,7 @@ public abstract class BaseThingHandler implements ThingHandler {
      * @return copy of the thing configuration (not null)
      */
     protected Configuration editConfiguration() {
-        Map<String, Object> properties = getRawConfig().getProperties();
-        return new Configuration(new HashMap<>(properties));
+        return new Configuration(getConfig());
     }
 
     /**
@@ -565,24 +520,19 @@ public abstract class BaseThingHandler implements ThingHandler {
      * @param configuration configuration, that was updated and should be persisted
      */
     protected void updateConfiguration(Configuration configuration) {
-        Map<String, Object> old = getRawConfig().getProperties();
-        Configuration oldResolved = getConfig();
+        Map<String, Object> old = getConfig().getRawProperties();
         ThingHandlerCallback callback = this.callback;
         if (callback == null) {
             logger.warn("Handler {} tried updating its configuration although the handler was already disposed.",
                     this.getClass().getSimpleName());
             return;
         }
-        Configuration resolvedConfiguration;
         try {
-            resolvedConfiguration = ConfigUtil.resolveVariables(configuration);
+            callback.validateConfigurationParameters(this.thing, configuration.getProperties());
         } catch (IllegalArgumentException e) {
             logger.warn("Attempt to apply configuration '{}' on thing '{}' blocked: {}", configuration, thing.getUID(),
                     e.getMessage());
             return;
-        }
-        try {
-            callback.validateConfigurationParameters(this.thing, resolvedConfiguration.getProperties());
         } catch (ConfigValidationException e) {
             logger.warn(
                     "Attempt to apply invalid configuration '{}' on thing '{}' blocked. This is most likely a bug: {}",
@@ -591,8 +541,7 @@ public abstract class BaseThingHandler implements ThingHandler {
         }
         try {
             synchronized (this) {
-                this.resolvedConfig = resolvedConfiguration;
-                this.thing.getConfiguration().setProperties(configuration.getProperties());
+                this.thing.getConfiguration().setProperties(configuration.getRawProperties());
                 callback.thingUpdated(thing);
             }
         } catch (RuntimeException e) {
@@ -601,7 +550,6 @@ public abstract class BaseThingHandler implements ThingHandler {
                     e.getClass().getSimpleName(), e.getMessage(), this.thing.getUID().getAsString());
             synchronized (this) {
                 this.thing.getConfiguration().setProperties(old);
-                this.resolvedConfig = oldResolved;
             }
             throw e;
         }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ChannelDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ChannelDTO.java
@@ -77,11 +77,6 @@ public class ChannelDTO {
         if (configuration == null) {
             return null;
         }
-
-        Map<String, Object> configurationMap = new HashMap<>(configuration.keySet().size());
-        for (String key : configuration.keySet()) {
-            configurationMap.put(key, configuration.get(key));
-        }
-        return configurationMap;
+        return new HashMap<>(configuration.getRawProperties());
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingDTOMapper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingDTOMapper.java
@@ -80,10 +80,6 @@ public class ThingDTOMapper {
     }
 
     private static Map<String, Object> toMap(Configuration configuration) {
-        Map<String, Object> configurationMap = new HashMap<>(configuration.keySet().size());
-        for (String key : configuration.keySet()) {
-            configurationMap.put(key, configuration.get(key));
-        }
-        return configurationMap;
+        return new HashMap<>(configuration.getRawProperties());
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/fileconverter/AbstractThingSerializer.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/fileconverter/AbstractThingSerializer.java
@@ -16,6 +16,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -114,6 +115,7 @@ public abstract class AbstractThingSerializer implements ThingSerializer {
     private List<ConfigParameter> getConfigurationParameters(
             List<ConfigDescriptionParameter> configDescriptionParameter, Configuration configParameters,
             boolean hideDefaultParameters) {
+        Map<String, Object> rawConfigParameters = configParameters.getRawProperties();
         List<ConfigParameter> parameters = new ArrayList<>();
         Set<String> handledNames = new HashSet<>();
         for (ConfigDescriptionParameter param : configDescriptionParameter) {
@@ -121,18 +123,18 @@ public abstract class AbstractThingSerializer implements ThingSerializer {
             if (handledNames.contains(paramName)) {
                 continue;
             }
-            Object value = configParameters.get(paramName);
+            Object value = rawConfigParameters.get(paramName);
             Object defaultValue = ConfigUtil.getDefaultValueAsCorrectType(param);
             if (value != null && (!hideDefaultParameters || !value.equals(defaultValue))) {
                 parameters.add(new ConfigParameter(paramName, value));
             }
             handledNames.add(paramName);
         }
-        for (String paramName : configParameters.keySet().stream().sorted().collect(Collectors.toList())) {
+        for (String paramName : rawConfigParameters.keySet().stream().sorted().toList()) {
             if (handledNames.contains(paramName)) {
                 continue;
             }
-            Object value = configParameters.get(paramName);
+            Object value = rawConfigParameters.get(paramName);
             if (value != null) {
                 parameters.add(new ConfigParameter(paramName, value));
             }
@@ -189,13 +191,11 @@ public abstract class AbstractThingSerializer implements ThingSerializer {
     }
 
     private boolean channelWithNonDefaultConfig(Channel channel) {
+        Map<String, Object> rawConfiguration = channel.getConfiguration().getRawProperties();
         for (ConfigDescriptionParameter param : getConfigDescriptionParameters(channel)) {
-            Object value = channel.getConfiguration().get(param.getName());
-            if (value != null) {
-                value = ConfigUtil.normalizeType(value, param);
-                if (!value.equals(ConfigUtil.getDefaultValueAsCorrectType(param))) {
-                    return true;
-                }
+            Object value = rawConfiguration.get(param.getName());
+            if (value != null && !value.equals(ConfigUtil.getDefaultValueAsCorrectType(param))) {
+                return true;
             }
         }
         return false;

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -708,7 +708,7 @@ public class ThingManagerImpl implements ReadyTracker, ThingManager, ThingTracke
         }
 
         Objects.requireNonNull(ConfigUtil.normalizeTypes(configuration.getProperties(), List.of(configDescription)))
-                .forEach(configuration::put);
+                .forEach(configuration::putNormalized);
     }
 
     private void doInitializeHandler(final ThingHandler thingHandler) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/events/LinkEventFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/events/LinkEventFactory.java
@@ -106,6 +106,6 @@ public class LinkEventFactory extends AbstractEventFactory {
 
     private static ItemChannelLinkDTO map(ItemChannelLink itemChannelLink) {
         return new ItemChannelLinkDTO(itemChannelLink.getItemName(), itemChannelLink.getLinkedUID().toString(),
-                itemChannelLink.getConfiguration().getProperties());
+                itemChannelLink.getConfiguration().getRawProperties());
     }
 }

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/dto/ThingDTOTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/dto/ThingDTOTest.java
@@ -18,9 +18,17 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.openhab.core.config.core.ConfigUtil;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.thing.Bridge;
@@ -42,11 +50,33 @@ import org.openhab.core.thing.internal.ThingImpl;
  * @author Andrew Fiddian-Green - Added semanticEquipmentTag
  */
 @NonNullByDefault
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = "org.openhab.core.config.core.ConfigUtil", mode = ResourceAccessMode.READ_WRITE)
 public class ThingDTOTest {
 
     private static final ThingTypeUID THING_TYPE_UID = new ThingTypeUID("binding-id", "thing-type-id");
     private static final ThingUID THING_UID = new ThingUID(THING_TYPE_UID, "thing-id");
     private final Map<String, String> properties = Map.of("key1", "value1");
+
+    private static class ConfigUtilAccessor extends ConfigUtil {
+        static void setEnv(Map<String, String> values) {
+            setEnvProvider(values::get);
+        }
+
+        static void resetEnv() {
+            setEnvProvider(System::getenv);
+        }
+    }
+
+    @BeforeEach
+    public void setUp() {
+        ConfigUtilAccessor.setEnv(Map.of("HOSTNAME", "openhab-host"));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        ConfigUtilAccessor.resetEnv();
+    }
 
     @Test
     public void testThingDTOMappingIsBidirectional() {
@@ -76,6 +106,46 @@ public class ThingDTOTest {
         Bridge subject = BridgeBuilder.create(THING_TYPE_UID, THING_UID).build();
         Thing result = ThingDTOMapper.map(ThingDTOMapper.map(subject), true);
         assertThat(result, is(instanceOf(BridgeImpl.class)));
+    }
+
+    @Test
+    public void testThingDTOMappingUsesRawConfigurationValues() {
+        Thing subject = ThingBuilder.create(THING_TYPE_UID, THING_UID)
+                .withConfiguration(new Configuration(Map.of("param1", "${ENV:HOSTNAME}")))
+                .withChannels(ChannelBuilder.create(new ChannelUID(THING_UID, "channel1"), CoreItemFactory.STRING)
+                        .withConfiguration(new Configuration(Map.of("param2", "${ENV:HOSTNAME}"))).build())
+                .build();
+
+        ThingDTO dto = ThingDTOMapper.map(subject);
+
+        assertThat(dto.configuration.get("param1"), is("${ENV:HOSTNAME}"));
+        assertThat(dto.channels.getFirst().configuration.get("param2"), is("${ENV:HOSTNAME}"));
+    }
+
+    @Test
+    public void testThingDTOMappingFromDtoPreservesRawConfigurationValues() {
+        ThingDTO dto = new ThingDTO();
+        dto.thingTypeUID = THING_TYPE_UID.getAsString();
+        dto.UID = THING_UID.getAsString();
+        dto.configuration = Map.of("param1", "${ENV:HOSTNAME}");
+
+        ChannelDTO channelDTO = new ChannelDTO();
+        channelDTO.uid = new ChannelUID(THING_UID, "channel1").getAsString();
+        channelDTO.itemType = CoreItemFactory.STRING;
+        channelDTO.kind = "STATE";
+        channelDTO.configuration = Map.of("param2", "${ENV:HOSTNAME}");
+        channelDTO.properties = Map.of();
+        channelDTO.defaultTags = Set.of();
+
+        dto.channels = List.of(channelDTO);
+
+        Thing thing = ThingDTOMapper.map(dto, false);
+
+        assertThat(thing.getConfiguration().get("param1"), is("openhab-host"));
+        assertThat(thing.getConfiguration().getRawProperties().get("param1"), is("${ENV:HOSTNAME}"));
+        assertThat(thing.getChannels().getFirst().getConfiguration().get("param2"), is("openhab-host"));
+        assertThat(thing.getChannels().getFirst().getConfiguration().getRawProperties().get("param2"),
+                is("${ENV:HOSTNAME}"));
     }
 
     private void assertThatChannelsArePresent(List<Channel> actual, List<Channel> expected) {

--- a/itests/org.openhab.core.model.rule.tests/src/main/java/org/openhab/core/model/rule/runtime/DSLRuleProviderTest.java
+++ b/itests/org.openhab.core.model.rule.tests/src/main/java/org/openhab/core/model/rule/runtime/DSLRuleProviderTest.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.xtext.naming.QualifiedName;
@@ -51,6 +52,7 @@ import org.openhab.core.automation.internal.module.handler.TimeOfDayConditionHan
 import org.openhab.core.automation.internal.module.handler.TimeOfDayTriggerHandler;
 import org.openhab.core.automation.module.script.internal.handler.AbstractScriptModuleHandler;
 import org.openhab.core.automation.module.script.internal.handler.ScriptActionHandler;
+import org.openhab.core.config.core.ConfigUtil;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.model.core.ModelRepository;
 import org.openhab.core.model.rule.jvmmodel.RulesRefresher;
@@ -74,8 +76,19 @@ public class DSLRuleProviderTest extends JavaOSGiTest {
     private @NonNullByDefault({}) DSLRuleProvider dslRuleProvider;
     private @NonNullByDefault({}) ReadyService readyService;
 
+    private static class ConfigUtilAccessor extends ConfigUtil {
+        static void setEnv(Map<String, String> values) {
+            setEnvProvider(values::get);
+        }
+
+        static void resetEnv() {
+            setEnvProvider(System::getenv);
+        }
+    }
+
     @BeforeEach
     public void setup() {
+        ConfigUtilAccessor.setEnv(Map.of("OPENHAB_TEST_DO_NOT_SET", "openhab-host"));
         registerVolatileStorageService();
 
         EventPublisher eventPublisher = event -> {
@@ -100,6 +113,7 @@ public class DSLRuleProviderTest extends JavaOSGiTest {
     @AfterEach
     public void tearDown() {
         modelRepository.removeModel(TESTMODEL_NAME);
+        ConfigUtilAccessor.resetEnv();
     }
 
     @Test
@@ -461,5 +475,30 @@ public class DSLRuleProviderTest extends JavaOSGiTest {
         Collection<Rule> actualRules = dslRuleProvider.getAll();
 
         assertThat(actualRules.size(), is(1));
+    }
+
+    @Test
+    public void testRawPlaceholderIsPreservedInScriptConfiguration() {
+        Collection<Rule> rules = dslRuleProvider.getAll();
+        assertThat(rules.size(), is(0));
+
+        String model = """
+                rule RawPlaceholderRule
+                when
+                   System started
+                then
+                   logInfo("Test", "${ENV:OPENHAB_TEST_DO_NOT_SET}")
+                end
+                """;
+
+        modelRepository.addOrRefreshModel(TESTMODEL_NAME,
+                new ByteArrayInputStream(model.getBytes(StandardCharsets.UTF_8)));
+        Collection<Rule> actualRules = dslRuleProvider.getAll();
+        assertThat(actualRules.size(), is(1));
+
+        Rule rule = actualRules.iterator().next();
+        String rawScript = (String) rule.getActions().getFirst().getConfiguration().getRawProperties()
+                .get(AbstractScriptModuleHandler.CONFIG_SCRIPT);
+        assertThat(rawScript, containsString("${ENV:OPENHAB_TEST_DO_NOT_SET}"));
     }
 }


### PR DESCRIPTION
## Summary
The primary goal of this pull request is to shift the raw / pattern resolution from `BaseThingHandler` into the `Configuration` class itself, ensuring that environment variable and pattern resolutions apply uniformly to all users of the `Configuration` class. To accomplish this, the PR cleanly distinguishes between raw (uninterpolated) configuration properties and resolved/normalized properties across openHAB core's configuration management, REST APIs, DTO mappers, file/YAML providers, and serializers.

Essentially this makes the configuration objects return the resolved values without any special steps. 
By taking this approach, all current and future users of the Configuration class continues to work without any changes.

The scenario is flipped. Getting the raw values require special steps instead of the other way around. The raw values are only needed in certain places on the storage/presentation layer, but not the runtime layer, and that's what the bulk of this PR is dealing with.

---

## Key Changes by Component

### 1. Core Configuration (`bundles/org.openhab.core.config.core`)
* **`Configuration.java`**: 
  * Added a separate `normalizedProperties` map alongside the existing `properties` map to cache resolved and normalized configuration values.
  * Introduced `getRawProperties()` to return an unmodifiable copy of the raw, uninterpolated properties.
  * Added `putNormalized(String key, Object value)` to insert pre-normalized values directly into the cache without clobbering or overwriting the raw value that may contain env patterns.
  * Updated `get(String key)` to lazily resolve variable patterns and normalize types on demand, caching the result.
* **`ConfigurationSerializer.java`**: Updated JSON serialization to use `getRawProperties()` so that raw placeholders are serialized rather than their resolved runtime values.
* **`ConfigUtil.java`**: Updated utility methods to align with the new raw/normalized property handling structure.

### 2. REST APIs & DTO Mappers (`bundles/org.openhab.core.automation.rest`, `bundles/org.openhab.core.automation`, `bundles/org.openhab.core.io.rest.core`)
* **Rule & Module Mappers/Resources**: Updated `RuleResource`, `RuleDTOMapper`, and `ModuleDTOMapper` to fetch configuration properties via `getRawProperties()`.
* **Thing & Link Mappers/Resources**: Modified `ThingResource`, `FileFormatItemDTOMapper`, `FileFormatResource`, `EnrichedItemChannelLinkDTOMapper`, and `LinkEventFactory` to expose raw configuration properties instead of evaluated ones.

### 3. Providers and Serializers (`bundles/org.openhab.core.model.thing`, `bundles/org.openhab.core.model.yaml`, `bundles/org.openhab.core.thing`)
* **YAML Providers & DTOs**: Updated `YamlThingProvider`, `YamlRuleDTO`, and `YamlModuleDTO` to correctly process and preserve raw configuration placeholders during YAML model loading and exporting.
* **Thing Handlers & Serializers**: Refactored `BaseThingHandler` and `AbstractThingSerializer` to interact with raw properties and configuration maps appropriately without triggering premature variable resolution.

### 4. Test Coverage (`*Test.java`)
* Added and updated comprehensive unit and integration tests across multiple bundles (`ConfigurationTest`, `FileFormatResourceTest`, `ItemChannelLinkResourceTest`, `ThingDTOTest`, `YamlRuleProviderTest`, `YamlRuleTemplateProviderTest`, `YamlThingProviderTest`, `DSLRuleProviderTest`).
* These tests explicitly verify that environment variable placeholders (e.g., `${ENV:HOSTNAME}`) are correctly resolved when accessed via `get()` or `as()`, while remaining preserved as raw strings in `getRawProperties()` and serialization outputs.

---

The above summary / description was AI generated based on the PR diff and some steering.

More details:

- Things
  - Things Config and Channel Config can use ${ENV} 
  - The ${ENV} appears in MainUI Thing details / code / config sheet
  - The actual config that the Thing / channel uses is the resolved value, not the raw ${ENV}
- Items
  - ${ENV} is usable in item-channel link profile config.
  - MainUI continues to show the ${ENV} 
  - The actual profile config uses the resolved value
- Rules
  - ${ENV} is usable in rule module (trigger/action/condition) config, as well as in Rule config itself
- Pages 
  -  Pages config is a simple Map, it doesn't use the Configuration class so it doesn't apply

More importantly: other types of add-ons beyond bindings can also benefit from the $ENV resolution.

This should solve https://github.com/openhab/openhab-addons/issues/21356 possibly without requiring any changes to be made on the binding itself.