### PR TITLE
Fix DSL implicit contexts variables for '.rules' based rules

### DIFF
--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
@@ -39,6 +39,8 @@ import org.slf4j.LoggerFactory
 import org.eclipse.xtext.common.types.JvmFormalParameter
 import org.eclipse.emf.common.util.EList
 import org.openhab.core.automation.module.script.rulesupport.shared.ValueCache
+import java.util.Map
+import org.openhab.core.events.Event
 
 /**
  * <p>Infers a JVM model from the source model.</p> 
@@ -108,6 +110,9 @@ class RulesJvmModelInferrer extends ScriptJvmModelInferrer {
             members += ruleModel.rules.map [ rule |
                 rule.toMethod("_" + rule.name, typeRef(Void.TYPE)) [
                     static = true
+                    parameters += rule.toParameter(VAR_EVENT_OBJECT, typeRef(Event))
+                    parameters += rule.toParameter(VAR_CTX, typeRef(Map, typeRef(String), typeRef(Object)))
+                    parameters += rule.toParameter(VAR_INPUTS, typeRef(Map, typeRef(String), typeRef(Map, typeRef(String), typeRef(Object))))
                     val privateCacheTypeRef = typeRef(ValueCache)
                     parameters += rule.toParameter(VAR_PRIVATE_CACHE, privateCacheTypeRef)
                     val sharedCacheTypeRef = typeRef(ValueCache)

--- a/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
+++ b/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
@@ -208,9 +208,9 @@ public class DSLScriptEngine implements javax.script.ScriptEngine {
                 }
             }
         }
-        evalContext.newValue(QualifiedName.create("ctx"), ctx);
-        evalContext.newValue(QualifiedName.create("eventObject"), eventObject);
-        evalContext.newValue(QualifiedName.create("inputs"), inputs);
+        evalContext.newValue(QualifiedName.create(ScriptJvmModelInferrer.VAR_CTX), ctx);
+        evalContext.newValue(QualifiedName.create(ScriptJvmModelInferrer.VAR_EVENT_OBJECT), eventObject);
+        evalContext.newValue(QualifiedName.create(ScriptJvmModelInferrer.VAR_INPUTS), inputs);
 
         Map<String, Object> cachePreset = scriptExtensionAccessor.findPreset("cache",
                 (String) context.getAttribute("oh.engine-identifier", ScriptContext.ENGINE_SCOPE));

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
@@ -91,6 +91,11 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
     /** Variable name for the cache */
     public static final String VAR_PRIVATE_CACHE = "privateCache";
     public static final String VAR_SHARED_CACHE = "sharedCache";
+    
+    /** Variable names for the context objects */
+    public static final String VAR_EVENT_OBJECT = "eventObject";
+    public static final String VAR_CTX = "ctx";
+    public static final String VAR_INPUTS = "inputs";
 
     /**
      * convenience API to build and initialize JvmTypes and their members.
@@ -139,9 +144,9 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
 
             members += script.toMethod("_script", null) [
                 static = true
-                parameters += script.toParameter("eventObject", typeRef(Event))
-                parameters += script.toParameter("ctx", typeRef(Map, typeRef(String), typeRef(Object)))
-                parameters += script.toParameter("inputs", typeRef(Map, typeRef(String), typeRef(Map, typeRef(String), typeRef(Object))))
+                parameters += script.toParameter(VAR_EVENT_OBJECT, typeRef(Event))
+                parameters += script.toParameter(VAR_CTX, typeRef(Map, typeRef(String), typeRef(Object)))
+                parameters += script.toParameter(VAR_INPUTS, typeRef(Map, typeRef(String), typeRef(Map, typeRef(String), typeRef(Object))))
                 val inputTypeRef = typeRef(String)
                 parameters += script.toParameter(VAR_INPUT, inputTypeRef)
                 val groupTypeRef = typeRef(Item)


### PR DESCRIPTION
This is a little follow-up of #5607. It turns out that I forgot to include the implicit variables in the `model.rule` bundle, so that they don't apply when a rule is parsed from a `.rules` file. This PR fixes that.

Should be backported.