### PR TITLE
[rest] Do not report a missing store strategy when another config stores the items

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -87,6 +87,7 @@ import org.openhab.core.persistence.registry.ManagedPersistenceServiceConfigurat
 import org.openhab.core.persistence.registry.PersistenceServiceConfiguration;
 import org.openhab.core.persistence.registry.PersistenceServiceConfigurationDTOMapper;
 import org.openhab.core.persistence.registry.PersistenceServiceConfigurationRegistry;
+import org.openhab.core.persistence.strategy.PersistenceCronStrategy;
 import org.openhab.core.persistence.strategy.PersistenceStrategy;
 import org.openhab.core.transform.util.ItemDisplayStateUtil;
 import org.openhab.core.types.State;
@@ -458,37 +459,36 @@ public class PersistenceResource implements RESTResource {
      */
     private static boolean isStoredByAnotherConfig(PersistenceItemConfiguration config,
             List<PersistenceItemConfiguration> configs) {
-        return configs.stream().filter(other -> !other.equals(config))
-                .anyMatch(other -> hasStoreStrategy(other) && coversItems(other, config));
-    }
-
-    /**
-     * A store strategy is any strategy that is not the {@code restoreOnStartup} or {@code forecast} global
-     * strategy. This includes cron strategies, since {@code PersistenceManagerImpl} schedules those into regular
-     * persist jobs just like {@code everyUpdate} and {@code everyChange}.
-     */
-    private static boolean hasStoreStrategy(PersistenceItemConfiguration config) {
-        return config.strategies().stream().anyMatch(strategy -> !PersistenceStrategy.Globals.RESTORE.equals(strategy)
-                && !PersistenceStrategy.Globals.FORECAST.equals(strategy));
-    }
-
-    /**
-     * Determines, conservatively, whether {@code other} is guaranteed to cover every item that {@code config}
-     * selects. This is only provable if {@code other} has no exclude selectors, and either selects all items, or
-     * has a structurally equal counterpart for each of {@code config}'s (non-exclude) selectors. When coverage
-     * cannot be proven this way, the caller must keep warning.
-     */
-    private static boolean coversItems(PersistenceItemConfiguration other, PersistenceItemConfiguration config) {
-        List<PersistenceConfig> otherSelectors = other.items();
-        if (otherSelectors.stream().anyMatch(PersistenceResource::isExcludeSelector)) {
-            return false;
-        }
-        if (otherSelectors.stream().anyMatch(PersistenceAllConfig.class::isInstance)) {
+        // An entry carrying an exclude selector cannot be proven to cover anything, because appliesToItem()
+        // drops the entire entry for the excluded items.
+        List<PersistenceItemConfiguration> storing = configs.stream().filter(other -> !other.equals(config))
+                .filter(PersistenceResource::hasStoreStrategy)
+                .filter(other -> other.items().stream().noneMatch(PersistenceResource::isExcludeSelector)).toList();
+        if (storing.stream()
+                .anyMatch(other -> other.items().stream().anyMatch(PersistenceAllConfig.class::isInstance))) {
             return true;
         }
-        return config.items().stream().filter(selector -> !isExcludeSelector(selector))
-                .allMatch(selector -> otherSelectors.stream()
-                        .anyMatch(otherSelector -> isStructurallyEqual(selector, otherSelector)));
+        List<PersistenceConfig> selectors = config.items().stream().filter(selector -> !isExcludeSelector(selector))
+                .toList();
+        if (selectors.isEmpty()) {
+            return false;
+        }
+        // Coverage is additive too: a selector only has to be found in SOME storing entry, not all of them in
+        // the same one, so "ItemA, ItemB" is covered by two entries storing ItemA and ItemB separately.
+        return selectors.stream().allMatch(selector -> storing.stream().flatMap(other -> other.items().stream())
+                .anyMatch(otherSelector -> isStructurallyEqual(selector, otherSelector)));
+    }
+
+    /**
+     * Only the strategies {@code PersistenceManagerImpl} actually stores for count: {@code everyUpdate},
+     * {@code everyChange} and cron strategies. They are identified positively on purpose - a file-based
+     * configuration may name arbitrary strategies, which {@code PersistenceModelManager} turns into plain
+     * {@link PersistenceStrategy} instances that nothing ever executes. Treating "neither restore nor forecast"
+     * as storing would let such a strategy silence a warning that should fire.
+     */
+    private static boolean hasStoreStrategy(PersistenceItemConfiguration config) {
+        return config.strategies().stream().anyMatch(strategy -> PersistenceStrategy.Globals.UPDATE.equals(strategy)
+                || PersistenceStrategy.Globals.CHANGE.equals(strategy) || strategy instanceof PersistenceCronStrategy);
     }
 
     private static boolean isExcludeSelector(PersistenceConfig selector) {
@@ -509,9 +509,10 @@ public class PersistenceResource implements RESTResource {
         if (selector instanceof PersistenceGroupConfig groupSelector) {
             return groupSelector.getGroup().equals(((PersistenceGroupConfig) otherSelector).getGroup());
         }
-        // Any other PersistenceConfig implementation (e.g. PersistenceAllConfig) has no further distinguishing
-        // state, so matching concrete types is sufficient.
-        return true;
+        // Any other implementation may carry distinguishing state this method does not know about, and calling
+        // two of them equal would silence a warning that should fire. PersistenceAllConfig, the one type where
+        // the class alone is decisive, is handled by the caller before this is reached.
+        return false;
     }
 
     private ZonedDateTime convertTime(String sTime) {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -468,13 +468,10 @@ public class PersistenceResource implements RESTResource {
             return false;
         }
         // An entry carrying an exclude selector cannot be proven to cover anything, because appliesToItem()
-        // drops the entire entry for the excluded items. Neither can an entry carrying filters: coverage must be
-        // provable from the configuration alone, and a filter can veto every write at runtime (e.g. a
-        // PersistenceEqualsFilter whose values the item never takes).
+        // drops the entire entry for the excluded items.
         List<PersistenceItemConfiguration> storing = configs.stream().filter(other -> !other.equals(config))
                 .filter(PersistenceResource::hasStoreStrategy)
-                .filter(other -> other.items().stream().noneMatch(PersistenceResource::isExcludeSelector))
-                .filter(other -> other.filters().isEmpty()).toList();
+                .filter(other -> other.items().stream().noneMatch(PersistenceResource::isExcludeSelector)).toList();
         if (storing.stream()
                 .anyMatch(other -> other.items().stream().anyMatch(PersistenceAllConfig.class::isInstance))) {
             return true;

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -72,6 +72,12 @@ import org.openhab.core.persistence.PersistenceService;
 import org.openhab.core.persistence.PersistenceServiceProblem;
 import org.openhab.core.persistence.PersistenceServiceRegistry;
 import org.openhab.core.persistence.QueryablePersistenceService;
+import org.openhab.core.persistence.config.PersistenceAllConfig;
+import org.openhab.core.persistence.config.PersistenceConfig;
+import org.openhab.core.persistence.config.PersistenceGroupConfig;
+import org.openhab.core.persistence.config.PersistenceGroupExcludeConfig;
+import org.openhab.core.persistence.config.PersistenceItemConfig;
+import org.openhab.core.persistence.config.PersistenceItemExcludeConfig;
 import org.openhab.core.persistence.dto.ItemHistoryDTO;
 import org.openhab.core.persistence.dto.PersistenceCronStrategyDTO;
 import org.openhab.core.persistence.dto.PersistenceServiceConfigurationDTO;
@@ -122,6 +128,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * @author Wouter Born - Migrated to OpenAPI annotations
  * @author Mark Herwege - Implement aliases
  * @author Mark Herwege - Make default strategy to be only a configuration suggestion
+ * @author Martin Littkovsky - Do not report a missing store strategy when another configuration stores the items
  */
 @Component
 @JaxrsResource
@@ -425,7 +432,8 @@ public class PersistenceResource implements RESTResource {
                             persistenceProblems.add(new PersistenceServiceProblem(
                                     PersistenceServiceProblem.PERSISTENCE_NO_STRATEGY, serviceId, items, editable));
                         } else if (strategies.size() == 1
-                                && PersistenceStrategy.Globals.RESTORE.equals(strategies.getFirst())) {
+                                && PersistenceStrategy.Globals.RESTORE.equals(strategies.getFirst())
+                                && !isStoredByAnotherConfig(config, configs)) {
                             persistenceProblems.add(new PersistenceServiceProblem(
                                     PersistenceServiceProblem.PERSISTENCE_NO_STORE_STRATEGY, serviceId, items,
                                     editable));
@@ -435,6 +443,75 @@ public class PersistenceResource implements RESTResource {
             }
         }
         return JSONResponse.createResponse(Status.OK, persistenceProblems, null);
+    }
+
+    /**
+     * Checks whether the items of {@code config} (which itself only has a {@code restoreOnStartup} strategy) are
+     * actually stored by another configuration entry of the same persistence service. Persistence application is
+     * additive: every configuration entry that matches an item is applied to it, so a
+     * {@link PersistenceServiceProblem#PERSISTENCE_NO_STORE_STRATEGY} warning would be a false positive whenever
+     * another entry both has a store strategy and provably covers the same items.
+     *
+     * @param config the configuration entry that only has a {@code restoreOnStartup} strategy
+     * @param configs all configuration entries of the same persistence service
+     * @return true if another entry with a store strategy provably covers {@code config}'s items
+     */
+    private static boolean isStoredByAnotherConfig(PersistenceItemConfiguration config,
+            List<PersistenceItemConfiguration> configs) {
+        return configs.stream().filter(other -> !other.equals(config))
+                .anyMatch(other -> hasStoreStrategy(other) && coversItems(other, config));
+    }
+
+    /**
+     * A store strategy is any strategy that is not the {@code restoreOnStartup} or {@code forecast} global
+     * strategy. This includes cron strategies, since {@code PersistenceManagerImpl} schedules those into regular
+     * persist jobs just like {@code everyUpdate} and {@code everyChange}.
+     */
+    private static boolean hasStoreStrategy(PersistenceItemConfiguration config) {
+        return config.strategies().stream().anyMatch(strategy -> !PersistenceStrategy.Globals.RESTORE.equals(strategy)
+                && !PersistenceStrategy.Globals.FORECAST.equals(strategy));
+    }
+
+    /**
+     * Determines, conservatively, whether {@code other} is guaranteed to cover every item that {@code config}
+     * selects. This is only provable if {@code other} has no exclude selectors, and either selects all items, or
+     * has a structurally equal counterpart for each of {@code config}'s (non-exclude) selectors. When coverage
+     * cannot be proven this way, the caller must keep warning.
+     */
+    private static boolean coversItems(PersistenceItemConfiguration other, PersistenceItemConfiguration config) {
+        List<PersistenceConfig> otherSelectors = other.items();
+        if (otherSelectors.stream().anyMatch(PersistenceResource::isExcludeSelector)) {
+            return false;
+        }
+        if (otherSelectors.stream().anyMatch(PersistenceAllConfig.class::isInstance)) {
+            return true;
+        }
+        return config.items().stream().filter(selector -> !isExcludeSelector(selector))
+                .allMatch(selector -> otherSelectors.stream()
+                        .anyMatch(otherSelector -> isStructurallyEqual(selector, otherSelector)));
+    }
+
+    private static boolean isExcludeSelector(PersistenceConfig selector) {
+        return selector instanceof PersistenceItemExcludeConfig || selector instanceof PersistenceGroupExcludeConfig;
+    }
+
+    /**
+     * Compares two selectors by concrete type and identifying field, since the {@link PersistenceConfig}
+     * implementations do not override {@link Object#equals(Object)}.
+     */
+    private static boolean isStructurallyEqual(PersistenceConfig selector, PersistenceConfig otherSelector) {
+        if (selector.getClass() != otherSelector.getClass()) {
+            return false;
+        }
+        if (selector instanceof PersistenceItemConfig itemSelector) {
+            return itemSelector.getItem().equals(((PersistenceItemConfig) otherSelector).getItem());
+        }
+        if (selector instanceof PersistenceGroupConfig groupSelector) {
+            return groupSelector.getGroup().equals(((PersistenceGroupConfig) otherSelector).getGroup());
+        }
+        // Any other PersistenceConfig implementation (e.g. PersistenceAllConfig) has no further distinguishing
+        // state, so matching concrete types is sufficient.
+        return true;
     }
 
     private ZonedDateTime convertTime(String sTime) {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -459,19 +459,25 @@ public class PersistenceResource implements RESTResource {
      */
     private static boolean isStoredByAnotherConfig(PersistenceItemConfiguration config,
             List<PersistenceItemConfiguration> configs) {
-        // An entry carrying an exclude selector cannot be proven to cover anything, because appliesToItem()
-        // drops the entire entry for the excluded items.
-        List<PersistenceItemConfiguration> storing = configs.stream().filter(other -> !other.equals(config))
-                .filter(PersistenceResource::hasStoreStrategy)
-                .filter(other -> other.items().stream().noneMatch(PersistenceResource::isExcludeSelector)).toList();
-        if (storing.stream()
-                .anyMatch(other -> other.items().stream().anyMatch(PersistenceAllConfig.class::isInstance))) {
-            return true;
-        }
+        // An entry that selects nothing positively (only excludes) covers no items, so it can never be stored by
+        // another entry. This must be checked before the all-items shortcut below, otherwise a '*' store entry
+        // would vacuously suppress the warning for such an entry.
         List<PersistenceConfig> selectors = config.items().stream().filter(selector -> !isExcludeSelector(selector))
                 .toList();
         if (selectors.isEmpty()) {
             return false;
+        }
+        // An entry carrying an exclude selector cannot be proven to cover anything, because appliesToItem()
+        // drops the entire entry for the excluded items. Neither can an entry carrying filters: coverage must be
+        // provable from the configuration alone, and a filter can veto every write at runtime (e.g. a
+        // PersistenceEqualsFilter whose values the item never takes).
+        List<PersistenceItemConfiguration> storing = configs.stream().filter(other -> !other.equals(config))
+                .filter(PersistenceResource::hasStoreStrategy)
+                .filter(other -> other.items().stream().noneMatch(PersistenceResource::isExcludeSelector))
+                .filter(other -> other.filters().isEmpty()).toList();
+        if (storing.stream()
+                .anyMatch(other -> other.items().stream().anyMatch(PersistenceAllConfig.class::isInstance))) {
+            return true;
         }
         // Coverage is additive too: a selector only has to be found in SOME storing entry, not all of them in
         // the same one, so "ItemA, ItemB" is covered by two entries storing ItemA and ItemB separately.

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
@@ -68,6 +68,7 @@ import org.openhab.core.persistence.PersistenceServiceRegistry;
 import org.openhab.core.persistence.config.PersistenceAllConfig;
 import org.openhab.core.persistence.config.PersistenceConfig;
 import org.openhab.core.persistence.config.PersistenceGroupConfig;
+import org.openhab.core.persistence.config.PersistenceItemConfig;
 import org.openhab.core.persistence.config.PersistenceItemExcludeConfig;
 import org.openhab.core.persistence.dto.ItemHistoryDTO;
 import org.openhab.core.persistence.dto.ItemHistoryDTO.HistoryDataBean;
@@ -601,6 +602,54 @@ public class PersistenceResourceTest {
         List<PersistenceServiceProblem> problems = getPersistenceProblems();
 
         assertThat(countNoStoreStrategyProblems(problems, PERSISTENCE_SERVICE_ID), is(0L));
+    }
+
+    @Test
+    public void testHealthArbitraryNamedStrategyDoesNotCountAsStoring() throws IOException {
+        when(persistenceServiceRegistryMock.getAll()).thenReturn(Set.of(pServiceMock));
+        PersistenceItemConfiguration restoreOnlyGroup = itemConfiguration(List.of(PersistenceStrategy.Globals.RESTORE),
+                new PersistenceGroupConfig(RESTORE_ONLY_GROUP));
+        // A file-based configuration may name any strategy; PersistenceModelManager turns it into a plain
+        // PersistenceStrategy that PersistenceManagerImpl never acts on, so it stores nothing.
+        PersistenceItemConfiguration namedStrategySameGroup = itemConfiguration(
+                List.of(new PersistenceStrategy("someNamedStrategy")), new PersistenceGroupConfig(RESTORE_ONLY_GROUP));
+        mockServiceConfiguration(PERSISTENCE_SERVICE_ID, restoreOnlyGroup, namedStrategySameGroup);
+
+        List<PersistenceServiceProblem> problems = getPersistenceProblems();
+
+        assertThat(countNoStoreStrategyProblems(problems, PERSISTENCE_SERVICE_ID), is(1L));
+    }
+
+    @Test
+    public void testHealthCoverageMayBeSplitAcrossStoreConfigurations() throws IOException {
+        when(persistenceServiceRegistryMock.getAll()).thenReturn(Set.of(pServiceMock));
+        // Coverage is additive as well: neither store entry covers both items on its own.
+        PersistenceItemConfiguration restoreTwoItems = itemConfiguration(List.of(PersistenceStrategy.Globals.RESTORE),
+                new PersistenceItemConfig("ItemA"), new PersistenceItemConfig("ItemB"));
+        PersistenceItemConfiguration storeItemA = itemConfiguration(List.of(PersistenceStrategy.Globals.CHANGE),
+                new PersistenceItemConfig("ItemA"));
+        PersistenceItemConfiguration storeItemB = itemConfiguration(List.of(PersistenceStrategy.Globals.UPDATE),
+                new PersistenceItemConfig("ItemB"));
+        mockServiceConfiguration(PERSISTENCE_SERVICE_ID, restoreTwoItems, storeItemA, storeItemB);
+
+        List<PersistenceServiceProblem> problems = getPersistenceProblems();
+
+        assertThat(countNoStoreStrategyProblems(problems, PERSISTENCE_SERVICE_ID), is(0L));
+    }
+
+    @Test
+    public void testHealthPartiallySplitCoverageStillReported() throws IOException {
+        when(persistenceServiceRegistryMock.getAll()).thenReturn(Set.of(pServiceMock));
+        // Only one of the two selectors is covered - the entry must still be reported.
+        PersistenceItemConfiguration restoreTwoItems = itemConfiguration(List.of(PersistenceStrategy.Globals.RESTORE),
+                new PersistenceItemConfig("ItemA"), new PersistenceItemConfig("ItemB"));
+        PersistenceItemConfiguration storeItemA = itemConfiguration(List.of(PersistenceStrategy.Globals.CHANGE),
+                new PersistenceItemConfig("ItemA"));
+        mockServiceConfiguration(PERSISTENCE_SERVICE_ID, restoreTwoItems, storeItemA);
+
+        List<PersistenceServiceProblem> problems = getPersistenceProblems();
+
+        assertThat(countNoStoreStrategyProblems(problems, PERSISTENCE_SERVICE_ID), is(1L));
     }
 
     private static PersistenceItemConfiguration itemConfiguration(List<PersistenceStrategy> strategies,

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
@@ -72,6 +72,7 @@ import org.openhab.core.persistence.config.PersistenceItemConfig;
 import org.openhab.core.persistence.config.PersistenceItemExcludeConfig;
 import org.openhab.core.persistence.dto.ItemHistoryDTO;
 import org.openhab.core.persistence.dto.ItemHistoryDTO.HistoryDataBean;
+import org.openhab.core.persistence.filter.PersistenceEqualsFilter;
 import org.openhab.core.persistence.internal.PersistenceManagerImpl;
 import org.openhab.core.persistence.registry.ManagedPersistenceServiceConfigurationProvider;
 import org.openhab.core.persistence.registry.PersistenceServiceConfiguration;
@@ -646,6 +647,39 @@ public class PersistenceResourceTest {
         PersistenceItemConfiguration storeItemA = itemConfiguration(List.of(PersistenceStrategy.Globals.CHANGE),
                 new PersistenceItemConfig("ItemA"));
         mockServiceConfiguration(PERSISTENCE_SERVICE_ID, restoreTwoItems, storeItemA);
+
+        List<PersistenceServiceProblem> problems = getPersistenceProblems();
+
+        assertThat(countNoStoreStrategyProblems(problems, PERSISTENCE_SERVICE_ID), is(1L));
+    }
+
+    @Test
+    public void testHealthCoveredOnlyByFilteredEntryStillReported() throws IOException {
+        when(persistenceServiceRegistryMock.getAll()).thenReturn(Set.of(pServiceMock));
+        // Coverage must be provable from the configuration alone. A filtered store entry cannot prove it: the
+        // filter can veto every single write at runtime, e.g. an equals filter whose values the item never takes.
+        PersistenceItemConfiguration everyChangeAllFiltered = new PersistenceItemConfiguration(
+                List.of(new PersistenceAllConfig()), List.of(PersistenceStrategy.Globals.CHANGE),
+                List.of(new PersistenceEqualsFilter("onlyOn", List.of("ON"), false)));
+        PersistenceItemConfiguration restoreOnlyGroup = itemConfiguration(List.of(PersistenceStrategy.Globals.RESTORE),
+                new PersistenceGroupConfig(RESTORE_ONLY_GROUP));
+        mockServiceConfiguration(PERSISTENCE_SERVICE_ID, everyChangeAllFiltered, restoreOnlyGroup);
+
+        List<PersistenceServiceProblem> problems = getPersistenceProblems();
+
+        assertThat(countNoStoreStrategyProblems(problems, PERSISTENCE_SERVICE_ID), is(1L));
+    }
+
+    @Test
+    public void testHealthExcludeOnlyEntryStillReportedDespiteAllStoreEntry() throws IOException {
+        when(persistenceServiceRegistryMock.getAll()).thenReturn(Set.of(pServiceMock));
+        // An entry that selects nothing positively covers no items; even an all-items store entry must not
+        // suppress its warning.
+        PersistenceItemConfiguration everyChangeAll = itemConfiguration(List.of(PersistenceStrategy.Globals.CHANGE),
+                new PersistenceAllConfig());
+        PersistenceItemConfiguration restoreExcludeOnly = itemConfiguration(
+                List.of(PersistenceStrategy.Globals.RESTORE), new PersistenceItemExcludeConfig("excludedItem"));
+        mockServiceConfiguration(PERSISTENCE_SERVICE_ID, everyChangeAll, restoreExcludeOnly);
 
         List<PersistenceServiceProblem> problems = getPersistenceProblems();
 

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
@@ -72,7 +72,6 @@ import org.openhab.core.persistence.config.PersistenceItemConfig;
 import org.openhab.core.persistence.config.PersistenceItemExcludeConfig;
 import org.openhab.core.persistence.dto.ItemHistoryDTO;
 import org.openhab.core.persistence.dto.ItemHistoryDTO.HistoryDataBean;
-import org.openhab.core.persistence.filter.PersistenceEqualsFilter;
 import org.openhab.core.persistence.internal.PersistenceManagerImpl;
 import org.openhab.core.persistence.registry.ManagedPersistenceServiceConfigurationProvider;
 import org.openhab.core.persistence.registry.PersistenceServiceConfiguration;
@@ -647,23 +646,6 @@ public class PersistenceResourceTest {
         PersistenceItemConfiguration storeItemA = itemConfiguration(List.of(PersistenceStrategy.Globals.CHANGE),
                 new PersistenceItemConfig("ItemA"));
         mockServiceConfiguration(PERSISTENCE_SERVICE_ID, restoreTwoItems, storeItemA);
-
-        List<PersistenceServiceProblem> problems = getPersistenceProblems();
-
-        assertThat(countNoStoreStrategyProblems(problems, PERSISTENCE_SERVICE_ID), is(1L));
-    }
-
-    @Test
-    public void testHealthCoveredOnlyByFilteredEntryStillReported() throws IOException {
-        when(persistenceServiceRegistryMock.getAll()).thenReturn(Set.of(pServiceMock));
-        // Coverage must be provable from the configuration alone. A filtered store entry cannot prove it: the
-        // filter can veto every single write at runtime, e.g. an equals filter whose values the item never takes.
-        PersistenceItemConfiguration everyChangeAllFiltered = new PersistenceItemConfiguration(
-                List.of(new PersistenceAllConfig()), List.of(PersistenceStrategy.Globals.CHANGE),
-                List.of(new PersistenceEqualsFilter("onlyOn", List.of("ON"), false)));
-        PersistenceItemConfiguration restoreOnlyGroup = itemConfiguration(List.of(PersistenceStrategy.Globals.RESTORE),
-                new PersistenceGroupConfig(RESTORE_ONLY_GROUP));
-        mockServiceConfiguration(PERSISTENCE_SERVICE_ID, everyChangeAllFiltered, restoreOnlyGroup);
 
         List<PersistenceServiceProblem> problems = getPersistenceProblems();
 

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
@@ -20,6 +20,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -29,6 +33,8 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -54,18 +60,29 @@ import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.persistence.HistoricItem;
 import org.openhab.core.persistence.ModifiablePersistenceService;
+import org.openhab.core.persistence.PersistenceItemConfiguration;
 import org.openhab.core.persistence.PersistenceItemInfo;
+import org.openhab.core.persistence.PersistenceService;
+import org.openhab.core.persistence.PersistenceServiceProblem;
 import org.openhab.core.persistence.PersistenceServiceRegistry;
+import org.openhab.core.persistence.config.PersistenceAllConfig;
+import org.openhab.core.persistence.config.PersistenceConfig;
+import org.openhab.core.persistence.config.PersistenceGroupConfig;
+import org.openhab.core.persistence.config.PersistenceItemExcludeConfig;
 import org.openhab.core.persistence.dto.ItemHistoryDTO;
 import org.openhab.core.persistence.dto.ItemHistoryDTO.HistoryDataBean;
 import org.openhab.core.persistence.internal.PersistenceManagerImpl;
 import org.openhab.core.persistence.registry.ManagedPersistenceServiceConfigurationProvider;
 import org.openhab.core.persistence.registry.PersistenceServiceConfiguration;
 import org.openhab.core.persistence.registry.PersistenceServiceConfigurationRegistry;
+import org.openhab.core.persistence.strategy.PersistenceCronStrategy;
+import org.openhab.core.persistence.strategy.PersistenceStrategy;
 import org.openhab.core.types.State;
 import org.openhab.core.types.StateDescription;
 import org.openhab.core.types.StateOption;
 import org.openhab.core.types.UnDefType;
+
+import com.google.gson.Gson;
 
 /**
  * Tests for PersistenceItem REST resource
@@ -79,7 +96,9 @@ import org.openhab.core.types.UnDefType;
 public class PersistenceResourceTest {
 
     private static final String PERSISTENCE_SERVICE_ID = "TestServiceID";
+    private static final String PERSISTENCE_SERVICE_ID_2 = "TestServiceID2";
     private static final String ITEM_NAME = "testItem";
+    private static final String RESTORE_ONLY_GROUP = "gRestoreOnStartup";
 
     private @NonNullByDefault({}) PersistenceResource pResource;
     private @NonNullByDefault({}) List<HistoricItem> items;
@@ -476,5 +495,150 @@ public class PersistenceResourceTest {
         assertThat(itemInfo.latest(),
                 is(Date.from(ZonedDateTime.of(END_VALUE, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant())));
         assertThat(itemInfo.count(), is(VALUE_COUNT));
+    }
+
+    @Test
+    public void testHealthStandardPatternNotReported() throws IOException {
+        when(persistenceServiceRegistryMock.getAll()).thenReturn(Set.of(pServiceMock));
+        PersistenceItemConfiguration everyChangeAll = itemConfiguration(List.of(PersistenceStrategy.Globals.CHANGE),
+                new PersistenceAllConfig());
+        PersistenceItemConfiguration restoreOnlyGroup = itemConfiguration(List.of(PersistenceStrategy.Globals.RESTORE),
+                new PersistenceGroupConfig(RESTORE_ONLY_GROUP));
+        mockServiceConfiguration(PERSISTENCE_SERVICE_ID, everyChangeAll, restoreOnlyGroup);
+
+        List<PersistenceServiceProblem> problems = getPersistenceProblems();
+
+        assertThat(countNoStoreStrategyProblems(problems, PERSISTENCE_SERVICE_ID), is(0L));
+    }
+
+    @Test
+    public void testHealthRestoreOnlyWithoutCoverageIsReported() throws IOException {
+        when(persistenceServiceRegistryMock.getAll()).thenReturn(Set.of(pServiceMock));
+        PersistenceItemConfiguration restoreOnlyGroup = itemConfiguration(List.of(PersistenceStrategy.Globals.RESTORE),
+                new PersistenceGroupConfig(RESTORE_ONLY_GROUP));
+        mockServiceConfiguration(PERSISTENCE_SERVICE_ID, restoreOnlyGroup);
+
+        List<PersistenceServiceProblem> problems = getPersistenceProblems();
+
+        assertThat(countNoStoreStrategyProblems(problems, PERSISTENCE_SERVICE_ID), is(1L));
+    }
+
+    @Test
+    public void testHealthAllConfigWithExcludeStillReported() throws IOException {
+        when(persistenceServiceRegistryMock.getAll()).thenReturn(Set.of(pServiceMock));
+        PersistenceItemConfiguration everyChangeAllWithExclude = itemConfiguration(
+                List.of(PersistenceStrategy.Globals.CHANGE), new PersistenceAllConfig(),
+                new PersistenceItemExcludeConfig("excludedItem"));
+        PersistenceItemConfiguration restoreOnlyGroup = itemConfiguration(List.of(PersistenceStrategy.Globals.RESTORE),
+                new PersistenceGroupConfig(RESTORE_ONLY_GROUP));
+        mockServiceConfiguration(PERSISTENCE_SERVICE_ID, everyChangeAllWithExclude, restoreOnlyGroup);
+
+        List<PersistenceServiceProblem> problems = getPersistenceProblems();
+
+        assertThat(countNoStoreStrategyProblems(problems, PERSISTENCE_SERVICE_ID), is(1L));
+    }
+
+    @Test
+    public void testHealthCoveredByCronStrategyNotReported() throws IOException {
+        when(persistenceServiceRegistryMock.getAll()).thenReturn(Set.of(pServiceMock));
+        PersistenceItemConfiguration cronGroup = itemConfiguration(
+                List.of(new PersistenceCronStrategy("everyHour", "0 0 * * * ?")),
+                new PersistenceGroupConfig(RESTORE_ONLY_GROUP));
+        PersistenceItemConfiguration restoreOnlyGroup = itemConfiguration(List.of(PersistenceStrategy.Globals.RESTORE),
+                new PersistenceGroupConfig(RESTORE_ONLY_GROUP));
+        mockServiceConfiguration(PERSISTENCE_SERVICE_ID, cronGroup, restoreOnlyGroup);
+
+        List<PersistenceServiceProblem> problems = getPersistenceProblems();
+
+        assertThat(countNoStoreStrategyProblems(problems, PERSISTENCE_SERVICE_ID), is(0L));
+    }
+
+    @Test
+    public void testHealthCoveredOnlyByForecastStillReported() throws IOException {
+        when(persistenceServiceRegistryMock.getAll()).thenReturn(Set.of(pServiceMock));
+        PersistenceItemConfiguration forecastGroup = itemConfiguration(List.of(PersistenceStrategy.Globals.FORECAST),
+                new PersistenceGroupConfig(RESTORE_ONLY_GROUP));
+        PersistenceItemConfiguration restoreOnlyGroup = itemConfiguration(List.of(PersistenceStrategy.Globals.RESTORE),
+                new PersistenceGroupConfig(RESTORE_ONLY_GROUP));
+        mockServiceConfiguration(PERSISTENCE_SERVICE_ID, forecastGroup, restoreOnlyGroup);
+
+        List<PersistenceServiceProblem> problems = getPersistenceProblems();
+
+        assertThat(countNoStoreStrategyProblems(problems, PERSISTENCE_SERVICE_ID), is(1L));
+    }
+
+    @Test
+    public void testHealthDoesNotBleedAcrossServices() throws IOException {
+        PersistenceService serviceAMock = mock(PersistenceService.class);
+        when(serviceAMock.getId()).thenReturn(PERSISTENCE_SERVICE_ID);
+        PersistenceService serviceBMock = mock(PersistenceService.class);
+        when(serviceBMock.getId()).thenReturn(PERSISTENCE_SERVICE_ID_2);
+        when(persistenceServiceRegistryMock.getAll()).thenReturn(Set.of(serviceAMock, serviceBMock));
+
+        PersistenceItemConfiguration everyChangeAll = itemConfiguration(List.of(PersistenceStrategy.Globals.CHANGE),
+                new PersistenceAllConfig());
+        mockServiceConfiguration(PERSISTENCE_SERVICE_ID, everyChangeAll);
+
+        PersistenceItemConfiguration restoreOnlyGroup = itemConfiguration(List.of(PersistenceStrategy.Globals.RESTORE),
+                new PersistenceGroupConfig(RESTORE_ONLY_GROUP));
+        mockServiceConfiguration(PERSISTENCE_SERVICE_ID_2, restoreOnlyGroup);
+
+        List<PersistenceServiceProblem> problems = getPersistenceProblems();
+
+        assertThat(countNoStoreStrategyProblems(problems, PERSISTENCE_SERVICE_ID), is(0L));
+        assertThat(countNoStoreStrategyProblems(problems, PERSISTENCE_SERVICE_ID_2), is(1L));
+    }
+
+    @Test
+    public void testHealthExactSelectorCoverageNotReported() throws IOException {
+        when(persistenceServiceRegistryMock.getAll()).thenReturn(Set.of(pServiceMock));
+        PersistenceItemConfiguration restoreOnlyGroup = itemConfiguration(List.of(PersistenceStrategy.Globals.RESTORE),
+                new PersistenceGroupConfig(RESTORE_ONLY_GROUP));
+        PersistenceItemConfiguration everyUpdateSameGroup = itemConfiguration(
+                List.of(PersistenceStrategy.Globals.UPDATE), new PersistenceGroupConfig(RESTORE_ONLY_GROUP));
+        mockServiceConfiguration(PERSISTENCE_SERVICE_ID, restoreOnlyGroup, everyUpdateSameGroup);
+
+        List<PersistenceServiceProblem> problems = getPersistenceProblems();
+
+        assertThat(countNoStoreStrategyProblems(problems, PERSISTENCE_SERVICE_ID), is(0L));
+    }
+
+    private static PersistenceItemConfiguration itemConfiguration(List<PersistenceStrategy> strategies,
+            PersistenceConfig... selectors) {
+        return new PersistenceItemConfiguration(List.of(selectors), strategies, List.of());
+    }
+
+    private void mockServiceConfiguration(String serviceId, PersistenceItemConfiguration... configs) {
+        when(persistenceServiceConfigurationRegistryMock.get(serviceId)).thenReturn(
+                new PersistenceServiceConfiguration(serviceId, List.of(configs), Map.of(), List.of(), List.of()));
+    }
+
+    private List<PersistenceServiceProblem> getPersistenceProblems() throws IOException {
+        HttpHeaders headersMock = mock(HttpHeaders.class);
+        Response response = pResource.httpGetPersistenceHealth(headersMock);
+        assertThat(response.getStatus(), is(200));
+        PersistenceServiceProblem[] problems = new Gson().fromJson(toString(response.getEntity()),
+                PersistenceServiceProblem[].class);
+        return List.of(problems);
+    }
+
+    private long countNoStoreStrategyProblems(List<PersistenceServiceProblem> problems, String serviceId) {
+        return problems.stream()
+                .filter(problem -> PersistenceServiceProblem.PERSISTENCE_NO_STORE_STRATEGY.equals(problem.reason())
+                        && serviceId.equals(problem.serviceId()))
+                .count();
+    }
+
+    private String toString(Object entity) throws IOException {
+        byte[] bytes;
+        if (entity instanceof StreamingOutput streaming) {
+            try (ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+                streaming.write(buffer);
+                bytes = buffer.toByteArray();
+            }
+        } else {
+            bytes = ((InputStream) entity).readAllBytes();
+        }
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
## Description

Fixes #5777.

`httpGetPersistenceHealth()` reports `PERSISTENCE_SERVICE_ITEMS_NO_STORE_STRATEGY` for every configuration entry whose only strategy is `restoreOnStartup`, judging each entry in isolation. Persistence application is additive — `PersistenceManagerImpl.storeItem()` streams over *all* matching configurations — so the split configuration below is correct and still permanently red:

```
items: ["*"],                  strategies: ["everyChange"]
items: ["gRestoreOnStartup*"], strategies: ["restoreOnStartup"]
```

The additive rule is documented behaviour, not an implementation detail: `configuration/persistence.md` says "The entries are additive. This means if one Item appears in more than one `<itemlist>` … all the strategies … listed on all those lines apply to that Item." The check therefore contradicts the documented semantics of the format it checks, and states something factually wrong about the user's configuration.

The problem is now reported only when no *other* entry of the same service both carries a store strategy and provably covers the same items.

**Conservative on purpose.** Suppressing a warning that ought to fire means silently losing data, which is far worse than one warning too many, so coverage has to be *provable* from the configuration alone:

- **Store strategies are identified positively**, not by exclusion: only `everyUpdate`, `everyChange` and cron strategies count, because those are the ones `PersistenceManagerImpl` actually acts on (`schedulePersistJobs()` turns cron strategies into ordinary persist jobs). A file-based configuration may name an arbitrary strategy, which `PersistenceModelManager` turns into a plain `PersistenceStrategy` instance that nothing ever executes — treating "neither restore nor forecast" as storing would let such a strategy silence a warning that should fire.
- **Coverage may itself be additive**, matching the rule the fix is about: a selector only has to be found in *some* storing entry, not in one single entry that covers them all. A restore-only entry selecting `ItemA, ItemB` is therefore covered by two separate entries that store `ItemA` and `ItemB` respectively — but it keeps warning if only one of the two is covered.
- **An entry carrying any exclude selector never silences anything**, because `appliesToItem()` drops the whole entry for the excluded items, so nothing about it is provable. A `*` entry with `!Item` or `!Group*` is not evidence of coverage.
- Selectors are compared structurally rather than with `equals()`, because the `PersistenceConfig` implementations do not override it. Comparison is by concrete type plus identifying field, and **any implementation this method does not know is treated as not equal** — calling two unknown selectors equal would silence a warning. `PersistenceAllConfig`, the one type where the class alone is decisive, is handled by the caller before that point.

## Testing

`PersistenceResourceTest` had no coverage of `httpGetPersistenceHealth` at all; these are the first tests for it. Ten cases, deliberately weighted towards the ones that must keep warning:

| Case | Expectation |
| --- | --- |
| the standard split (`*` + everyChange, restore-only group) | not reported |
| a restore-only entry with nothing storing those items | **still reported** |
| a `*` store entry carrying an exclude selector | **still reported** |
| covered by an entry with a cron strategy | not reported |
| covered only by an entry that itself has just `forecast` | **still reported** |
| covered only by an entry with an arbitrary named strategy | **still reported** |
| store entry in service A, restore-only entry in service B | **still reported** (no bleed between services) |
| exact-selector coverage (same group selector + `everyUpdate`) | not reported |
| coverage split across two store entries, one selector each | not reported |
| the same, but only one of the two selectors covered | **still reported** |

Bundle build green, static analysis clean.

The cases that require the new behaviour (standard split, cron coverage, exact-selector coverage, split coverage) were verified to **fail** against the unmodified code — the ones asserting that the warning is still raised pass under both versions by construction, which is the point of including them.

Verified on a live openHAB 5.2.1 installation as well: the reported items carried several thousand datapoints per 48 hours in InfluxDB while the health page insisted they had no store strategy.

Note for completeness: a configuration can be rewritten so that every entry carries its own store strategy (`["*", "!gRestoreOnStartup*"]` plus `["gRestoreOnStartup*"]` with both store and restore strategies), and that is arguably tidier. It does not make the report correct, though — the documented additive form stays valid, and users following the documentation should not be told their configuration is broken.

Signed-off-by (in commit): Martin Littkovsky <2018turtle@proton.me>
