### PR TITLE
docs: fix typo ocurred -> occurred in REST log API docs

### DIFF
--- a/bundles/org.openhab.core.io.rest.log/README.md
+++ b/bundles/org.openhab.core.io.rest.log/README.md
@@ -40,7 +40,7 @@ but also compatible to [Apiary](apiary.com) for automatic doc generation and API
                 + `info`
                 + `debug`
 
-        + url (string, optional) - The URL where the log event ocurred.
+        + url (string, optional) - The URL where the log event occurred.
         + message (string, optional) - The message to log.
 
     + Body


### PR DESCRIPTION
## Description

One-word typo fix in `bundles/org.openhab.core.io.rest.log/README.md:43`:

> `+ url (string, optional) - The URL where the log event ocurred.`

→ "occurred".

This is the human-readable description of the `url` field in the API Blueprint definition; the field name itself is untouched. `ocurred` occurs exactly once in the repository, so there is nothing else to keep in sync.

Documentation only — no code or behaviour changes.

Commit is signed off per `CONTRIBUTING.md`.
