### PR TITLE
Exclude log4j from javaxcomm

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -310,6 +310,11 @@
           <groupId>commons-net</groupId>
           <artifactId>commons-net</artifactId>
         </exclusion>
+        <exclusion>
+          <!-- Log4j 1 API is provided by Pax Logging -->
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
`org.vesalainen.comm:javaxcomm` transitively pulls in the old `log4j:log4j` dependency.

This dependency is not needed because openHAB uses Pax Logging, which provides compatibility for the Log4j 1 API and routes logging through the configured Log4j 2 backend.

Keeping the transitive Log4j 1 dependency causes unnecessary vulnerability warnings in Maven dependency analysis, IDEs, and Dependabot. Since the Core BOM is used by almost every openHAB project, these warnings are propagated widely.

This change excludes the unused `log4j:log4j` dependency from `javaxcomm`.
