### PR TITLE
Fix various startup issues

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptEngineFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptEngineFactory.java
@@ -87,4 +87,14 @@ public interface ScriptEngineFactory {
     default @Nullable ScriptDependencyTracker getDependencyTracker() {
         return null;
     }
+
+    /**
+     * @return {@code true} if the engine is done initializing and is ready to serve, {@code false} otherwise.
+     *
+     * @implNote The default implementation returns {@code true}, making this an optional method that can be used by
+     *           engines that need to do further initialization after bundle activation.
+     */
+    default boolean isReady() {
+        return true;
+    }
 }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineFactoryBundleTracker.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineFactoryBundleTracker.java
@@ -12,15 +12,19 @@
  */
 package org.openhab.core.automation.module.script.internal;
 
+import java.util.Collection;
 import java.util.Dictionary;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.automation.module.script.ScriptEngineFactory;
-import org.openhab.core.service.AbstractServiceBundleTracker;
+import org.openhab.core.service.BaseServiceBundleTracker;
 import org.openhab.core.service.ReadyMarker;
 import org.openhab.core.service.ReadyService;
+import org.openhab.core.service.StartLevelService;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -33,12 +37,17 @@ import org.osgi.service.component.annotations.Reference;
  */
 @NonNullByDefault
 @Component(immediate = true)
-public class ScriptEngineFactoryBundleTracker extends AbstractServiceBundleTracker {
+public class ScriptEngineFactoryBundleTracker extends BaseServiceBundleTracker {
     public static final ReadyMarker READY_MARKER = new ReadyMarker("automation", "scriptEngineFactories");
 
     @Activate
     public ScriptEngineFactoryBundleTracker(final @Reference ReadyService readyService, BundleContext bc) {
-        super(readyService, bc, READY_MARKER);
+        super(readyService, READY_MARKER, bc);
+    }
+
+    @Override
+    protected int minimumStartLevel() {
+        return StartLevelService.STARTLEVEL_MODEL;
     }
 
     @Override
@@ -46,5 +55,29 @@ public class ScriptEngineFactoryBundleTracker extends AbstractServiceBundleTrack
         Dictionary<String, String> headers = bundle.getHeaders();
         String provideCapability = headers.get("Provide-Capability");
         return provideCapability != null && provideCapability.contains(ScriptEngineFactory.class.getName());
+    }
+
+    @Override
+    protected boolean evaluateReady() {
+        boolean ready = super.evaluateReady();
+        if (ready) {
+            try {
+                Collection<ServiceReference<ScriptEngineFactory>> refs = context
+                        .getServiceReferences(ScriptEngineFactory.class, null);
+                for (ServiceReference<ScriptEngineFactory> ref : refs) {
+                    ScriptEngineFactory engineFactory = context.getService(ref);
+                    try {
+                        if (!engineFactory.isReady()) {
+                            return false;
+                        }
+                    } finally {
+                        context.ungetService(ref);
+                    }
+                }
+            } catch (InvalidSyntaxException e) {
+                // Cannot happen when the filter is null
+            }
+        }
+        return ready;
     }
 }

--- a/bundles/org.openhab.core.graal/.classpath
+++ b/bundles/org.openhab.core.graal/.classpath
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
+		<attributes>
+			<attribute name="annotationpath" value="target/dependency"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="annotationpath" value="target/dependency"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path=".apt_generated_tests">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path=".apt_generated">
+		<attributes>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/org.openhab.core.graal/.project
+++ b/bundles/org.openhab.core.graal/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.core.graal</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.openhab.core.graal/NOTICE
+++ b/bundles/org.openhab.core.graal/NOTICE
@@ -1,0 +1,14 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-core
+

