### PR TITLE
[openapi] make slots in UIComponent optional

### DIFF
--- a/bundles/org.openhab.core.sitemap/.classpath
+++ b/bundles/org.openhab.core.sitemap/.classpath
@@ -38,5 +38,16 @@
 			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/org.openhab.core.sitemap/.classpath
+++ b/bundles/org.openhab.core.sitemap/.classpath
@@ -38,16 +38,5 @@
 			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="target/generated-sources/annotations">
-		<attributes>
-			<attribute name="optional" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/UIComponent.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/UIComponent.java
@@ -34,9 +34,10 @@ import io.swagger.v3.oas.annotations.media.Schema.AdditionalPropertiesValue;
  * @author Yannick Schaus - Initial contribution
  */
 public class UIComponent {
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     String component;
 
-    @Schema(additionalProperties = AdditionalPropertiesValue.TRUE)
+    @Schema(additionalProperties = AdditionalPropertiesValue.TRUE, requiredMode = Schema.RequiredMode.REQUIRED)
     Map<String, Object> config;
 
     Map<String, List<UIComponent>> slots = null;


### PR DESCRIPTION
Now that the #5686 has been solved with the new version of swagger and the slots element is included in UIComponent, slots is an optional element.