### PR TITLE
Add HTTP PATCH request action

### DIFF
--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
@@ -241,7 +241,8 @@ public class HttpUtil {
         }
 
         // add content if a valid method is given ...
-        if (content != null && (HttpMethod.POST.equals(method) || HttpMethod.PUT.equals(method))) {
+        if (content != null && (HttpMethod.POST.equals(method) || HttpMethod.PUT.equals(method)
+                || HttpMethod.PATCH.equals(method))) {
             // Close this outmost stream again after use!
             try (final InputStreamContentProvider inputStreamContentProvider = new InputStreamContentProvider(
                     content)) {
@@ -341,12 +342,12 @@ public class HttpUtil {
      *
      * @param httpMethodString the name of the {@link HttpMethod} to create
      * @throws IllegalArgumentException if <code>httpMethod</code> is none of <code>GET</code>, <code>PUT</code>,
-     *             <code>POST</POST> or <code>DELETE</code>
+     *             <code>POST</code>, <code>PATCH</code>, or <code>DELETE</code>
      */
     public static HttpMethod createHttpMethod(String httpMethodString) {
         // @formatter:off
         return Optional.ofNullable(HttpMethod.fromString(httpMethodString))
-                .filter(m -> m == GET || m == POST || m == PUT || m == DELETE)
+                .filter(m -> m == GET || m == POST || m == PUT || m == PATCH || m == DELETE)
                 .orElseThrow(() -> new IllegalArgumentException("Given HTTP Method '" + httpMethodString + "' is unknown"));
         // @formatter:on
     }

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/HttpUtilTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/HttpUtilTest.java
@@ -65,6 +65,7 @@ public class HttpUtilTest extends BaseHttpUtilTest {
         assertEquals(HttpMethod.GET, HttpUtil.createHttpMethod("GET"));
         assertEquals(HttpMethod.PUT, HttpUtil.createHttpMethod("PUT"));
         assertEquals(HttpMethod.POST, HttpUtil.createHttpMethod("POST"));
+        assertEquals(HttpMethod.PATCH, HttpUtil.createHttpMethod("PATCH"));
         assertEquals(HttpMethod.DELETE, HttpUtil.createHttpMethod("DELETE"));
     }
 

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/HttpUtilTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/HttpUtilTest.java
@@ -13,10 +13,15 @@
 package org.openhab.core.io.net.http;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -81,5 +86,22 @@ public class HttpUtilTest extends BaseHttpUtilTest {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
                 () -> HttpUtil.createHttpMethod("TRACE"));
         assertEquals("Given HTTP Method 'TRACE' is unknown", exception.getMessage());
+    }
+
+    @Test
+    public void testPatchWithContent() throws Exception {
+        mockResponse(HttpStatus.OK_200);
+        String payload = "test payload";
+        InputStream contentStream = new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8));
+
+        String result = HttpUtil.executeUrl("PATCH", URL, contentStream, "text/plain", 500);
+
+        assertEquals("Some content", result);
+
+        verify(httpClientMock).newRequest(URI.create(URL));
+        verify(requestMock).method(HttpMethod.PATCH);
+        verify(requestMock).timeout(500, TimeUnit.MILLISECONDS);
+        verify(requestMock).content(any(), eq("text/plain"));
+        verify(requestMock).send();
     }
 }

