### PR TITLE
Fix unstable AudioConsoleTest

### DIFF
--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioConsoleTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioConsoleTest.java
@@ -14,6 +14,7 @@ package org.openhab.core.audio.internal;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -69,8 +70,6 @@ public class AudioConsoleTest extends AbstractAudioServletTest {
             consoleOutput = s;
         }
     };
-
-    private final int testTimeout = 5;
 
     @BeforeEach
     public void setUp() throws IOException {
@@ -146,12 +145,14 @@ public class AudioConsoleTest extends AbstractAudioServletTest {
         AudioStream audioStream = getByteArrayAudioStream(testByteArray, AudioFormat.CONTAINER_WAVE,
                 AudioFormat.CODEC_PCM_SIGNED);
 
-        String url = serveStream(audioStream, testTimeout);
+        String url = serveStream(audioStream);
 
         String[] args = { AudioConsoleCommandExtension.SUBCMD_STREAM, url };
         audioConsoleCommandExtension.execute(args, consoleMock);
 
-        assertThat("The streamed URL was not as expected", ((URLAudioStream) audioSink.audioStream).getURL(), is(url));
+        URLAudioStream urlAudioStream = assertInstanceOf(URLAudioStream.class, audioSink.audioStream);
+        assertThat("The streamed URL was not as expected", urlAudioStream.getURL(), is(url));
+        urlAudioStream.close();
     }
 
     @Test
@@ -159,12 +160,14 @@ public class AudioConsoleTest extends AbstractAudioServletTest {
         AudioStream audioStream = getByteArrayAudioStream(testByteArray, AudioFormat.CONTAINER_WAVE,
                 AudioFormat.CODEC_PCM_SIGNED);
 
-        String url = serveStream(audioStream, testTimeout);
+        String url = serveStream(audioStream);
 
         String[] args = { AudioConsoleCommandExtension.SUBCMD_STREAM, audioSink.getId(), url };
         audioConsoleCommandExtension.execute(args, consoleMock);
 
-        assertThat("The streamed URL was not as expected", ((URLAudioStream) audioSink.audioStream).getURL(), is(url));
+        URLAudioStream urlAudioStream = assertInstanceOf(URLAudioStream.class, audioSink.audioStream);
+        assertThat("The streamed URL was not as expected", urlAudioStream.getURL(), is(url));
+        urlAudioStream.close();
     }
 
     @Test


### PR DESCRIPTION
## Description

This fixes the unstable `AudioConsoleTest` reported in #3405.

The stream tests currently create their local HTTP test stream with a five-second lifetime. That timeout starts when the stream URL is created, not when `URLAudioStream` actually connects to it. On a sufficiently slow or loaded CI runner, the stream can therefore expire before the connection is made.

When that happens, `AudioServlet` removes the expired stream and the HTTP request fails. Constructing `URLAudioStream` then throws an `AudioException`, which is caught by `AudioConsoleCommandExtension`. Because the audio manager never reaches the sink, `AudioSinkFake.audioStream` remains `null`, and the test subsequently fails with the misleading `NullPointerException` reported in the issue.

The previous increase of this timeout from one to five seconds only reduced the likelihood of the failure; it did not remove the timing dependency.

## Changes

- Use the one-shot `serveStream(audioStream)` overload in the two console stream tests instead of an arbitrarily expiring stream.
- Remove the now-unused five-second test timeout.
- Assert that the sink actually received a `URLAudioStream` before checking its URL, so a future failure reports the real state instead of producing an NPE.
- Close the captured `URLAudioStream` after verification.

The one-shot stream is a better fit for these tests because they only need a single HTTP access and are not testing stream expiration behavior.

Fixes #3405

## Testing

The change is limited to `AudioConsoleTest`. The commit and diff were verified against current `main`. A local Maven test run could not be performed in the execution environment because direct outbound access to GitHub is unavailable; the pull request CI will run the repository checks.