### PR TITLE
[io.net] Fix shutdown hang: keep the shared thread pool alive until both clients are stopped

### DIFF
--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/WebClientFactoryImpl.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/WebClientFactoryImpl.java
@@ -136,6 +136,13 @@ public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory
             commonWebSocketClient = null;
             logger.debug("Jetty shared web socket client stopped");
         }
+        if (threadPool != null) {
+            try {
+                threadPool.stop();
+            } catch (Exception e) {
+                logger.error("error while stopping shared Jetty thread pool", e);
+            }
+        }
         threadPool = null;
     }
 
@@ -227,6 +234,18 @@ public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory
         try {
             if (threadPool == null) {
                 threadPool = createThreadPool("common", minThreadsShared, maxThreadsShared, keepAliveTimeoutShared);
+                // The pool is shared between the http client and the web socket client. Start it
+                // ourselves so both Jetty containers treat it as an unmanaged bean and neither
+                // stops it while the other client is still using it (see the shared-bean rule in
+                // Jetty's ContainerLifeCycle javadoc). It is stopped explicitly in deactivate().
+                try {
+                    threadPool.start();
+                } catch (Exception e) {
+                    // roll back so a later initialize() retry recreates the pool
+                    // instead of reusing a dead one
+                    threadPool = null;
+                    throw e;
+                }
             }
 
             if (commonHttpClient == null) {

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/WebClientFactoryImpl.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/WebClientFactoryImpl.java
@@ -240,6 +240,10 @@ public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory
                 // Jetty's ContainerLifeCycle javadoc). It is stopped explicitly in deactivate().
                 try {
                     threadPool.start();
+                    // Set the stop timeout right after starting the pool we now own. We need the
+                    // stop timeout in order to prevent blocking the deactivation of this
+                    // component, see https://github.com/eclipse/smarthome/issues/6632
+                    threadPool.setStopTimeout(0);
                 } catch (Exception e) {
                     // roll back so a later initialize() retry recreates the pool
                     // instead of reusing a dead one
@@ -250,11 +254,6 @@ public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory
 
             if (commonHttpClient == null) {
                 commonHttpClient = createHttpClientInternal("common", null, true, threadPool);
-                // we need to set the stop timeout AFTER the client has been started, because
-                // otherwise the Jetty client sets it back to the default value.
-                // We need the stop timeout in order to prevent blocking the deactivation of this
-                // component, see https://github.com/eclipse/smarthome/issues/6632
-                threadPool.setStopTimeout(0);
                 logger.debug("Jetty shared http client created");
             }
 

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/internal/WebClientFactoryImplTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/internal/WebClientFactoryImplTest.java
@@ -74,7 +74,15 @@ public class WebClientFactoryImplTest {
         // tear down the shared thread pool underneath the common WebSocketClient, whose selector
         // then died with a ClosedSelectorException and deactivate() blocked forever.
         // Deactivation must always complete.
-        Thread deactivateThread = new Thread(() -> webClientFactory.deactivate());
+        deactivateWithTimeout();
+    }
+
+    private void deactivateWithTimeout() throws InterruptedException {
+        // Regression-safe: run deactivate() on a DAEMON thread so a blocked
+        // deactivation can neither keep the test JVM alive nor leak a running
+        // non-daemon thread into subsequent tests; fail loudly via the assert.
+        Thread deactivateThread = new Thread(() -> webClientFactory.deactivate(), "webClientFactory-deactivate");
+        deactivateThread.setDaemon(true);
         deactivateThread.start();
         deactivateThread.join(10_000);
         assertThat("deactivate() did not complete", deactivateThread.isAlive(), is(false));
@@ -105,7 +113,7 @@ public class WebClientFactoryImplTest {
         assertThat(sharedPool.isRunning(), is(true));
 
         // deactivation stops the pool itself, after both clients
-        webClientFactory.deactivate();
+        deactivateWithTimeout();
         assertThat(sharedPool.isRunning(), is(false));
     }
 

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/internal/WebClientFactoryImplTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/internal/WebClientFactoryImplTest.java
@@ -78,22 +78,15 @@ public class WebClientFactoryImplTest {
     }
 
     private void deactivateWithTimeout() throws InterruptedException {
-        // Regression-safe: run deactivate() on a DAEMON thread so a blocked
-        // deactivation can neither keep the test JVM alive nor leak a running
-        // non-daemon thread into subsequent tests; fail loudly via the assert.
         Thread deactivateThread = new Thread(() -> webClientFactory.deactivate(), "webClientFactory-deactivate");
         deactivateThread.setDaemon(true);
         deactivateThread.start();
         deactivateThread.join(10_000);
 
-        // Capture the verdict BEFORE interrupting: the interrupt is cleanup, not a second chance.
-        // If it unblocked the deactivation, this test still has to report the timeout it observed,
-        // otherwise a real shutdown regression would pass.
+        // Capture the verdict before interrupting: the interrupt is cleanup, so an interrupt that
+        // happens to unblock the deactivation must not turn an observed timeout into a pass.
         boolean timedOut = deactivateThread.isAlive();
         if (timedOut) {
-            // Best effort to release a blocked deactivation instead of leaving it running next to
-            // the following tests; the daemon flag above remains the final safeguard for the case
-            // where Jetty does not react to the interrupt at all.
             deactivateThread.interrupt();
         }
         assertThat("deactivate() did not complete", timedOut, is(false));

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/internal/WebClientFactoryImplTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/internal/WebClientFactoryImplTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -36,6 +37,7 @@ import javax.net.ssl.SSLHandshakeException;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,12 +70,14 @@ public class WebClientFactoryImplTest {
 
     @AfterEach
     public void tearDown() throws InterruptedException {
-        // Sometimes a java.nio.channels.ClosedSelectorException occurs when the commonWebSocketClient
-        // is stopped while its threads are still starting. This would cause webClientFactory.deactivate()
-        // to block forever so continue if it has not completed after 2 seconds.
+        // Regression check for the former shutdown hang: stopping the common HTTP client used to
+        // tear down the shared thread pool underneath the common WebSocketClient, whose selector
+        // then died with a ClosedSelectorException and deactivate() blocked forever.
+        // Deactivation must always complete.
         Thread deactivateThread = new Thread(() -> webClientFactory.deactivate());
         deactivateThread.start();
-        deactivateThread.join(2000);
+        deactivateThread.join(10_000);
+        assertThat("deactivate() did not complete", deactivateThread.isAlive(), is(false));
     }
 
     @Test
@@ -83,6 +87,26 @@ public class WebClientFactoryImplTest {
 
         assertThat(httpClient, is(notNullValue()));
         assertThat(webSocketClient, is(notNullValue()));
+    }
+
+    @Test
+    public void testSharedThreadPoolIsUnmanagedAndStoppedByDeactivate() throws Exception {
+        HttpClient httpClient = webClientFactory.getCommonHttpClient();
+        WebSocketClient webSocketClient = webClientFactory.getCommonWebSocketClient();
+
+        Executor executor = httpClient.getExecutor();
+        assertThat(executor, is(instanceOf(QueuedThreadPool.class)));
+        QueuedThreadPool sharedPool = (QueuedThreadPool) executor;
+
+        // both clients use the same pool, but neither container manages its lifecycle
+        assertThat(webSocketClient.getHttpClient().getExecutor(), is(sameInstance(executor)));
+        assertThat(httpClient.isManaged(sharedPool), is(false));
+        assertThat(webSocketClient.getHttpClient().isManaged(sharedPool), is(false));
+        assertThat(sharedPool.isRunning(), is(true));
+
+        // deactivation stops the pool itself, after both clients
+        webClientFactory.deactivate();
+        assertThat(sharedPool.isRunning(), is(false));
     }
 
     @Disabled("connecting to the outside world makes this test flaky")

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/internal/WebClientFactoryImplTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/internal/WebClientFactoryImplTest.java
@@ -85,7 +85,18 @@ public class WebClientFactoryImplTest {
         deactivateThread.setDaemon(true);
         deactivateThread.start();
         deactivateThread.join(10_000);
-        assertThat("deactivate() did not complete", deactivateThread.isAlive(), is(false));
+
+        // Capture the verdict BEFORE interrupting: the interrupt is cleanup, not a second chance.
+        // If it unblocked the deactivation, this test still has to report the timeout it observed,
+        // otherwise a real shutdown regression would pass.
+        boolean timedOut = deactivateThread.isAlive();
+        if (timedOut) {
+            // Best effort to release a blocked deactivation instead of leaving it running next to
+            // the following tests; the daemon flag above remains the final safeguard for the case
+            // where Jetty does not react to the interrupt at all.
+            deactivateThread.interrupt();
+        }
+        assertThat("deactivate() did not complete", timedOut, is(false));
     }
 
     @Test


### PR DESCRIPTION
## Description

`WebClientFactoryImpl` shares one `QueuedThreadPool` between the common Jetty `HttpClient` and the common `WebSocketClient`, but hands it over **unstarted**. Jetty's `ContainerLifeCycle.addBean(Object)` heuristic therefore makes the pool a MANAGED bean of the first client started with it (the common `HttpClient`, which implicitly starts the pool during its own start), while the `WebSocketClient` — created after the pool is already running — merely borrows it as an UNMANAGED bean. `deactivate()` stops the owning HttpClient first, which tears the shared pool down while the WebSocketClient's `ManagedSelector` is still running on it. The selector thread dies with `java.nio.channels.ClosedSelectorException` without draining its update queue, and the subsequent `commonWebSocketClient.stop()` then waits forever on the latches in Jetty 9.4's timeout-less `ManagedSelector.doStop()` — freezing the entire framework shutdown until the service supervisor SIGKILLs the JVM.

Observed on openHAB 5.2.1 (openHABian/RPi4, Jetty 9.4.58): intermittent shutdown hangs (5 of 8 stops on one day, identical stack), `TimeoutStopSec` (600 s) exhausted, SIGKILL mid-deactivation (which once truncated `log4j2.xml`). The hang occurs with **zero active WebSocket connections** — it is the pool teardown, not connection activity. Full analysis with thread dumps and the timing chain available on request.

Fingerprint during a hang:

```
[WARN] [org.eclipse.jetty.io.ManagedSelector] - java.nio.channels.ClosedSelectorException

"Framework stop - Equinox Container" WAITING on CountDownLatch
    org.eclipse.jetty.io.ManagedSelector.doStop(ManagedSelector.java:140)
    org.eclipse.jetty.client.HttpClient.doStop(HttpClient.java:294)
    org.eclipse.jetty.websocket.client.WebSocketClient.doStop(WebSocketClient.java:429)
    org.openhab.core.io.net.http.internal.WebClientFactoryImpl.deactivate(WebClientFactoryImpl.java:131)
```

## The fix

Jetty's own `ContainerLifeCycle` javadoc prescribes it:

> "If adding a bean that is shared between multiple ContainerLifeCycle instances, then it should be started before being added, so it is unmanaged, or the API must be used to explicitly set it as unmanaged."

So: start the pool in `initialize()` before handing it to the clients (an already-started bean is added UNMANAGED, so neither client stops it anymore), and stop it explicitly as the **last** step of `deactivate()`. If `threadPool.start()` fails, the field is rolled back to `null` so a later lazy `initialize()` retry recreates the pool instead of reusing a dead one. The `setStopTimeout(0)` mitigation from eclipse/smarthome#6632 keeps covering the pool's own stop, so deactivation cannot block there either.

No runtime behavior changes: the pool ran from the first client start before; it still does.

## Testing

- `mvn clean install -pl bundles/org.openhab.core.io.net`: BUILD SUCCESS on this branch and on the 5.2.1 tag; 39 tests, 0 failures (4 skipped, pre-existing).
- A 5.2.1-based build of this fix is deployed on the affected installation. A verification stop shows the previously-never-reached second debug line 2 ms after the first (`Jetty shared http client stopped` → `Jetty shared web socket client stopped`), no `ClosedSelectorException`; in every hang the second line never appeared. Longer-term observation is running with a scoped DEBUG logger on `org.openhab.core.io.net.http.internal` recording the deactivation order of every future shutdown.

Related: eclipse/smarthome#6632 (2018 predecessor of this hang, mitigated with `setStopTimeout(0)`), #3315 (Jetty 9.4 EOL umbrella — this is a minimal self-contained correction until the Jetty upgrade lands).