--- a/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/actions/HTTPTest.java
+++ b/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/actions/HTTPTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.model.script.actions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.openhab.core.io.net.http.HttpUtil;
+
+/**
+ * Unit tests for {@link HTTP} actions, covering GET, PUT, POST, PATCH, DELETE, and error handling.
+ *
+ * @author Jimmy Tanagra - Initial contribution
+ */
+class HTTPTest {
+
+    private MockedStatic<HttpUtil> httpUtilMock;
+
+    @BeforeEach
+    void setUp() {
+        httpUtilMock = mockStatic(HttpUtil.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        httpUtilMock.close();
+    }
+
+    // --- GET Tests ---
+
+    @Test
+    void testSendHttpGetRequestBasic() throws Exception {
+        httpUtilMock.when(() -> HttpUtil.executeUrl(eq("GET"), eq("http://example.com"), eq(5000)))
+                .thenReturn("get-response");
+
+        String response = HTTP.sendHttpGetRequest("http://example.com");
+
+        assertEquals("get-response", response);
+        httpUtilMock.verify(() -> HttpUtil.executeUrl("GET", "http://example.com", 5000));
+    }
+
+    @Test
+    void testSendHttpGetRequestWithTimeout() throws Exception {
+        httpUtilMock.when(() -> HttpUtil.executeUrl(eq("GET"), eq("http://example.com"), eq(3000)))
+                .thenReturn("get-timeout");
+
+        String response = HTTP.sendHttpGetRequest("http://example.com", 3000);
+
+        assertEquals("get-timeout", response);
+        httpUtilMock.verify(() -> HttpUtil.executeUrl("GET", "http://example.com", 3000));
+    }
+
+    @Test
+    void testSendHttpGetRequestWithHeadersAndTimeout() throws Exception {
+        httpUtilMock.when(() -> HttpUtil.executeUrl(eq("GET"), eq("http://example.com"), any(Properties.class),
+                eq(null), eq(null), eq(2000))).thenReturn("get-headers");
+
+        Map<String, String> headers = Map.of("X-Test", "Value");
+        String response = HTTP.sendHttpGetRequest("http://example.com", headers, 2000);
+
+        assertEquals("get-headers", response);
+        httpUtilMock.verify(() -> HttpUtil.executeUrl(eq("GET"), eq("http://example.com"), any(Properties.class),
+                eq(null), eq(null), eq(2000)));
+    }
+
+    // --- PUT Tests ---
+
+    @Test
+    void testSendHttpPutRequestBasic() throws Exception {
+        httpUtilMock.when(() -> HttpUtil.executeUrl(eq("PUT"), eq("http://example.com"), eq(1000)))
+                .thenReturn("put-response");
+
+        String response = HTTP.sendHttpPutRequest("http://example.com");
+
+        assertEquals("put-response", response);
+        httpUtilMock.verify(() -> HttpUtil.executeUrl("PUT", "http://example.com", 1000));
+    }
+
+    @Test
+    void testSendHttpPutRequestWithContentAndTimeout() throws Exception {
+        httpUtilMock.when(() -> HttpUtil.executeUrl(eq("PUT"), eq("http://example.com"), any(InputStream.class),
+                eq("text/plain"), eq(2000))).thenReturn("put-content");
+
+        String response = HTTP.sendHttpPutRequest("http://example.com", "text/plain", "hello", 2000);
+
+        assertEquals("put-content", response);
+        httpUtilMock.verify(() -> HttpUtil.executeUrl(eq("PUT"), eq("http://example.com"), any(InputStream.class),
+                eq("text/plain"), eq(2000)));
+    }
+
+    // --- POST Tests ---
+
+    @Test
+    void testSendHttpPostRequestBasic() throws Exception {
+        httpUtilMock.when(() -> HttpUtil.executeUrl(eq("POST"), eq("http://example.com"), eq(1000)))
+                .thenReturn("post-response");
+
+        String response = HTTP.sendHttpPostRequest("http://example.com");
+
+        assertEquals("post-response", response);
+        httpUtilMock.verify(() -> HttpUtil.executeUrl("POST", "http://example.com", 1000));
+    }
+
+    @Test
+    void testSendHttpPostRequestWithContentHeadersAndTimeout() throws Exception {
+        httpUtilMock.when(() -> HttpUtil.executeUrl(eq("POST"), eq("http://example.com"), any(Properties.class),
+                any(InputStream.class), eq("application/json"), eq(3000))).thenReturn("post-full");
+
+        Map<String, String> headers = Map.of("Authorization", "Bearer token");
+        String response = HTTP.sendHttpPostRequest("http://example.com", "application/json", "{\"a\":1}", headers,
+                3000);
+
+        assertEquals("post-full", response);
+        httpUtilMock.verify(() -> HttpUtil.executeUrl(eq("POST"), eq("http://example.com"), any(Properties.class),
+                any(InputStream.class), eq("application/json"), eq(3000)));
+    }
+
+    // --- PATCH Tests ---
+
+    @Test
+    void testSendHttpPatchRequestBasic() throws Exception {
+        httpUtilMock.when(() -> HttpUtil.executeUrl(eq("PATCH"), eq("http://example.com"), eq(1000)))
+                .thenReturn("patch-response");
+
+        String response = HTTP.sendHttpPatchRequest("http://example.com");
+
+        assertEquals("patch-response", response);
+        httpUtilMock.verify(() -> HttpUtil.executeUrl("PATCH", "http://example.com", 1000));
+    }
+
+    @Test
+    void testSendHttpPatchRequestWithContentAndHeaders() throws Exception {
+        httpUtilMock.when(() -> HttpUtil.executeUrl(eq("PATCH"), eq("http://example.com"), any(Properties.class),
+                any(InputStream.class), eq("application/json"), eq(2000))).thenReturn("patch-full");
+
+        Map<String, String> headers = Map.of("X-Custom", "Header");
+        String response = HTTP.sendHttpPatchRequest("http://example.com", "application/json", "content", headers, 2000);
+
+        assertEquals("patch-full", response);
+        httpUtilMock.verify(() -> HttpUtil.executeUrl(eq("PATCH"), eq("http://example.com"), any(Properties.class),
+                any(InputStream.class), eq("application/json"), eq(2000)));
+    }
+
+    // --- DELETE Tests ---
+
+    @Test
+    void testSendHttpDeleteRequestBasic() throws Exception {
+        httpUtilMock.when(() -> HttpUtil.executeUrl(eq("DELETE"), eq("http://example.com"), eq(1000)))
+                .thenReturn("delete-response");
+
+        String response = HTTP.sendHttpDeleteRequest("http://example.com");
+
+        assertEquals("delete-response", response);
+        httpUtilMock.verify(() -> HttpUtil.executeUrl("DELETE", "http://example.com", 1000));
+    }
+
+    // --- Error Handling Tests ---
+
+    @Test
+    void testRequestHandlesIOExceptionGracefully() throws Exception {
+        httpUtilMock.when(() -> HttpUtil.executeUrl(anyString(), anyString(), anyInt()))
+                .thenThrow(new IOException("Connection refused"));
+
+        String response = HTTP.sendHttpGetRequest("http://example.com");
+
+        assertNull(response);
+    }
+}

--- a/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/actions/HTTPTest.java
+++ b/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/actions/HTTPTest.java
@@ -25,6 +25,8 @@ import java.io.InputStream;
 import java.util.Map;
 import java.util.Properties;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,9 +38,10 @@ import org.openhab.core.io.net.http.HttpUtil;
  *
  * @author Jimmy Tanagra - Initial contribution
  */
+@NonNullByDefault
 class HTTPTest {
 
-    private MockedStatic<HttpUtil> httpUtilMock;
+    private @Nullable MockedStatic<HttpUtil> httpUtilMock;
 
     @BeforeEach
     void setUp() {

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/HTTP.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/HTTP.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - Initial contribution
  * @author Jan N. Klug - add timeout methods
  * @author Dan Cunningham - add image download methods
+ * @author Jimmy Tanagra - add PATCH request methods and DRY refactoring
  */
 public class HTTP {
 
@@ -44,6 +45,8 @@ public class HTTP {
     public static final String CONTENT_TYPE_JSON = "application/json";
 
     private static Logger logger = LoggerFactory.getLogger(HTTP.class);
+
+    // --- GET Methods ---
 
     /**
      * Send out a GET-HTTP request. Errors will be logged, success returns response
@@ -63,13 +66,7 @@ public class HTTP {
      * @return the response body or <code>NULL</code> when the request went wrong
      */
     public static String sendHttpGetRequest(String url, int timeout) {
-        String response = null;
-        try {
-            return HttpUtil.executeUrl(HttpMethod.GET.name(), url, timeout);
-        } catch (IOException e) {
-            logger.error("Fatal transport error: {}", e.getMessage());
-        }
-        return response;
+        return executeRequest(HttpMethod.GET.name(), url, timeout);
     }
 
     /**
@@ -81,15 +78,10 @@ public class HTTP {
      * @return the response body or <code>NULL</code> when the request went wrong
      */
     public static String sendHttpGetRequest(String url, Map<String, String> headers, int timeout) {
-        try {
-            Properties headerProperties = new Properties();
-            headerProperties.putAll(headers);
-            return HttpUtil.executeUrl(HttpMethod.GET.name(), url, headerProperties, null, null, timeout);
-        } catch (IOException e) {
-            logger.error("Fatal transport error: {}", e.getMessage());
-        }
-        return null;
+        return executeRequest(HttpMethod.GET.name(), url, headers, timeout);
     }
+
+    // --- PUT Methods ---
 
     /**
      * Send out a PUT-HTTP request. Errors will be logged, returned values just ignored.
@@ -109,13 +101,7 @@ public class HTTP {
      * @return the response body or <code>NULL</code> when the request went wrong
      */
     public static String sendHttpPutRequest(String url, int timeout) {
-        String response = null;
-        try {
-            response = HttpUtil.executeUrl(HttpMethod.PUT.name(), url, timeout);
-        } catch (IOException e) {
-            logger.error("Fatal transport error: {}", e.getMessage());
-        }
-        return response;
+        return executeRequest(HttpMethod.PUT.name(), url, timeout);
     }
 
     /**
@@ -142,14 +128,7 @@ public class HTTP {
      * @return the response body or <code>NULL</code> when the request went wrong
      */
     public static String sendHttpPutRequest(String url, String contentType, String content, int timeout) {
-        String response = null;
-        try {
-            response = HttpUtil.executeUrl(HttpMethod.PUT.name(), url,
-                    new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)), contentType, timeout);
-        } catch (IOException e) {
-            logger.error("Fatal transport error: {}", e.getMessage());
-        }
-        return response;
+        return executeRequest(HttpMethod.PUT.name(), url, contentType, content, timeout);
     }
 
     /**
@@ -165,16 +144,10 @@ public class HTTP {
      */
     public static String sendHttpPutRequest(String url, String contentType, String content, Map<String, String> headers,
             int timeout) {
-        try {
-            Properties headerProperties = new Properties();
-            headerProperties.putAll(headers);
-            return HttpUtil.executeUrl(HttpMethod.PUT.name(), url, headerProperties,
-                    new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)), contentType, timeout);
-        } catch (IOException e) {
-            logger.error("Fatal transport error: {}", e.getMessage());
-        }
-        return null;
+        return executeRequest(HttpMethod.PUT.name(), url, contentType, content, headers, timeout);
     }
+
+    // --- POST Methods ---
 
     /**
      * Send out a POST-HTTP request. Errors will be logged, returned values just ignored.
@@ -194,13 +167,7 @@ public class HTTP {
      * @return the response body or <code>NULL</code> when the request went wrong
      */
     public static String sendHttpPostRequest(String url, int timeout) {
-        String response = null;
-        try {
-            response = HttpUtil.executeUrl(HttpMethod.POST.name(), url, timeout);
-        } catch (IOException e) {
-            logger.error("Fatal transport error: {}", e.getMessage());
-        }
-        return response;
+        return executeRequest(HttpMethod.POST.name(), url, timeout);
     }
 
     /**
@@ -227,14 +194,7 @@ public class HTTP {
      * @return the response body or <code>NULL</code> when the request went wrong
      */
     public static String sendHttpPostRequest(String url, String contentType, String content, int timeout) {
-        String response = null;
-        try {
-            response = HttpUtil.executeUrl(HttpMethod.POST.name(), url,
-                    new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)), contentType, timeout);
-        } catch (IOException e) {
-            logger.error("Fatal transport error: {}", e.getMessage());
-        }
-        return response;
+        return executeRequest(HttpMethod.POST.name(), url, contentType, content, timeout);
     }
 
     /**
@@ -250,16 +210,76 @@ public class HTTP {
      */
     public static String sendHttpPostRequest(String url, String contentType, String content,
             Map<String, String> headers, int timeout) {
-        try {
-            Properties headerProperties = new Properties();
-            headerProperties.putAll(headers);
-            return HttpUtil.executeUrl(HttpMethod.POST.name(), url, headerProperties,
-                    new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)), contentType, timeout);
-        } catch (IOException e) {
-            logger.error("Fatal transport error: {}", e.getMessage());
-        }
-        return null;
+        return executeRequest(HttpMethod.POST.name(), url, contentType, content, headers, timeout);
     }
