### PR TITLE
Keep resolveConfig in sync

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
@@ -157,6 +157,19 @@ public abstract class BaseThingHandler implements ThingHandler {
     @Override
     public void thingUpdated(Thing thing) {
         dispose();
+        setThing(thing);
+        initialize();
+    }
+
+    /**
+     * Replaces the {@link Thing} handled by this handler and refreshes its resolved configuration.
+     * <p>
+     * Custom {@link #thingUpdated(Thing)} implementations should use this method instead of assigning directly to
+     * {@link #thing}, so the Thing and resolved configuration remain consistent.
+     *
+     * @param thing the updated Thing
+     */
+    protected final void setThing(Thing thing) {
         Configuration resolvedConfiguration;
         try {
             resolvedConfiguration = ConfigUtil.resolveVariables(thing.getConfiguration());
@@ -169,7 +182,6 @@ public abstract class BaseThingHandler implements ThingHandler {
             this.thing = thing;
             this.resolvedConfig = resolvedConfiguration;
         }
-        initialize();
     }
 
     @Override

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/BaseThingHandlerTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/BaseThingHandlerTest.java
@@ -66,6 +66,10 @@ class BaseThingHandlerTest {
         public void initialize() {
             this.configInInitialize = getConfig();
         }
+
+        public void replaceThing(Thing thing) {
+            setThing(thing);
+        }
     }
 
     private static class ConfigUtilAccessor extends ConfigUtil {
@@ -119,6 +123,18 @@ class BaseThingHandlerTest {
         Thing thing = handler.editThing()
                 .withConfiguration(new Configuration(Map.of("p1", "${ENV:FOO}", "p2", "${ENV:BAR}"))).build();
         handler.thingUpdated(thing);
+
+        assertEquals("resolved-foo", handler.getConfig().get("p1"));
+        assertEquals("resolved-bar", handler.getConfig().get("p2"));
+    }
+
+    @Test
+    public void testResolvedConfigAfterSetThing() {
+        handler.getConfig();
+        Thing thing = handler.editThing()
+                .withConfiguration(new Configuration(Map.of("p1", "${ENV:FOO}", "p2", "${ENV:BAR}"))).build();
+
+        handler.replaceThing(thing);
 
         assertEquals("resolved-foo", handler.getConfig().get("p1"));
         assertEquals("resolved-bar", handler.getConfig().get("p2"));


### PR DESCRIPTION
As a follow up to https://github.com/openhab/openhab-core/pull/5568/

That PR made the `BaseThingHandler` caches the resolved Thing configuration in `resolvedConfig`.

The default `thingUpdated(Thing)` implementation updates both the Thing and this cache. Custom implementations cannot do the same because `resolvedConfig` is private. Assigning a new value to `this.thing` can therefore leave `getConfig()` and `getConfigAs()` returning configuration resolved from the previous Thing.

This change extracts the existing replacement logic into a protected final `setThing(Thing)` method. The default `thingUpdated(Thing)` implementation uses this method, so its behavior remains unchanged.

Custom implementations can now replace the Thing without using the default dispose/reinitialize lifecycle while keeping the resolved configuration cache in sync.

A unit test was added that populates the old cache, replaces the Thing using `setThing()`, and verifies that the new resolved configuration is returned.