--- a/bundles/org.openhab.core.graal/pom.xml
+++ b/bundles/org.openhab.core.graal/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.core.bundles</groupId>
+    <artifactId>org.openhab.core.reactor.bundles</artifactId>
+    <version>5.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.core.graal</artifactId>
+
+  <name>openHAB Core :: Bundles :: Graal</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openhab.osgiify</groupId>
+      <artifactId>org.graalvm.polyglot.polyglot</artifactId>
+      <version>${graalvm.version}</version>
+      <!-- provided as OSGi bundle at runtime, available only at compile time -->
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/bundles/org.openhab.core.graal/src/main/java/org/openhab/core/graal/GraalUtil.java
+++ b/bundles/org.openhab.core.graal/src/main/java/org/openhab/core/graal/GraalUtil.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.graal;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.Language;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A utility class with Graal-related functionality.
+ *
+ * @author Ravi Nadahar - Initial contribution
+ */
+public class GraalUtil {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GraalUtil.class);
+    private static final Object LANGUAGE_INIT_LOCK = new Object();
+    private static final Map<String, Language> CACHED_LANGUAGES = new ConcurrentHashMap<>();
+
+    /**
+     * Thread-safe retrieval of a language from an engine.
+     * Ensures that language initialization happens serially, preventing race conditions
+     * in Graal's internal language cache.
+     */
+    public static @Nullable Language getLanguage(Engine engine, String languageId) {
+        Language cached = CACHED_LANGUAGES.get(languageId);
+        if (cached != null) {
+            return cached;
+        }
+
+        synchronized (LANGUAGE_INIT_LOCK) {
+            // Check again after acquiring lock (another thread may have just populated it)
+            cached = CACHED_LANGUAGES.get(languageId);
+            if (cached != null) {
+                return cached;
+            }
+
+            try {
+                Language lang = engine.getLanguages().get(languageId);
+                if (lang != null) {
+                    CACHED_LANGUAGES.put(languageId, lang);
+                }
+                return lang;
+            } catch (RuntimeException e) {
+                LOGGER.error("Graal: Failed to initialize language: {}", languageId, e);
+                return null;
+            }
+        }
+    }
+
+    /**
+     * Reset the cache (useful for testing or if bundles are dynamically unloaded/reloaded).
+     */
+    public static void clearCache() {
+        synchronized (LANGUAGE_INIT_LOCK) {
+            CACHED_LANGUAGES.clear();
+        }
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceFactoryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceFactoryImpl.java
@@ -69,12 +69,14 @@ public class WatchServiceFactoryImpl implements WatchServiceFactory {
                 Dictionary<String, Object> map = new Hashtable<>();
 
                 map.put("name", name);
+                map.put(WatchService.SERVICE_PROPERTY_NAME, name);
                 map.put("path", basePath.toString());
                 config.update(map);
             } else {
                 Configuration config = configurations[0];
                 Dictionary<String, Object> map = config.getProperties();
                 map.put("name", name);
+                map.put(WatchService.SERVICE_PROPERTY_NAME, name);
                 map.put("path", basePath.toString());
                 config.update(map);
             }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceImpl.java
@@ -22,14 +22,17 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -37,12 +40,19 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.service.WatchService;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.cm.ConfigurationEvent;
+import org.osgi.service.cm.ConfigurationListener;
+import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,21 +83,22 @@ public class WatchServiceImpl implements WatchService, DirectoryChangeListener {
     private final List<Listener> dirPathListeners = new CopyOnWriteArrayList<>();
     private final List<Listener> subDirPathListeners = new CopyOnWriteArrayList<>();
     private final Map<Path, FileHash> hashCache = new ConcurrentHashMap<>();
+    private final ConfigurationAdmin configurationAdmin;
     private final ExecutorService executor;
     private final ScheduledExecutorService scheduler;
 
     private final String name;
     private final BundleContext bundleContext;
-
-    private @Nullable Path basePath;
-    private @Nullable DirectoryWatcher dirWatcher;
-    private @Nullable ServiceRegistration<WatchService> reg;
+    private volatile @Nullable Path basePath;
+    volatile @Nullable DirectoryWatcher dirWatcher;
 
     private final Map<Path, ScheduledFuture<?>> scheduledEvents = new HashMap<>();
     private final Map<Path, List<DirectoryChangeEvent>> scheduledEventKinds = new ConcurrentHashMap<>();
 
     @Activate
-    public WatchServiceImpl(WatchServiceConfiguration config, BundleContext bundleContext) throws IOException {
+    public WatchServiceImpl(@Reference ConfigurationAdmin configurationAdmin, WatchServiceConfiguration config,
+            BundleContext bundleContext, ComponentContext componentContext) throws IOException {
+        this.configurationAdmin = configurationAdmin;
         this.bundleContext = bundleContext;
         if (config.name().isBlank()) {
             throw new IllegalArgumentException("service name must not be blank");
@@ -96,11 +107,11 @@ public class WatchServiceImpl implements WatchService, DirectoryChangeListener {
         this.name = config.name();
         executor = Executors.newSingleThreadExecutor(r -> new Thread(r, name));
         scheduler = ThreadPoolManager.getScheduledPool("watchservice");
-        modified(config);
+        modified(config, componentContext);
     }
 
     @Modified
-    public void modified(WatchServiceConfiguration config) throws IOException {
+    public void modified(WatchServiceConfiguration config, final ComponentContext componentContext) throws IOException {
         logger.trace("Trying to setup WatchService '{}' with path '{}'", config.name(), config.path());
 
         Path basePath = Path.of(config.path()).toAbsolutePath();
@@ -109,10 +120,11 @@ public class WatchServiceImpl implements WatchService, DirectoryChangeListener {
             return;
         }
 
+        final boolean cycle = this.basePath != null;
         this.basePath = basePath;
 
         try {
-            closeWatcherAndUnregister();
+            closeWatcher();
 
             if (!Files.exists(basePath)) {
                 logger.info("Watch directory '{}' does not exist. Trying to create it.", basePath);
@@ -120,12 +132,64 @@ public class WatchServiceImpl implements WatchService, DirectoryChangeListener {
             }
 
             DirectoryWatcher newDirWatcher = DirectoryWatcher.builder().listener(this).path(basePath).build();
-            CompletableFuture
-                    .runAsync(
-                            () -> newDirWatcher.watchAsync(executor)
-                                    .thenRun(() -> logger.debug("WatchService '{}' has been shut down.", name)),
-                            ThreadPoolManager.getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON))
-                    .thenRun(this::registerWatchService);
+            ThreadPoolManager.getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON).execute(() -> {
+                if (cycle) {
+                    Object pid = componentContext.getProperties().get("service.pid");
+                    if (pid instanceof String pidString) {
+                        Configuration[] configs = null;
+                        try {
+                            configs = configurationAdmin.listConfigurations("(service.pid=" + pidString + ")");
+                        } catch (IOException | InvalidSyntaxException e) {
+                            logger.warn("WatchService '{}': Failed to acquire configuration, cannot restart service",
+                                    name, e);
+                        }
+
+                        if (configs != null && configs.length > 0) {
+                            final AtomicReference<@Nullable ServiceRegistration<ConfigurationListener>> registrationReference = new AtomicReference<>();
+
+                            ConfigurationListener tempListener = new ConfigurationListener() {
+                                @Override
+                                public void configurationEvent(@Nullable ConfigurationEvent event) {
+                                    if (event != null && event.getType() == ConfigurationEvent.CM_DELETED
+                                            && pidString.equals(event.getPid())) {
+                                        logger.debug("WatchService '{}': Configuration deleted", name);
+
+                                        // Unregister the listener first, this is a one trick pony
+                                        ServiceRegistration<ConfigurationListener> registration = registrationReference
+                                                .get();
+                                        if (registration != null) {
+                                            try {
+                                                registration.unregister();
+                                            } catch (IllegalStateException e) {
+                                                // Already unregistered
+                                            }
+                                        }
+
+                                        createConfiguration(basePath);
+                                    }
+                                }
+                            };
+
+                            ServiceRegistration<ConfigurationListener> registration = bundleContext
+                                    .registerService(ConfigurationListener.class, tempListener, null);
+                            registrationReference.set(registration);
+                            try {
+                                configs[0].delete();
+                            } catch (IOException | RuntimeException e) {
+                                logger.warn("WatchService '{}': Failed to delete configuration, cannot restart service",
+                                        name, e);
+                                try {
+                                    registration.unregister();
+                                } catch (IllegalStateException e2) {
+                                    // Already unregistered
+                                }
+                            }
+                        }
+                    }
+                }
+                newDirWatcher.watchAsync(executor)
+                        .thenRun(() -> logger.debug("WatchService '{}' has been shut down.", name));
+            });
             this.dirWatcher = newDirWatcher;
         } catch (NoSuchFileException e) {
             // log message here, otherwise it'll be swallowed by the call to newInstance in the factory
@@ -143,35 +207,45 @@ public class WatchServiceImpl implements WatchService, DirectoryChangeListener {
     @Deactivate
     public void deactivate() {
         try {
-            closeWatcherAndUnregister();
-            executor.shutdown();
+            closeWatcher();
+            executor.shutdownNow();
+            try {
+                executor.awaitTermination(1000L, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                // We still want to cancel the scheduled events, so let it be re-caught after that
+            }
+            synchronized (scheduledEvents) {
+                for (ScheduledFuture<?> future : scheduledEvents.values()) {
+                    if (!future.isDone()) {
+                        future.cancel(true);
+                    }
+                }
+                for (ScheduledFuture<?> future : scheduledEvents.values()) {
+                    if (!future.isDone()) {
+                        try {
+                            future.get(1000L, TimeUnit.MILLISECONDS);
+                        } catch (CancellationException e) {
+                            // This is what we want. move on
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            return;
+                        } catch (ExecutionException | TimeoutException e) {
+                            logger.debug("Failed to conclude scheduled event during deactivate: {}", e.getMessage(), e);
+                        }
+                    }
+                }
+            }
         } catch (IOException e) {
             logger.warn("Failed to shutdown WatchService '{}'", name, e);
         }
     }
 
-    private void registerWatchService() {
-        Dictionary<String, Object> properties = new Hashtable<>();
-        properties.put(WatchService.SERVICE_PROPERTY_NAME, name);
-        this.reg = bundleContext.registerService(WatchService.class, this, properties);
-        logger.debug("WatchService '{}' completed initialization and registered itself as service.", name);
-    }
-
-    private void closeWatcherAndUnregister() throws IOException {
+    private void closeWatcher() throws IOException {
         DirectoryWatcher localDirWatcher = this.dirWatcher;
         if (localDirWatcher != null) {
             localDirWatcher.close();
             this.dirWatcher = null;
-        }
-
-        ServiceRegistration<?> localReg = this.reg;
-        if (localReg != null) {
-            try {
-                localReg.unregister();
-            } catch (IllegalStateException e) {
-                logger.debug("WatchService '{}' was already unregistered.", name, e);
-            }
-            this.reg = null;
         }
 
         hashCache.clear();
@@ -230,8 +304,36 @@ public class WatchServiceImpl implements WatchService, DirectoryChangeListener {
                 future.cancel(true);
             }
             future = scheduler.schedule(() -> notifyListeners(path), PROCESSING_TIME, TimeUnit.MILLISECONDS);
-            scheduledEventKinds.computeIfAbsent(path, k -> new CopyOnWriteArrayList<>()).add(directoryChangeEvent);
+            Objects.requireNonNull(scheduledEventKinds.computeIfAbsent(path, k -> new CopyOnWriteArrayList<>()))
+                    .add(directoryChangeEvent);
             scheduledEvents.put(path, future);
+        }
+    }
+
+    private void createConfiguration(Path basePath) {
+        logger.debug("WatchService '{}': Creating new configuration for path '{}'", name, basePath);
+        try {
+            String filter = "(&(name=" + name + ")" + "(service.factoryPid=" + WatchService.SERVICE_PID + "))";
+            Configuration[] configurations = configurationAdmin.listConfigurations(filter);
+
+            if (configurations == null || configurations.length == 0) {
+                Configuration c = configurationAdmin.createFactoryConfiguration(WatchService.SERVICE_PID, "?");
+                Dictionary<String, Object> map = new Hashtable<>();
+
+                map.put("name", name);
+                map.put(WatchService.SERVICE_PROPERTY_NAME, name);
+                map.put("path", basePath.toString());
+                c.update(map);
+            } else {
+                Configuration c = configurations[0];
+                Dictionary<String, Object> map = c.getProperties();
+                map.put("name", name);
+                map.put(WatchService.SERVICE_PROPERTY_NAME, name);
+                map.put("path", basePath.toString());
+                c.update(map);
+            }
+        } catch (IOException | InvalidSyntaxException e) {
+            logger.error("WatchService '{}': Failed to create configuration with path '{}'", name, basePath, e);
         }
     }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/BaseServiceBundleTracker.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/BaseServiceBundleTracker.java
@@ -22,52 +22,70 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
 import org.osgi.util.tracker.BundleTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The {@link AbstractServiceBundleTracker} tracks a set of bundles (selected {@link #isRelevantBundle(Bundle)}
- * and sets the
- * {@link #readyMarker} when all registered bundles are active
+ * The {@link BaseServiceBundleTracker} tracks a set of bundles (selected {@link #isRelevantBundle(Bundle)} and sets
+ * the {@link #readyMarker} when all registered bundles are active. Methods can be overridden to add additional
+ * conditions that must be fulfilled.
  *
- * @author Jan N. Klug - Initial contribution
+ * @author Ravi Nadahar - Initial contribution
  */
 @NonNullByDefault
-public abstract class AbstractServiceBundleTracker extends BundleTracker<Bundle> implements ReadyService.ReadyTracker {
+public abstract class BaseServiceBundleTracker extends BundleTracker<Bundle> implements ReadyService.ReadyTracker {
     private static final int STATE_MASK = Bundle.INSTALLED | Bundle.RESOLVED | Bundle.ACTIVE | Bundle.STARTING
             | Bundle.STOPPING | Bundle.UNINSTALLED;
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(BaseServiceBundleTracker.class);
 
     private final ReadyService readyService;
     private final ReadyMarker readyMarker;
 
     private final Map<String, Integer> bundles = new ConcurrentHashMap<>();
-    private volatile boolean startLevel = false;
-    private volatile boolean ready = false;
+    private volatile boolean startLevelReached = false;
+
+    // All access must be guarded by "this"
+    private boolean ready = false;
 
     @Activate
-    public AbstractServiceBundleTracker(final @Reference ReadyService readyService, BundleContext bc,
-            ReadyMarker readyMarker) {
+    public BaseServiceBundleTracker(ReadyService readyService, ReadyMarker readyMarker, BundleContext bc) {
         super(bc, STATE_MASK, null);
         this.readyService = readyService;
         this.readyMarker = readyMarker;
         this.open();
 
-        readyService.registerTracker(this, new ReadyMarkerFilter().withType(StartLevelService.STARTLEVEL_MARKER_TYPE)
-                .withIdentifier(Integer.toString(StartLevelService.STARTLEVEL_MODEL)));
+        int minLevel = minimumStartLevel();
+        if (minLevel >= 0) {
+            readyService.registerTracker(this, new ReadyMarkerFilter()
+                    .withType(StartLevelService.STARTLEVEL_MARKER_TYPE).withIdentifier(Integer.toString(minLevel)));
+        } else {
+            startLevelReached = true;
+        }
     }
 
     @Deactivate
     public void deactivate() throws Exception {
         this.close();
-        ready = false;
+        synchronized (this) {
+            ready = false;
+        }
     }
 
-    private boolean allBundlesActive() {
-        return bundles.values().stream().allMatch(i -> i == Bundle.ACTIVE);
-    }
+    /**
+     * The minimum startlevel when this tracker might mark the {@code readyMarker} ready;
+     *
+     * @return The minimum startlevel or a negative value to disable.
+     */
+    protected abstract int minimumStartLevel();
+
+    /**
+     * Decide if a bundle should be tracked by this bundle tracker.
+     *
+     * @param bundle the bundle to evaluate.
+     * @return {@code true} if the bundle should be tracked, {@code false} otherwise.
+     */
+    protected abstract boolean isRelevantBundle(Bundle bundle);
 
     @Override
     public Bundle addingBundle(@NonNullByDefault({}) Bundle bundle, @Nullable BundleEvent event) {
@@ -76,7 +94,7 @@ public abstract class AbstractServiceBundleTracker extends BundleTracker<Bundle>
         if (isRelevantBundle(bundle)) {
             logger.debug("Added {}: {} ", bsn, stateToString(state));
             bundles.put(bsn, state);
-            checkReady();
+            handleChange();
         }
 
         return bundle;
@@ -90,7 +108,7 @@ public abstract class AbstractServiceBundleTracker extends BundleTracker<Bundle>
         if (isRelevantBundle(bundle)) {
             logger.debug("Modified {}: {}", bsn, stateToString(state));
             bundles.put(bsn, state);
-            checkReady();
+            handleChange();
         }
     }
 
@@ -101,41 +119,55 @@ public abstract class AbstractServiceBundleTracker extends BundleTracker<Bundle>
         if (isRelevantBundle(bundle)) {
             logger.debug("Removed {}", bsn);
             bundles.remove(bsn);
-            checkReady();
+            handleChange();
         }
     }
 
     @Override
     public void onReadyMarkerAdded(ReadyMarker readyMarker) {
         logger.debug("Readymarker '{}' added", readyMarker);
-        startLevel = true;
-        checkReady();
+        startLevelReached = true;
+        handleChange();
     }
 
     @Override
     public void onReadyMarkerRemoved(ReadyMarker readyMarker) {
         logger.debug("Readymarker '{}' removed", readyMarker);
-        startLevel = false;
-        ready = false;
-        readyService.unmarkReady(readyMarker);
+        startLevelReached = false;
+        handleChange();
     }
 
-    private synchronized void checkReady() {
-        boolean allBundlesActive = allBundlesActive();
-        logger.trace("ready: {}, startlevel: {}, allActive: {}", ready, startLevel, allBundlesActive);
+    protected void handleChange() {
+        logger.trace("{} before change: ready: {}, startLevelReached: {}", getClass().getSimpleName(), ready,
+                startLevelReached);
 
-        if (!ready && startLevel && allBundlesActive) {
-            logger.debug("Adding ready marker '{}': All bundles ready ({})", readyMarker, bundles);
-            readyService.markReady(readyMarker);
-            ready = true;
-        } else if (ready && !allBundlesActive) {
-            logger.debug("Removing ready marker '{}' : Not all bundles ready ({})", readyMarker, bundles);
-            readyService.unmarkReady(readyMarker);
-            ready = false;
+        boolean newReady = evaluateReady();
+        synchronized (this) {
+            if (ready != newReady) {
+                ready = newReady;
+                if (newReady) {
+                    logger.debug("All conditions met, marking readymarker '{}' ready ({})", readyMarker, bundles);
+                    readyService.markReady(readyMarker);
+                } else {
+                    logger.debug("All conditions not met, marking readymarker '{}' not ready ({})", readyMarker,
+                            bundles);
+                    readyService.unmarkReady(readyMarker);
+                }
+                logger.trace("{} after change: ready: {}, startLevelReached: {}", getClass().getSimpleName(), ready,
+                        startLevelReached);
+            }
         }
     }
 
-    private String stateToString(int state) {
+    protected boolean evaluateReady() {
+        return startLevelReached && allBundlesActive();
+    }
+
+    protected boolean allBundlesActive() {
+        return bundles.values().stream().allMatch(i -> i == Bundle.ACTIVE);
+    }
+
+    protected String stateToString(int state) {
         return switch (state) {
             case Bundle.UNINSTALLED -> "UNINSTALLED";
             case Bundle.INSTALLED -> "INSTALLED";
@@ -146,12 +178,4 @@ public abstract class AbstractServiceBundleTracker extends BundleTracker<Bundle>
             default -> "UNKNOWN";
         };
     }
-
-    /**
-     * Decide if a bundle should be tracked by this bundle tracker
-     *
-     * @param bundle the bundle
-     * @return {@code true} if the bundle should be considered, {@code false} otherwise
-     */
-    protected abstract boolean isRelevantBundle(Bundle bundle);
 }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/WatchServiceImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/WatchServiceImplTest.java
@@ -22,6 +22,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.AfterEach;
@@ -37,6 +39,11 @@ import org.openhab.core.JavaTest;
 import org.openhab.core.service.WatchService;
 import org.openhab.core.service.WatchService.Kind;
 import org.osgi.framework.BundleContext;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.ComponentContext;
+
+import io.methvin.watcher.DirectoryChangeListener;
+import io.methvin.watcher.DirectoryWatcher;
 
 /**
  * The {@link WatchServiceImplTest} is a
@@ -52,21 +59,23 @@ public class WatchServiceImplTest extends JavaTest {
     private static final String TEST_FILE_NAME = "testFile";
 
     public @Mock @NonNullByDefault({}) WatchServiceImpl.WatchServiceConfiguration configurationMock;
+    public @Mock @NonNullByDefault({}) ComponentContext componentContextMock;
     public @Mock @NonNullByDefault({}) BundleContext bundleContextMock;
+    public @Mock @NonNullByDefault({}) ConfigurationAdmin configurationAdminMock;
 
     private @NonNullByDefault({}) WatchServiceImpl watchService;
     private @TempDir @NonNullByDefault({}) Path rootPath;
     private @NonNullByDefault({}) TestWatchEventListener listener;
 
     @BeforeEach
-    public void setup() throws IOException {
+    public void setup() throws Exception {
         when(configurationMock.name()).thenReturn("unnamed");
         when(configurationMock.path()).thenReturn(rootPath.toString());
 
-        watchService = new WatchServiceImpl(configurationMock, bundleContextMock);
+        watchService = new WatchServiceImpl(configurationAdminMock, configurationMock, bundleContextMock,
+                componentContextMock);
         listener = new TestWatchEventListener();
-
-        verify(bundleContextMock, timeout(5000)).registerService(eq(WatchService.class), eq(watchService), any());
+        waitForDirWatcher();
     }
 
     @AfterEach
@@ -232,6 +241,35 @@ public class WatchServiceImplTest extends JavaTest {
         assertThat(listener.events, hasSize(1));
         assertThat(listener.events, hasItem(new Event(fullPath, kind)));
         listener.events.clear();
+    }
+
+    private void waitForDirWatcher() throws IOException, InterruptedException {
+        while (!isDirWatcherReady()) {
+            Thread.sleep(5L);
+        }
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        WatchService.WatchEventListener warmUpListener = new WatchService.WatchEventListener() {
+
+            @Override
+            public void processWatchEvent(Kind kind, Path fullPath) {
+                latch.countDown();
+            }
+        };
+        Path pingFile = rootPath.resolve("watcher-warmup.ping");
+        watchService.registerListener(warmUpListener, pingFile, false);
+        Files.createFile(pingFile);
+        latch.await(1000L, TimeUnit.MILLISECONDS);
+        watchService.unregisterListener(warmUpListener);
+    }
+
+    private boolean isDirWatcherReady() {
+        DirectoryWatcher watcher = watchService.dirWatcher;
+        if (watcher == null) {
+            return false;
+        }
+        DirectoryChangeListener listener = watcher.getListener();
+        return listener != null && listener.isWatching();
     }
 
     private static class TestWatchEventListener implements WatchService.WatchEventListener {

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -116,6 +116,7 @@
     <module>org.openhab.core.test.magic</module>
     <module>org.openhab.core.ui</module>
     <module>org.openhab.core.ui.icon</module>
+    <module>org.openhab.core.graal</module>
   </modules>
 
   <properties>

--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -556,4 +556,11 @@
 		<feature>openhab-core-io-transport-upnp</feature>
 	</feature>
 
+	<feature name="openhab-core-graal" description="Graal Shared" version="${project.version}">
+		<requirement>openhab.tp;filter:="(feature=graal-common)"</requirement>
+		<feature dependency="true">openhab.tp-graal-common</feature>
+
+		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.graal/${project.version}</bundle>
+	</feature>
+
 </features>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -289,4 +289,47 @@
 		<bundle dependency="true">mvn:org.javassist/javassist/3.30.2-GA</bundle>
 	</feature>
 
+	<feature name="openhab.tp-graal-polyglot" description="Graal Polyglot" version="${project.version}">
+		<capability>openhab.tp;feature=graal-polyglot;version=${graalvm.version}</capability>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.polyglot.polyglot/${graalvm.version}</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.collections/${graalvm.version}</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.word/${graalvm.version}</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.jniutils/${graalvm.version}</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.sdk.nativeimage/${graalvm.version}</bundle>
+
+		<!-- This is only needed because of the reqirement on the polyglot bundle -->
+		<feature dependency="true">spifly</feature>
+	</feature>
+
+	<feature name="openhab.tp-graal-common" description="Graal Common" version="${project.version}">
+		<capability>openhab.tp;feature=graal-common;version=${graalvm.version}</capability>
+		<feature dependency="true">openhab.tp-graal-polyglot</feature>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.regex.regex/${graalvm.version}</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.icu4j/${graalvm.version}</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.json/${graalvm.version}</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.shadowed.xz/${graalvm.version}</bundle>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.tools.chromeinspector-tool/${graalvm.version}</bundle>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.tools.profiler-tool/${graalvm.version}</bundle>
+		<bundle dependency="true" start-level="79">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-api/${graalvm.version}</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-compiler/${graalvm.version}</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-runtime/${graalvm.version}</bundle>
+	</feature>
+
+	<feature name="openhab.tp-graal-javascript" description="Graal JavaScript" version="${project.version}">
+		<capability>openhab.tp;feature=graal-javascript;version=${graalvm.version}</capability>
+		<feature dependency="true">openhab.tp-graal-common</feature>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.js.js-language/${graalvm.version}</bundle>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.js.js-scriptengine/${graalvm.version}</bundle>
+	</feature>
+
+	<feature name="openhab.tp-graal-python" description="Graal Python" version="${project.version}">
+		<capability>openhab.tp;feature=graal-python;version=${graalvm.version}</capability>
+		<feature dependency="true">openhab.tp-graal-common</feature>
+		<bundle dependency="true">mvn:org.openhab.osgiify/org.graalvm.llvm.llvm-api/${graalvm.version}</bundle>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.python.python-resources/${graalvm.version}</bundle>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.python.python-language/${graalvm.version}</bundle>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-nfi/${graalvm.version}</bundle>
+		<bundle dependency="true" start-level="78">mvn:org.openhab.osgiify/org.graalvm.truffle.truffle-nfi-libffi/${graalvm.version}</bundle>
+	</feature>
+
 </features>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <eea.version>2.4.0</eea.version>
     <karaf.compile.version>4.4.11</karaf.compile.version>
     <karaf.tooling.version>4.4.11</karaf.tooling.version>
+    <graalvm.version>25.0.1</graalvm.version>
     <sat.version>0.18.0</sat.version>
     <slf4j.version>2.0.17</slf4j.version>
     <xtext.version>2.43.0</xtext.version>


### PR DESCRIPTION
This started out with a narrow focus on the Graal problems (and there's an upcoming companion PR for add-ons), but grew as I found more problems.

It's really 3 parts:

* A shared Graal language lock that is intended to make sure that every bundle sees the same languages. There are many design decisions to be discussed here, the whole organisation of where to put this shared code, features, bundles etc. - and whether the lock is the right solution.
* A modification of how the `automation/scriptEngineFactories` ready marker for start level 40 works. Up until now, the script engines have been considered ready as soon as the bundle has started. But, that's not actually "true", some of them need some time to initialize asynchronously. I've created a mechanism to make it actually wait until the engine says it's "ready". This defaults to `true` so that engines that don't implement this will still work the "old way" - that is, satisfy the requirement as soon as the bundle has been activated.
* A refactoring of how `WatchServiceImpl` registers with OSGi. The current implementation mixes declarative style/annotations and programmatic registration, which causes problems. These problems have probably been around since #3004. DS is single-threaded, so it's not thread-safe. Making other threads also do registrations causes problems with visibility between components, which manifests, for example, with services that are claimed to be `ACTIVE` return `null` instances. I've managed to find a way to avoid doing manual service registration by manipulating `ConfigurationAdmin` instead. It seems to relieve the problem.

I'm leaving it as a draft, since I'm sure there are many things that will need to be changed/rearranged etc.

What can be said is that with this, and the corresponding changes I've done to `addons`, JS scripting and Python scripting seem to be able to coexist happily, and startup behavior seems much more consistent/predictable without these "random failures" that currently exist where the solution is to ask the user to restart OH. I haven't built and tested this under Karaf, but I strongly suspect that this will make it possible to install/uninstall Graal add-ons dynamically, without having to restart OH, like all other add-ons.