+
+    // --- PATCH Methods ---
+
+    /**
+     * Send out a PATCH-HTTP request. Errors will be logged, returned values just ignored.
+     *
+     * @param url the URL to be used for the PATCH request.
+     * @return the response body or <code>NULL</code> when the request went wrong
+     */
+    public static String sendHttpPatchRequest(String url) {
+        return sendHttpPatchRequest(url, 1000);
+    }
+
+    /**
+     * Send out a PATCH-HTTP request. Errors will be logged, returned values just ignored.
+     *
+     * @param url the URL to be used for the PATCH request.
+     * @param timeout timeout in ms
+     * @return the response body or <code>NULL</code> when the request went wrong
+     */
+    public static String sendHttpPatchRequest(String url, int timeout) {
+        return executeRequest(HttpMethod.PATCH.name(), url, timeout);
+    }
+
+    /**
+     * Send out a PATCH-HTTP request. Errors will be logged, returned values just ignored.
+     *
+     * @param url the URL to be used for the PATCH request.
+     * @param contentType the content type of the given <code>content</code>
+     * @param content the content to be send to the given <code>url</code> or <code>null</code> if no content should be
+     *            sent.
+     * @return the response body or <code>NULL</code> when the request went wrong
+     */
+    public static String sendHttpPatchRequest(String url, String contentType, String content) {
+        return sendHttpPatchRequest(url, contentType, content, 1000);
+    }
+
+    /**
+     * Send out a PATCH-HTTP request. Errors will be logged, returned values just ignored.
+     *
+     * @param url the URL to be used for the PATCH request.
+     * @param contentType the content type of the given <code>content</code>
+     * @param content the content to be send to the given <code>url</code> or <code>null</code> if no content should be
+     *            sent.
+     * @param timeout timeout in ms
+     * @return the response body or <code>NULL</code> when the request went wrong
+     */
+    public static String sendHttpPatchRequest(String url, String contentType, String content, int timeout) {
+        return executeRequest(HttpMethod.PATCH.name(), url, contentType, content, timeout);
+    }
+
+    /**
+     * Send out a PATCH-HTTP request. Errors will be logged, returned values just ignored.
+     *
+     * @param url the URL to be used for the PATCH request.
+     * @param contentType the content type of the given <code>content</code>
+     * @param content the content to be send to the given <code>url</code> or <code>null</code> if no content should be
+     *            sent.
+     * @param headers the HTTP headers to be sent in the request.
+     * @param timeout timeout in ms
+     * @return the response body or <code>NULL</code> when the request went wrong
+     */
+    public static String sendHttpPatchRequest(String url, String contentType, String content,
+            Map<String, String> headers, int timeout) {
+        return executeRequest(HttpMethod.PATCH.name(), url, contentType, content, headers, timeout);
+    }
+
+    // --- DELETE Methods ---
 
     /**
      * Send out a DELETE-HTTP request. Errors will be logged, returned values just ignored.
@@ -279,13 +299,7 @@ public class HTTP {
      * @return the response body or <code>NULL</code> when the request went wrong
      */
     public static String sendHttpDeleteRequest(String url, int timeout) {
-        String response = null;
-        try {
-            response = HttpUtil.executeUrl(HttpMethod.DELETE.name(), url, timeout);
-        } catch (IOException e) {
-            logger.error("Fatal transport error: {}", e.getMessage());
-        }
-        return response;
+        return executeRequest(HttpMethod.DELETE.name(), url, timeout);
     }
 
     /**
@@ -297,15 +311,10 @@ public class HTTP {
      * @return the response body or <code>NULL</code> when the request went wrong
      */
     public static String sendHttpDeleteRequest(String url, Map<String, String> headers, int timeout) {
-        try {
-            Properties headerProperties = new Properties();
-            headerProperties.putAll(headers);
-            return HttpUtil.executeUrl(HttpMethod.DELETE.name(), url, headerProperties, null, null, timeout);
-        } catch (IOException e) {
-            logger.error("Fatal transport error: {}", e.getMessage());
-        }
-        return null;
+        return executeRequest(HttpMethod.DELETE.name(), url, headers, timeout);
     }
+
+    // --- Image Download Methods ---
 
     @ActionDoc(text = "downloads an image from a url and updates the Image item's state with it", returns = "true if successful, false otherwise")
     public static boolean setImage(
@@ -352,5 +361,56 @@ public class HTTP {
             logger.error("Cannot update item '{}' with image: {}", itemName, e.getMessage());
             return false;
         }
+    }
+
+    private static String executeRequest(String method, String url, int timeout) {
+        try {
+            return HttpUtil.executeUrl(method, url, timeout);
+        } catch (IOException e) {
+            logger.error("Fatal transport error: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    private static String executeRequest(String method, String url, Map<String, String> headers, int timeout) {
+        try {
+            Properties headerProperties = new Properties();
+            if (headers != null) {
+                headerProperties.putAll(headers);
+            }
+            return HttpUtil.executeUrl(method, url, headerProperties, null, null, timeout);
+        } catch (IOException e) {
+            logger.error("Fatal transport error: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    private static String executeRequest(String method, String url, String contentType, String content, int timeout) {
+        try {
+            ByteArrayInputStream contentStream = content != null
+                    ? new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))
+                    : null;
+            return HttpUtil.executeUrl(method, url, contentStream, contentType, timeout);
+        } catch (IOException e) {
+            logger.error("Fatal transport error: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    private static String executeRequest(String method, String url, String contentType, String content,
+            Map<String, String> headers, int timeout) {
+        try {
+            Properties headerProperties = new Properties();
+            if (headers != null) {
+                headerProperties.putAll(headers);
+            }
+            ByteArrayInputStream contentStream = content != null
+                    ? new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))
+                    : null;
+            return HttpUtil.executeUrl(method, url, headerProperties, contentStream, contentType, timeout);
+        } catch (IOException e) {
+            logger.error("Fatal transport error: {}", e.getMessage());
+        }
+        return null;
     }
 }


### PR DESCRIPTION
- Update `HttpUtil.createHttpMethod` to recognize and allow `PATCH` alongside GET, PUT, POST, and DELETE.
- Add `sendHttpPatchRequest` methods with signature parity (supporting timeouts, content types, payloads, and custom headers).
- Refactor internal request execution using DRY private helper methods to eliminate duplicate boilerplate code across all HTTP actions.
- Add unit tests covering all HTTP action methods and error handling.

Resolves #5658 
Resolves #3762

