### PR TITLE
Improve test coverage for existing auth behavior

### DIFF
--- a/bundles/org.openhab.core.io.rest.auth/src/test/java/org/openhab/core/io/rest/auth/AuthFilterTest.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/test/java/org/openhab/core/io/rest/auth/AuthFilterTest.java
@@ -12,14 +12,19 @@
  */
 package org.openhab.core.io.rest.auth;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.SecurityContext;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,13 +36,21 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.openhab.core.auth.Authentication;
+import org.openhab.core.auth.AuthenticationException;
+import org.openhab.core.auth.Credentials;
+import org.openhab.core.auth.ManagedUser;
+import org.openhab.core.auth.Role;
 import org.openhab.core.auth.UserRegistry;
 import org.openhab.core.io.rest.auth.internal.JwtHelper;
+import org.openhab.core.io.rest.auth.internal.JwtSecurityContext;
+import org.openhab.core.io.rest.auth.internal.UserSecurityContext;
 
 /**
  * The {@link AuthFilterTest} is a
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Gabor Bicskei - Added regression tests for auth behavior
  */
 @NonNullByDefault
 @ExtendWith(MockitoExtension.class)
@@ -112,5 +125,347 @@ public class AuthFilterTest {
         authFilter.filter(containerRequestContext);
 
         verify(containerRequestContext, never()).setSecurityContext(any());
+    }
+
+    // --- New regression tests below use a manually constructed AuthFilter to avoid mock reference issues ---
+
+    private AuthFilter createAuthFilter() {
+        AuthFilter filter = new AuthFilter(jwtHelperMock, userRegistryMock);
+        return filter;
+    }
+
+    // --- JWT Bearer Token Auth ---
+
+    @Test
+    public void jwtBearerTokenSetsJwtSecurityContext() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of(AuthFilter.CONFIG_IMPLICIT_USER_ROLE, false));
+        Authentication auth = new Authentication("testuser", Role.ADMIN);
+        when(jwtHelperMock.verifyAndParseJwtAccessToken("valid.jwt.token")).thenReturn(auth);
+        when(servletRequest.getHeader("X-OPENHAB-TOKEN")).thenReturn(null);
+        when(servletRequest.getHeader("Authorization")).thenReturn("Bearer valid.jwt.token");
+
+        SecurityContext sc = filter.getSecurityContext(servletRequest, false);
+
+        assertNotNull(sc);
+        assertInstanceOf(JwtSecurityContext.class, sc);
+    }
+
+    @Test
+    public void invalidJwtBearerTokenThrowsAuthenticationException() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of(AuthFilter.CONFIG_IMPLICIT_USER_ROLE, false));
+        when(jwtHelperMock.verifyAndParseJwtAccessToken("bad.jwt.token"))
+                .thenThrow(new AuthenticationException("Invalid token"));
+        when(servletRequest.getHeader("X-OPENHAB-TOKEN")).thenReturn(null);
+        when(servletRequest.getHeader("Authorization")).thenReturn("Bearer bad.jwt.token");
+
+        assertThrows(AuthenticationException.class, () -> filter.getSecurityContext(servletRequest, false));
+    }
+
+    // --- API Token (oh.*) Auth ---
+
+    @Test
+    public void apiTokenSetsUserSecurityContext() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of(AuthFilter.CONFIG_IMPLICIT_USER_ROLE, false));
+        Authentication auth = new Authentication("testuser", Role.ADMIN);
+        ManagedUser user = new ManagedUser("testuser", "salt", "hash");
+        user.setRoles(Set.of(Role.ADMIN));
+        when(userRegistryMock.authenticate(any(Credentials.class))).thenReturn(auth);
+        when(userRegistryMock.get("testuser")).thenReturn(user);
+        when(servletRequest.getHeader("X-OPENHAB-TOKEN")).thenReturn(null);
+        when(servletRequest.getHeader("Authorization")).thenReturn("Bearer oh.mytoken.secretvalue");
+
+        SecurityContext sc = filter.getSecurityContext(servletRequest, false);
+
+        assertNotNull(sc);
+        assertInstanceOf(UserSecurityContext.class, sc);
+        assertEquals("ApiToken", sc.getAuthenticationScheme());
+    }
+
+    @Test
+    public void apiTokenUserNotFoundThrowsAuthenticationException() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of(AuthFilter.CONFIG_IMPLICIT_USER_ROLE, false));
+        Authentication auth = new Authentication("testuser", Role.ADMIN);
+        when(userRegistryMock.authenticate(any(Credentials.class))).thenReturn(auth);
+        when(userRegistryMock.get("testuser")).thenReturn(null);
+        when(servletRequest.getHeader("X-OPENHAB-TOKEN")).thenReturn(null);
+        when(servletRequest.getHeader("Authorization")).thenReturn("Bearer oh.mytoken.secretvalue");
+
+        assertThrows(AuthenticationException.class, () -> filter.getSecurityContext(servletRequest, false));
+    }
+
+    // --- X-OPENHAB-TOKEN Header ---
+
+    @Test
+    public void altAuthHeaderWithJwtToken() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of(AuthFilter.CONFIG_IMPLICIT_USER_ROLE, false));
+        Authentication auth = new Authentication("testuser", Role.USER);
+        when(jwtHelperMock.verifyAndParseJwtAccessToken("jwt.from.header")).thenReturn(auth);
+        when(servletRequest.getHeader("X-OPENHAB-TOKEN")).thenReturn("jwt.from.header");
+
+        SecurityContext sc = filter.getSecurityContext(servletRequest, false);
+
+        assertNotNull(sc);
+        assertInstanceOf(JwtSecurityContext.class, sc);
+    }
+
+    @Test
+    public void altAuthHeaderWithApiToken() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of(AuthFilter.CONFIG_IMPLICIT_USER_ROLE, false));
+        Authentication auth = new Authentication("testuser", Role.ADMIN);
+        ManagedUser user = new ManagedUser("testuser", "salt", "hash");
+        user.setRoles(Set.of(Role.ADMIN));
+        when(userRegistryMock.authenticate(any(Credentials.class))).thenReturn(auth);
+        when(userRegistryMock.get("testuser")).thenReturn(user);
+        when(servletRequest.getHeader("X-OPENHAB-TOKEN")).thenReturn("oh.mytoken.secretvalue");
+
+        SecurityContext sc = filter.getSecurityContext(servletRequest, false);
+
+        assertNotNull(sc);
+        assertInstanceOf(UserSecurityContext.class, sc);
+        assertEquals("ApiToken", sc.getAuthenticationScheme());
+    }
+
+    @Test
+    public void altAuthHeaderTakesPrecedenceOverAuthorizationHeader() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of(AuthFilter.CONFIG_IMPLICIT_USER_ROLE, false));
+        Authentication auth = new Authentication("testuser", Role.USER);
+        when(jwtHelperMock.verifyAndParseJwtAccessToken("alt.header.token")).thenReturn(auth);
+        when(servletRequest.getHeader("X-OPENHAB-TOKEN")).thenReturn("alt.header.token");
+        when(servletRequest.getHeader("Authorization")).thenReturn("Bearer other.jwt.token");
+
+        filter.getSecurityContext(servletRequest, false);
+
+        verify(jwtHelperMock).verifyAndParseJwtAccessToken("alt.header.token");
+        verify(jwtHelperMock, never()).verifyAndParseJwtAccessToken("other.jwt.token");
+    }
+
+    // --- Basic Auth ---
+
+    @Test
+    public void basicAuthWithUsernamePasswordWhenAllowed() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of(AuthFilter.CONFIG_IMPLICIT_USER_ROLE, false, AuthFilter.CONFIG_ALLOW_BASIC_AUTH, true));
+        String credentials = Base64.getEncoder().encodeToString("testuser:testpass".getBytes(StandardCharsets.UTF_8));
+        Authentication auth = new Authentication("testuser", Role.ADMIN);
+        ManagedUser user = new ManagedUser("testuser", "salt", "hash");
+        user.setRoles(Set.of(Role.ADMIN));
+        when(userRegistryMock.authenticate(any(Credentials.class))).thenReturn(auth);
+        when(userRegistryMock.get("testuser")).thenReturn(user);
+        when(servletRequest.getHeader("X-OPENHAB-TOKEN")).thenReturn(null);
+        when(servletRequest.getHeader("Authorization")).thenReturn("Basic " + credentials);
+
+        SecurityContext sc = filter.getSecurityContext(servletRequest, false);
+
+        assertNotNull(sc);
+        assertInstanceOf(UserSecurityContext.class, sc);
+        assertEquals("Basic", sc.getAuthenticationScheme());
+    }
+
+    @Test
+    public void basicAuthWithUsernamePasswordWhenDisabledThrowsAuthenticationException() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of(AuthFilter.CONFIG_IMPLICIT_USER_ROLE, false, AuthFilter.CONFIG_ALLOW_BASIC_AUTH, false));
+        String credentials = Base64.getEncoder().encodeToString("testuser:testpass".getBytes(StandardCharsets.UTF_8));
+        when(servletRequest.getHeader("X-OPENHAB-TOKEN")).thenReturn(null);
+        when(servletRequest.getHeader("Authorization")).thenReturn("Basic " + credentials);
+
+        assertThrows(AuthenticationException.class, () -> filter.getSecurityContext(servletRequest, false));
+    }
+
+    @Test
+    public void basicAuthSinglePartTreatedAsBearerToken() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of(AuthFilter.CONFIG_IMPLICIT_USER_ROLE, false));
+        String singlePartToken = Base64.getEncoder().encodeToString("some-jwt-token".getBytes(StandardCharsets.UTF_8));
+        Authentication auth = new Authentication("testuser", Role.USER);
+        when(jwtHelperMock.verifyAndParseJwtAccessToken("some-jwt-token")).thenReturn(auth);
+        when(servletRequest.getHeader("X-OPENHAB-TOKEN")).thenReturn(null);
+        when(servletRequest.getHeader("Authorization")).thenReturn("Basic " + singlePartToken);
+
+        SecurityContext sc = filter.getSecurityContext(servletRequest, false);
+
+        assertNotNull(sc);
+        assertInstanceOf(JwtSecurityContext.class, sc);
+    }
+
+    @Test
+    public void basicAuthMoreThanTwoPartsThrowsAuthenticationException() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of(AuthFilter.CONFIG_IMPLICIT_USER_ROLE, false, AuthFilter.CONFIG_ALLOW_BASIC_AUTH, true));
+        String credentials = Base64.getEncoder().encodeToString("user:pass:extra".getBytes(StandardCharsets.UTF_8));
+        when(servletRequest.getHeader("X-OPENHAB-TOKEN")).thenReturn(null);
+        when(servletRequest.getHeader("Authorization")).thenReturn("Basic " + credentials);
+
+        assertThrows(AuthenticationException.class, () -> filter.getSecurityContext(servletRequest, false));
+    }
+
+    // --- Query Token (accessToken parameter) ---
+
+    @Test
+    public void queryTokenAllowedWithBearerToken() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of(AuthFilter.CONFIG_IMPLICIT_USER_ROLE, false));
+        Authentication auth = new Authentication("testuser", Role.USER);
+        when(jwtHelperMock.verifyAndParseJwtAccessToken("jwt.query.token")).thenReturn(auth);
+        when(servletRequest.getHeader("X-OPENHAB-TOKEN")).thenReturn(null);
+        when(servletRequest.getHeader("Authorization")).thenReturn(null);
+        when(servletRequest.getParameterMap()).thenReturn(Map.of("accessToken", new String[] { "jwt.query.token" }));
+
+        SecurityContext sc = filter.getSecurityContext(servletRequest, true);
+
+        assertNotNull(sc);
+        assertInstanceOf(JwtSecurityContext.class, sc);
+    }
+
+    @Test
+    public void queryTokenFallsBackToBasicAuthWhenBearerFails() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of(AuthFilter.CONFIG_IMPLICIT_USER_ROLE, false, AuthFilter.CONFIG_ALLOW_BASIC_AUTH, true));
+        String base64Credentials = Base64.getEncoder()
+                .encodeToString("testuser:testpass".getBytes(StandardCharsets.UTF_8));
+        when(jwtHelperMock.verifyAndParseJwtAccessToken(base64Credentials))
+                .thenThrow(new AuthenticationException("not a JWT"));
+        Authentication auth = new Authentication("testuser", Role.USER);
+        ManagedUser user = new ManagedUser("testuser", "salt", "hash");
+        user.setRoles(Set.of(Role.USER));
+        when(userRegistryMock.authenticate(any(Credentials.class))).thenReturn(auth);
+        when(userRegistryMock.get("testuser")).thenReturn(user);
+        when(servletRequest.getHeader("X-OPENHAB-TOKEN")).thenReturn(null);
+        when(servletRequest.getHeader("Authorization")).thenReturn(null);
+        when(servletRequest.getParameterMap()).thenReturn(Map.of("accessToken", new String[] { base64Credentials }));
+
+        SecurityContext sc = filter.getSecurityContext(servletRequest, true);
+
+        assertNotNull(sc);
+        assertInstanceOf(UserSecurityContext.class, sc);
+    }
+
+    @Test
+    public void queryTokenNotUsedWhenAllowQueryTokenIsFalse() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of(AuthFilter.CONFIG_IMPLICIT_USER_ROLE, false));
+        when(servletRequest.getHeader("X-OPENHAB-TOKEN")).thenReturn(null);
+        when(servletRequest.getHeader("Authorization")).thenReturn(null);
+        when(servletRequest.getParameterMap()).thenReturn(Map.of("accessToken", new String[] { "some.token" }));
+
+        SecurityContext sc = filter.getSecurityContext(servletRequest, false);
+
+        assertNull(sc);
+    }
+
+    // --- Credential Checking Order ---
+
+    @Test
+    public void noCredentialsNoImplicitRoleReturnsNull() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of(AuthFilter.CONFIG_IMPLICIT_USER_ROLE, false));
+        when(servletRequest.getHeader("X-OPENHAB-TOKEN")).thenReturn(null);
+        when(servletRequest.getHeader("Authorization")).thenReturn(null);
+
+        SecurityContext sc = filter.getSecurityContext(servletRequest, false);
+
+        assertNull(sc);
+    }
+
+    @Test
+    public void noCredentialsWithImplicitRoleReturnsAnonymousContext() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of(AuthFilter.CONFIG_IMPLICIT_USER_ROLE, true));
+        when(servletRequest.getHeader("X-OPENHAB-TOKEN")).thenReturn(null);
+        when(servletRequest.getHeader("Authorization")).thenReturn(null);
+
+        SecurityContext sc = filter.getSecurityContext(servletRequest, false);
+
+        assertNotNull(sc);
+        assertInstanceOf(AnonymousUserSecurityContext.class, sc);
+    }
+
+    // --- Basic Auth Caching ---
+
+    @Test
+    public void basicAuthCachedOnSecondCall() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of(AuthFilter.CONFIG_IMPLICIT_USER_ROLE, false, AuthFilter.CONFIG_ALLOW_BASIC_AUTH, true));
+        String credentials = Base64.getEncoder().encodeToString("testuser:testpass".getBytes(StandardCharsets.UTF_8));
+        Authentication auth = new Authentication("testuser", Role.ADMIN);
+        ManagedUser user = new ManagedUser("testuser", "salt", "hash");
+        user.setRoles(Set.of(Role.ADMIN));
+        when(userRegistryMock.authenticate(any(Credentials.class))).thenReturn(auth);
+        when(userRegistryMock.get("testuser")).thenReturn(user);
+        when(servletRequest.getHeader("X-OPENHAB-TOKEN")).thenReturn(null);
+        when(servletRequest.getHeader("Authorization")).thenReturn("Basic " + credentials);
+
+        filter.getSecurityContext(servletRequest, false);
+        filter.getSecurityContext(servletRequest, false);
+
+        verify(userRegistryMock, times(1)).authenticate(any(Credentials.class));
+    }
+
+    @Test
+    public void basicAuthCacheDisabledWithZeroExpiration() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of(AuthFilter.CONFIG_IMPLICIT_USER_ROLE, false, AuthFilter.CONFIG_ALLOW_BASIC_AUTH, true,
+                AuthFilter.CONFIG_CACHE_EXPIRATION, 0L));
+        String credentials = Base64.getEncoder().encodeToString("testuser:testpass".getBytes(StandardCharsets.UTF_8));
+        Authentication auth = new Authentication("testuser", Role.ADMIN);
+        ManagedUser user = new ManagedUser("testuser", "salt", "hash");
+        user.setRoles(Set.of(Role.ADMIN));
+        when(userRegistryMock.authenticate(any(Credentials.class))).thenReturn(auth);
+        when(userRegistryMock.get("testuser")).thenReturn(user);
+        when(servletRequest.getHeader("X-OPENHAB-TOKEN")).thenReturn(null);
+        when(servletRequest.getHeader("Authorization")).thenReturn("Basic " + credentials);
+
+        filter.getSecurityContext(servletRequest, false);
+        filter.getSecurityContext(servletRequest, false);
+
+        verify(userRegistryMock, times(2)).authenticate(any(Credentials.class));
+    }
+
+    // --- getSecurityContext(String bearerToken) overload ---
+
+    @Test
+    public void getSecurityContextWithNullBearerTokenReturnsNull() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of());
+
+        SecurityContext sc = filter.getSecurityContext((String) null);
+
+        assertNull(sc);
+    }
+
+    @Test
+    public void getSecurityContextWithJwtBearerToken() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of());
+        Authentication auth = new Authentication("testuser", Role.USER);
+        when(jwtHelperMock.verifyAndParseJwtAccessToken("my.jwt.token")).thenReturn(auth);
+
+        SecurityContext sc = filter.getSecurityContext("my.jwt.token");
+
+        assertNotNull(sc);
+        assertInstanceOf(JwtSecurityContext.class, sc);
+    }
+
+    @Test
+    public void getSecurityContextWithApiTokenBearerToken() throws Exception {
+        AuthFilter filter = createAuthFilter();
+        filter.activate(Map.of());
+        Authentication auth = new Authentication("testuser", Role.ADMIN);
+        ManagedUser user = new ManagedUser("testuser", "salt", "hash");
+        user.setRoles(Set.of(Role.ADMIN));
+        when(userRegistryMock.authenticate(any(Credentials.class))).thenReturn(auth);
+        when(userRegistryMock.get("testuser")).thenReturn(user);
+
+        SecurityContext sc = filter.getSecurityContext("oh.mytoken.secretvalue");
+
+        assertNotNull(sc);
+        assertInstanceOf(UserSecurityContext.class, sc);
     }
 }

--- a/bundles/org.openhab.core.io.rest.auth/src/test/java/org/openhab/core/io/rest/auth/internal/JwtHelperTest.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/test/java/org/openhab/core/io/rest/auth/internal/JwtHelperTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.io.rest.auth.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.jose4j.jwk.RsaJsonWebKey;
+import org.jose4j.jwk.RsaJwkGenerator;
+import org.jose4j.jws.AlgorithmIdentifiers;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.NumericDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.auth.Authentication;
+import org.openhab.core.auth.AuthenticationException;
+import org.openhab.core.auth.GenericUser;
+import org.openhab.core.auth.Role;
+import org.openhab.core.auth.User;
+
+/**
+ * Tests for {@link JwtHelper}.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public class JwtHelperTest {
+
+    private static final String ISSUER_NAME = "openhab";
+    private static final String AUDIENCE = "openhab";
+
+    private @NonNullByDefault({}) JwtHelper jwtHelper;
+
+    @BeforeEach
+    public void setup() {
+        // JwtHelper persists its RSA key under OpenHAB.getUserDataFolder()/secrets. The userdata folder is redirected
+        // to target/openhab/userdata via the surefire 'openhab.userdata' system property in the root pom, so the key
+        // never lands in the source tree and is removed by 'mvn clean'. Setting it on the JVM command line is required
+        // because JwtHelper.KEY_FILE_PATH is a static final field resolved once at class-initialization time, which can
+        // happen before any test callback runs (for example when another test class creates a JwtHelper mock).
+        jwtHelper = new JwtHelper();
+    }
+
+    /**
+     * Returns the RSA key that the {@link JwtHelper} instance under test uses for signing and verification. The key is
+     * read directly from the instance's private {@code jwtWebKey} field via reflection rather than re-read from disk,
+     * which guarantees it is exactly the key material {@code JwtHelper} signs and verifies with. Tokens crafted with it
+     * are therefore rejected only for the reason under test (expiration or issuer), never for a signature mismatch.
+     */
+    private RsaJsonWebKey getJwtHelperKey() throws Exception {
+        Field keyField = JwtHelper.class.getDeclaredField("jwtWebKey");
+        keyField.setAccessible(true);
+        return (RsaJsonWebKey) keyField.get(jwtHelper);
+    }
+
+    // --- Token Creation ---
+
+    @Test
+    public void tokenCreationReturnsNonEmptyString() {
+        User user = new GenericUser("testuser", Set.of(Role.ADMIN));
+        String token = jwtHelper.getJwtAccessToken(user, "test-client", "admin", 60);
+
+        assertNotNull(token);
+        assertFalse(token.isEmpty());
+    }
+
+    @Test
+    public void tokenHasThreeParts() {
+        User user = new GenericUser("testuser", Set.of(Role.USER));
+        String token = jwtHelper.getJwtAccessToken(user, "test-client", "user", 60);
+
+        // JWT compact serialization has 3 dot-separated parts: header.payload.signature
+        String[] parts = token.split("\\.");
+        assertEquals(3, parts.length);
+    }
+
+    @Test
+    public void tokenClaimsContainCorrectSubject() throws Exception {
+        User user = new GenericUser("admin_user", Set.of(Role.ADMIN));
+        String token = jwtHelper.getJwtAccessToken(user, "my-client", "admin", 60);
+
+        Authentication auth = jwtHelper.verifyAndParseJwtAccessToken(token);
+        assertEquals("admin_user", auth.getUsername());
+    }
+
+    @Test
+    public void tokenClaimsContainCorrectRoles() throws Exception {
+        User user = new GenericUser("admin_user", Set.of(Role.ADMIN, Role.USER));
+        String token = jwtHelper.getJwtAccessToken(user, "my-client", "admin", 60);
+
+        Authentication auth = jwtHelper.verifyAndParseJwtAccessToken(token);
+        assertTrue(auth.getRoles().contains(Role.ADMIN));
+        assertTrue(auth.getRoles().contains(Role.USER));
+    }
+
+    @Test
+    public void tokenClaimsContainCorrectScope() throws Exception {
+        User user = new GenericUser("testuser", Set.of(Role.USER));
+        String token = jwtHelper.getJwtAccessToken(user, "my-client", "user", 60);
+
+        Authentication auth = jwtHelper.verifyAndParseJwtAccessToken(token);
+        assertEquals("user", auth.getScope());
+    }
+
+    @Test
+    public void tokenWithNoRoles() throws Exception {
+        User user = new GenericUser("testuser", Set.of());
+        String token = jwtHelper.getJwtAccessToken(user, "my-client", "admin", 60);
+
+        Authentication auth = jwtHelper.verifyAndParseJwtAccessToken(token);
+        assertTrue(auth.getRoles().isEmpty());
+    }
+
+    // --- Token Verification ---
+
+    @Test
+    public void validTokenVerifiesSuccessfully() throws Exception {
+        User user = new GenericUser("testuser", Set.of(Role.ADMIN));
+        String token = jwtHelper.getJwtAccessToken(user, "test-client", "admin", 60);
+
+        Authentication auth = jwtHelper.verifyAndParseJwtAccessToken(token);
+
+        assertNotNull(auth);
+        assertEquals("testuser", auth.getUsername());
+    }
+
+    @Test
+    public void expiredTokenThrowsAuthenticationException() throws Exception {
+        // Build a genuinely expired token signed with the SAME key JwtHelper uses, so the only reason verification
+        // fails is the expired 'exp' claim (and not a malformed token or a signature/issuer mismatch). All other
+        // required claims (issuer, audience, subject, valid signature) are present and correct. The expiration is set
+        // well beyond JwtHelper's 30 second allowed clock skew.
+        RsaJsonWebKey key = getJwtHelperKey();
+
+        NumericDate expiredAt = NumericDate.now();
+        expiredAt.addSeconds(-600); // 10 minutes in the past
+
+        JwtClaims claims = new JwtClaims();
+        claims.setIssuer(ISSUER_NAME);
+        claims.setAudience(AUDIENCE);
+        claims.setExpirationTime(expiredAt);
+        claims.setGeneratedJwtId();
+        claims.setIssuedAt(expiredAt);
+        claims.setNotBefore(expiredAt);
+        claims.setSubject("testuser");
+        claims.setStringListClaim("role", List.of(Role.ADMIN));
+        claims.setClaim("scope", "admin");
+
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setPayload(claims.toJson());
+        jws.setKey(key.getPrivateKey());
+        jws.setKeyIdHeaderValue(key.getKeyId());
+        jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.RSA_USING_SHA256);
+
+        String expiredToken = jws.getCompactSerialization();
+
+        assertThrows(AuthenticationException.class, () -> {
+            jwtHelper.verifyAndParseJwtAccessToken(expiredToken);
+        });
+    }
+
+    @Test
+    public void malformedTokenThrowsAuthenticationException() {
+        assertThrows(AuthenticationException.class, () -> {
+            jwtHelper.verifyAndParseJwtAccessToken("not-a-jwt");
+        });
+    }
+
+    @Test
+    public void emptyTokenThrowsAuthenticationException() {
+        assertThrows(AuthenticationException.class, () -> {
+            jwtHelper.verifyAndParseJwtAccessToken("");
+        });
+    }
+
+    @Test
+    public void wrongSignatureTokenThrowsAuthenticationException() throws Exception {
+        // Create a token signed with a DIFFERENT RSA key
+        RsaJsonWebKey differentKey = RsaJwkGenerator.generateJwk(2048);
+
+        JwtClaims claims = new JwtClaims();
+        claims.setIssuer(ISSUER_NAME);
+        claims.setAudience(AUDIENCE);
+        claims.setExpirationTimeMinutesInTheFuture(60);
+        claims.setGeneratedJwtId();
+        claims.setIssuedAtToNow();
+        claims.setNotBeforeMinutesInThePast(2);
+        claims.setSubject("testuser");
+        claims.setStringListClaim("role", List.of(Role.ADMIN));
+        claims.setClaim("scope", "admin");
+
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setPayload(claims.toJson());
+        jws.setKey(differentKey.getPrivateKey());
+        jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.RSA_USING_SHA256);
+
+        String tokenWithWrongKey = jws.getCompactSerialization();
+
+        assertThrows(AuthenticationException.class, () -> {
+            jwtHelper.verifyAndParseJwtAccessToken(tokenWithWrongKey);
+        });
+    }
+
+    @Test
+    public void tokenWithWrongIssuerThrowsAuthenticationException() throws Exception {
+        // Sign with the SAME key JwtHelper uses but set a wrong 'iss' claim, so the ONLY reason verification fails is
+        // the issuer mismatch (the signature is valid and all other required claims are present and correct). This
+        // isolates the test to actual issuer enforcement rather than a signature verification failure.
+        RsaJsonWebKey key = getJwtHelperKey();
+
+        JwtClaims claims = new JwtClaims();
+        claims.setIssuer("wrong-issuer");
+        claims.setAudience(AUDIENCE);
+        claims.setExpirationTimeMinutesInTheFuture(60);
+        claims.setGeneratedJwtId();
+        claims.setIssuedAtToNow();
+        claims.setNotBeforeMinutesInThePast(2);
+        claims.setSubject("testuser");
+        claims.setStringListClaim("role", List.of(Role.ADMIN));
+        claims.setClaim("scope", "admin");
+
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setPayload(claims.toJson());
+        jws.setKey(key.getPrivateKey());
+        jws.setKeyIdHeaderValue(key.getKeyId());
+        jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.RSA_USING_SHA256);
+
+        String wrongIssuerToken = jws.getCompactSerialization();
+
+        assertThrows(AuthenticationException.class, () -> {
+            jwtHelper.verifyAndParseJwtAccessToken(wrongIssuerToken);
+        });
+    }
+
+    // --- Round Trip ---
+
+    @Test
+    public void roundTripPreservesAllFields() throws Exception {
+        User user = new GenericUser("myuser", Set.of(Role.ADMIN, Role.USER));
+        String token = jwtHelper.getJwtAccessToken(user, "test-client-id", "admin user", 60);
+
+        Authentication auth = jwtHelper.verifyAndParseJwtAccessToken(token);
+
+        assertEquals("myuser", auth.getUsername());
+        assertEquals(Set.of(Role.ADMIN, Role.USER), auth.getRoles());
+        assertEquals("admin user", auth.getScope());
+    }
+
+    @Test
+    public void multipleTokensForSameUserAreDistinct() {
+        User user = new GenericUser("testuser", Set.of(Role.ADMIN));
+        String token1 = jwtHelper.getJwtAccessToken(user, "client1", "admin", 60);
+        String token2 = jwtHelper.getJwtAccessToken(user, "client2", "admin", 60);
+
+        // Different JTI and potentially different iat means different tokens
+        assertNotEquals(token1, token2);
+    }
+
+    // --- Key Persistence ---
+
+    @Test
+    public void twoJwtHelperInstancesShareSameKey() throws Exception {
+        // Both instances should load the same key from disk
+        JwtHelper helper2 = new JwtHelper();
+
+        User user = new GenericUser("testuser", Set.of(Role.ADMIN));
+        String token = jwtHelper.getJwtAccessToken(user, "client", "admin", 60);
+
+        // The second instance should be able to verify tokens created by the first
+        Authentication auth = helper2.verifyAndParseJwtAccessToken(token);
+        assertEquals("testuser", auth.getUsername());
+    }
+}

--- a/bundles/org.openhab.core.io.rest.auth/src/test/java/org/openhab/core/io/rest/auth/internal/RolesAllowedDynamicFeatureImplTest.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/test/java/org/openhab/core/io/rest/auth/internal/RolesAllowedDynamicFeatureImplTest.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.io.rest.auth.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Method;
+import java.security.Principal;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.core.auth.Role;
+
+/**
+ * Tests for {@link RolesAllowedDynamicFeatureImpl}.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class RolesAllowedDynamicFeatureImplTest {
+
+    private @NonNullByDefault({}) RolesAllowedDynamicFeatureImpl feature;
+
+    private @Mock @NonNullByDefault({}) ResourceInfo resourceInfo;
+    private @Mock @NonNullByDefault({}) FeatureContext featureContext;
+    private @Mock @NonNullByDefault({}) ContainerRequestContext requestContext;
+    private @Mock @NonNullByDefault({}) SecurityContext securityContext;
+
+    @BeforeEach
+    public void setup() {
+        feature = new RolesAllowedDynamicFeatureImpl();
+        when(requestContext.getSecurityContext()).thenReturn(securityContext);
+    }
+
+    // --- Helper methods and test resource classes ---
+
+    private ContainerRequestFilter captureRegisteredFilter() {
+        ArgumentCaptor<ContainerRequestFilter> captor = ArgumentCaptor.forClass(ContainerRequestFilter.class);
+        verify(featureContext).register(captor.capture());
+        return captor.getValue();
+    }
+
+    private void configureMethod(Class<?> resourceClass, String methodName) throws NoSuchMethodException {
+        Method method = resourceClass.getMethod(methodName);
+        when(resourceInfo.getResourceMethod()).thenReturn(method);
+        when(resourceInfo.getResourceClass()).thenReturn((Class) resourceClass);
+    }
+
+    // --- Test resource classes with various annotations ---
+
+    @SuppressWarnings("unused")
+    public static class AdminOnlyResource {
+        @RolesAllowed({ Role.ADMIN })
+        public void adminMethod() {
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class UserAndAdminResource {
+        @RolesAllowed({ Role.USER, Role.ADMIN })
+        public void userOrAdminMethod() {
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class DenyAllResource {
+        @DenyAll
+        public void deniedMethod() {
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class PermitAllResource {
+        @PermitAll
+        public void openMethod() {
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @RolesAllowed({ Role.ADMIN })
+    public static class ClassLevelRolesResource {
+        public void inheritedMethod() {
+        }
+
+        @PermitAll
+        public void permitAllMethod() {
+        }
+
+        @RolesAllowed({ Role.USER })
+        public void overriddenMethod() {
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class NoAnnotationResource {
+        public void unannotatedMethod() {
+        }
+    }
+
+    // --- @RolesAllowed({ Role.ADMIN }) tests ---
+
+    @Test
+    public void adminOnlyMethodAllowsAdminRole() throws Exception {
+        configureMethod(AdminOnlyResource.class, "adminMethod");
+        feature.configure(resourceInfo, featureContext);
+
+        ContainerRequestFilter filter = captureRegisteredFilter();
+
+        when(securityContext.isUserInRole(Role.ADMIN)).thenReturn(true);
+        when(securityContext.getUserPrincipal()).thenReturn(mock(Principal.class));
+
+        filter.filter(requestContext);
+
+        // Should not abort — admin is allowed
+        verify(requestContext, never()).abortWith(any());
+    }
+
+    @Test
+    public void adminOnlyMethodBlocksUserRole() throws Exception {
+        configureMethod(AdminOnlyResource.class, "adminMethod");
+        feature.configure(resourceInfo, featureContext);
+
+        ContainerRequestFilter filter = captureRegisteredFilter();
+
+        when(securityContext.isUserInRole(Role.ADMIN)).thenReturn(false);
+        when(securityContext.getUserPrincipal()).thenReturn(mock(Principal.class));
+
+        filter.filter(requestContext);
+
+        // Should abort with 403 — authenticated but wrong role
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(requestContext).abortWith(responseCaptor.capture());
+        assertEquals(403, responseCaptor.getValue().getStatus());
+    }
+
+    @Test
+    public void adminOnlyMethodReturns401ForUnauthenticated() throws Exception {
+        configureMethod(AdminOnlyResource.class, "adminMethod");
+        feature.configure(resourceInfo, featureContext);
+
+        ContainerRequestFilter filter = captureRegisteredFilter();
+
+        when(securityContext.isUserInRole(Role.ADMIN)).thenReturn(false);
+        when(securityContext.getUserPrincipal()).thenReturn(null);
+
+        filter.filter(requestContext);
+
+        // Should abort with 401 — not authenticated
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(requestContext).abortWith(responseCaptor.capture());
+        assertEquals(401, responseCaptor.getValue().getStatus());
+    }
+
+    // --- @RolesAllowed({ Role.USER, Role.ADMIN }) tests ---
+
+    @Test
+    public void userOrAdminMethodAllowsAdminRole() throws Exception {
+        configureMethod(UserAndAdminResource.class, "userOrAdminMethod");
+        feature.configure(resourceInfo, featureContext);
+
+        ContainerRequestFilter filter = captureRegisteredFilter();
+
+        when(securityContext.isUserInRole(Role.ADMIN)).thenReturn(true);
+
+        filter.filter(requestContext);
+
+        verify(requestContext, never()).abortWith(any());
+    }
+
+    @Test
+    public void userOrAdminMethodAllowsUserRole() throws Exception {
+        configureMethod(UserAndAdminResource.class, "userOrAdminMethod");
+        feature.configure(resourceInfo, featureContext);
+
+        ContainerRequestFilter filter = captureRegisteredFilter();
+
+        when(securityContext.isUserInRole(Role.USER)).thenReturn(true);
+
+        filter.filter(requestContext);
+
+        verify(requestContext, never()).abortWith(any());
+    }
+
+    @Test
+    public void userOrAdminMethodDeniesUnknownRole() throws Exception {
+        configureMethod(UserAndAdminResource.class, "userOrAdminMethod");
+        feature.configure(resourceInfo, featureContext);
+
+        ContainerRequestFilter filter = captureRegisteredFilter();
+
+        when(securityContext.isUserInRole(anyString())).thenReturn(false);
+        when(securityContext.getUserPrincipal()).thenReturn(mock(Principal.class));
+
+        filter.filter(requestContext);
+
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(requestContext).abortWith(responseCaptor.capture());
+        assertEquals(403, responseCaptor.getValue().getStatus());
+    }
+
+    // --- @DenyAll tests ---
+
+    @Test
+    public void denyAllReturns401ForUnauthenticated() throws Exception {
+        configureMethod(DenyAllResource.class, "deniedMethod");
+        feature.configure(resourceInfo, featureContext);
+
+        ContainerRequestFilter filter = captureRegisteredFilter();
+
+        when(securityContext.getUserPrincipal()).thenReturn(null);
+
+        filter.filter(requestContext);
+
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(requestContext).abortWith(responseCaptor.capture());
+        assertEquals(401, responseCaptor.getValue().getStatus());
+    }
+
+    @Test
+    public void denyAllReturns403ForAuthenticated() throws Exception {
+        configureMethod(DenyAllResource.class, "deniedMethod");
+        feature.configure(resourceInfo, featureContext);
+
+        ContainerRequestFilter filter = captureRegisteredFilter();
+
+        when(securityContext.getUserPrincipal()).thenReturn(mock(Principal.class));
+
+        filter.filter(requestContext);
+
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(requestContext).abortWith(responseCaptor.capture());
+        assertEquals(403, responseCaptor.getValue().getStatus());
+    }
+
+    // --- @PermitAll tests ---
+
+    @Test
+    public void permitAllDoesNotRegisterFilter() throws Exception {
+        configureMethod(PermitAllResource.class, "openMethod");
+        feature.configure(resourceInfo, featureContext);
+
+        verify(featureContext, never()).register(any(ContainerRequestFilter.class));
+    }
+
+    // --- Class-level annotation tests ---
+
+    @Test
+    public void classLevelRolesAllowedAppliesToUnannotatedMethod() throws Exception {
+        configureMethod(ClassLevelRolesResource.class, "inheritedMethod");
+        feature.configure(resourceInfo, featureContext);
+
+        ContainerRequestFilter filter = captureRegisteredFilter();
+
+        // Admin role matches class-level @RolesAllowed
+        when(securityContext.isUserInRole(Role.ADMIN)).thenReturn(true);
+
+        filter.filter(requestContext);
+
+        verify(requestContext, never()).abortWith(any());
+    }
+
+    @Test
+    public void classLevelRolesAllowedBlocksWrongRole() throws Exception {
+        configureMethod(ClassLevelRolesResource.class, "inheritedMethod");
+        feature.configure(resourceInfo, featureContext);
+
+        ContainerRequestFilter filter = captureRegisteredFilter();
+
+        when(securityContext.isUserInRole(Role.ADMIN)).thenReturn(false);
+        when(securityContext.getUserPrincipal()).thenReturn(mock(Principal.class));
+
+        filter.filter(requestContext);
+
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(requestContext).abortWith(responseCaptor.capture());
+        assertEquals(403, responseCaptor.getValue().getStatus());
+    }
+
+    @Test
+    public void permitAllOnMethodOverridesClassLevelRoles() throws Exception {
+        configureMethod(ClassLevelRolesResource.class, "permitAllMethod");
+        feature.configure(resourceInfo, featureContext);
+
+        // @PermitAll on method should prevent filter registration
+        verify(featureContext, never()).register(any(ContainerRequestFilter.class));
+    }
+
+    @Test
+    public void methodLevelRolesAllowedOverridesClassLevel() throws Exception {
+        configureMethod(ClassLevelRolesResource.class, "overriddenMethod");
+        feature.configure(resourceInfo, featureContext);
+
+        ContainerRequestFilter filter = captureRegisteredFilter();
+
+        // Method says @RolesAllowed(USER), so USER should be allowed even though class says ADMIN
+        when(securityContext.isUserInRole(Role.USER)).thenReturn(true);
+
+        filter.filter(requestContext);
+
+        verify(requestContext, never()).abortWith(any());
+    }
+
+    // --- No annotation tests ---
+
+    @Test
+    public void noAnnotationDoesNotRegisterFilter() throws Exception {
+        configureMethod(NoAnnotationResource.class, "unannotatedMethod");
+        feature.configure(resourceInfo, featureContext);
+
+        verify(featureContext, never()).register(any(ContainerRequestFilter.class));
+    }
+}

--- a/bundles/org.openhab.core.io.rest.auth/src/test/java/org/openhab/core/io/rest/auth/internal/TokenResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/test/java/org/openhab/core/io/rest/auth/internal/TokenResourceTest.java
@@ -1,0 +1,572 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.io.rest.auth.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.security.MessageDigest;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.jose4j.base64url.Base64Url;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.core.auth.ManagedUser;
+import org.openhab.core.auth.PendingToken;
+import org.openhab.core.auth.Role;
+import org.openhab.core.auth.UserRegistry;
+import org.openhab.core.auth.UserSession;
+
+/**
+ * Tests for {@link TokenResource}.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class TokenResourceTest {
+
+    private @NonNullByDefault({}) TokenResource tokenResource;
+
+    private @Mock @NonNullByDefault({}) UserRegistry userRegistryMock;
+    private @Mock @NonNullByDefault({}) JwtHelper jwtHelperMock;
+    private @Mock @NonNullByDefault({}) SecurityContext securityContextMock;
+
+    @BeforeEach
+    public void setup() {
+        tokenResource = new TokenResource(userRegistryMock, jwtHelperMock);
+        when(jwtHelperMock.getJwtAccessToken(any(), any(), any(), eq(TokenResource.TOKEN_LIFETIME)))
+                .thenReturn("mock.jwt.token");
+    }
+
+    // --- Helper methods ---
+
+    /**
+     * Calls TokenResource.getToken with proper null handling for parameters that are nullable at runtime
+     * but declared as @NonNull due to class-level @NonNullByDefault on TokenResource.
+     */
+    @NonNullByDefault({})
+    private Response callGetToken(String grantType, String code, String redirectUri, String clientId,
+            String refreshToken, String codeVerifier, boolean useCookie, Cookie sessionCookie) {
+        return tokenResource.getToken(grantType, code, redirectUri, clientId, refreshToken, codeVerifier, useCookie,
+                sessionCookie);
+    }
+
+    /**
+     * Calls TokenResource.deleteSession with proper null handling.
+     */
+    @NonNullByDefault({})
+    private Response callDeleteSession(String refreshToken, String id, Cookie sessionCookie,
+            SecurityContext securityContext) {
+        return tokenResource.deleteSession(refreshToken, id, sessionCookie, securityContext);
+    }
+
+    private ManagedUser createUserWithPendingToken(String username, String authCode, String clientId,
+            String redirectUri, String scope) {
+        return createUserWithPendingToken(username, authCode, clientId, redirectUri, scope, null, null);
+    }
+
+    @NonNullByDefault({})
+    private ManagedUser createUserWithPendingToken(String username, String authCode, String clientId,
+            String redirectUri, String scope, String codeChallenge, String codeChallengeMethod) {
+        ManagedUser user = new ManagedUser(username, "salt", "hash");
+        user.setRoles(new HashSet<>(Set.of(Role.ADMIN)));
+        PendingToken pendingToken = new PendingToken(authCode, clientId, redirectUri, scope, codeChallenge,
+                codeChallengeMethod);
+        user.setPendingToken(pendingToken);
+        return user;
+    }
+
+    private ManagedUser createUserWithSession(String username, String refreshToken, String sessionId, String clientId,
+            String redirectUri, String scope) {
+        ManagedUser user = new ManagedUser(username, "salt", "hash");
+        user.setRoles(new HashSet<>(Set.of(Role.ADMIN)));
+        UserSession session = new UserSession(sessionId, refreshToken, clientId, redirectUri, scope);
+        user.setSessions(new ArrayList<>(List.of(session)));
+        return user;
+    }
+
+    // --- Authorization Code Grant ---
+
+    @Test
+    public void authorizationCodeGrantHappyPath() {
+        String authCode = UUID.randomUUID().toString();
+        ManagedUser user = createUserWithPendingToken("testuser", authCode, "test-client", "http://localhost/callback",
+                "admin");
+        when(userRegistryMock.getAll()).thenReturn(List.of(user));
+
+        Response response = callGetToken("authorization_code", authCode, "http://localhost/callback", "test-client",
+                null, null, false, null);
+
+        assertEquals(200, response.getStatus());
+        assertNotNull(response.getEntity());
+        assertInstanceOf(TokenResponseDTO.class, response.getEntity());
+        TokenResponseDTO dto = (TokenResponseDTO) response.getEntity();
+        assertEquals("mock.jwt.token", dto.access_token);
+        assertEquals("bearer", dto.token_type);
+        assertEquals(TokenResource.TOKEN_LIFETIME * 60, dto.expires_in);
+        assertNotNull(dto.refresh_token);
+        assertEquals("admin", dto.scope);
+
+        // Pending token should be cleared
+        assertNull(user.getPendingToken());
+        // Session should be added
+        assertEquals(1, user.getSessions().size());
+    }
+
+    @Test
+    public void authorizationCodeGrantWrongClientId() {
+        String authCode = UUID.randomUUID().toString();
+        ManagedUser user = createUserWithPendingToken("testuser", authCode, "correct-client",
+                "http://localhost/callback", "admin");
+        when(userRegistryMock.getAll()).thenReturn(List.of(user));
+
+        Response response = callGetToken("authorization_code", authCode, "http://localhost/callback", "wrong-client",
+                null, null, false, null);
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    public void authorizationCodeGrantWrongRedirectUri() {
+        String authCode = UUID.randomUUID().toString();
+        ManagedUser user = createUserWithPendingToken("testuser", authCode, "test-client", "http://localhost/callback",
+                "admin");
+        when(userRegistryMock.getAll()).thenReturn(List.of(user));
+
+        Response response = callGetToken("authorization_code", authCode, "http://localhost/wrong", "test-client", null,
+                null, false, null);
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    public void authorizationCodeGrantInvalidCode() {
+        when(userRegistryMock.getAll()).thenReturn(List.of());
+
+        Response response = callGetToken("authorization_code", "invalid-code", "http://localhost/callback",
+                "test-client", null, null, false, null);
+
+        assertEquals(400, response.getStatus());
+    }
+
+    // --- PKCE Validation ---
+
+    @Test
+    public void pkceS256ValidationSucceeds() throws Exception {
+        String codeVerifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
+        String codeChallenge = Base64Url.encode(sha256.digest(codeVerifier.getBytes()));
+
+        String authCode = UUID.randomUUID().toString();
+        ManagedUser user = createUserWithPendingToken("testuser", authCode, "test-client", "http://localhost/callback",
+                "admin", codeChallenge, "S256");
+        when(userRegistryMock.getAll()).thenReturn(List.of(user));
+
+        Response response = callGetToken("authorization_code", authCode, "http://localhost/callback", "test-client",
+                null, codeVerifier, false, null);
+
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void pkceS256ValidationFailsWithWrongVerifier() throws Exception {
+        String correctVerifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
+        String codeChallenge = Base64Url.encode(sha256.digest(correctVerifier.getBytes()));
+
+        String authCode = UUID.randomUUID().toString();
+        ManagedUser user = createUserWithPendingToken("testuser", authCode, "test-client", "http://localhost/callback",
+                "admin", codeChallenge, "S256");
+        when(userRegistryMock.getAll()).thenReturn(List.of(user));
+
+        Response response = callGetToken("authorization_code", authCode, "http://localhost/callback", "test-client",
+                null, "wrong-verifier", false, null);
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    public void pkcePlainValidationSucceeds() {
+        String codeVerifier = "plain-code-challenge";
+
+        String authCode = UUID.randomUUID().toString();
+        ManagedUser user = createUserWithPendingToken("testuser", authCode, "test-client", "http://localhost/callback",
+                "admin", codeVerifier, "plain");
+        when(userRegistryMock.getAll()).thenReturn(List.of(user));
+
+        Response response = callGetToken("authorization_code", authCode, "http://localhost/callback", "test-client",
+                null, codeVerifier, false, null);
+
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void pkcePlainValidationFailsWithWrongVerifier() {
+        String authCode = UUID.randomUUID().toString();
+        ManagedUser user = createUserWithPendingToken("testuser", authCode, "test-client", "http://localhost/callback",
+                "admin", "correct-challenge", "plain");
+        when(userRegistryMock.getAll()).thenReturn(List.of(user));
+
+        Response response = callGetToken("authorization_code", authCode, "http://localhost/callback", "test-client",
+                null, "wrong-verifier", false, null);
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    public void pkceMissingVerifierWhenChallengePresent() {
+        String authCode = UUID.randomUUID().toString();
+        ManagedUser user = createUserWithPendingToken("testuser", authCode, "test-client", "http://localhost/callback",
+                "admin", "some-challenge", "S256");
+        when(userRegistryMock.getAll()).thenReturn(List.of(user));
+
+        // codeVerifier is null
+        Response response = callGetToken("authorization_code", authCode, "http://localhost/callback", "test-client",
+                null, null, false, null);
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    public void noPkceSkipsValidation() {
+        String authCode = UUID.randomUUID().toString();
+        // No code challenge in pending token (both null)
+        ManagedUser user = createUserWithPendingToken("testuser", authCode, "test-client", "http://localhost/callback",
+                "admin");
+        when(userRegistryMock.getAll()).thenReturn(List.of(user));
+
+        Response response = callGetToken("authorization_code", authCode, "http://localhost/callback", "test-client",
+                null, null, false, null);
+
+        assertEquals(200, response.getStatus());
+    }
+
+    // --- Refresh Token Grant ---
+
+    @Test
+    public void refreshTokenGrantHappyPath() {
+        String refreshToken = UUID.randomUUID().toString().replace("-", "");
+        String sessionId = UUID.randomUUID().toString();
+        ManagedUser user = createUserWithSession("testuser", refreshToken, sessionId, "test-client",
+                "http://localhost/callback", "admin");
+        when(userRegistryMock.getAll()).thenReturn(List.of(user));
+
+        Response response = callGetToken("refresh_token", null, null, "test-client", refreshToken, null, false, null);
+
+        assertEquals(200, response.getStatus());
+        assertInstanceOf(TokenResponseDTO.class, response.getEntity());
+        TokenResponseDTO dto = (TokenResponseDTO) response.getEntity();
+        assertEquals("mock.jwt.token", dto.access_token);
+        assertEquals(refreshToken, dto.refresh_token);
+    }
+
+    @Test
+    public void refreshTokenGrantMissingRefreshToken() {
+        Response response = callGetToken("refresh_token", null, null, "test-client", null, null, false, null);
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    public void refreshTokenGrantInvalidRefreshToken() {
+        when(userRegistryMock.getAll()).thenReturn(List.of());
+
+        Response response = callGetToken("refresh_token", null, null, "test-client", "invalid-refresh-token", null,
+                false, null);
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    public void refreshTokenGrantWithSessionCookieValidation() {
+        String refreshToken = UUID.randomUUID().toString().replace("-", "");
+        String sessionId = UUID.randomUUID().toString();
+        ManagedUser user = createUserWithSession("testuser", refreshToken, sessionId, "test-client",
+                "http://localhost/callback", "admin");
+        // Mark session as requiring cookie
+        user.getSessions().get(0).setSessionCookie(true);
+        when(userRegistryMock.getAll()).thenReturn(List.of(user));
+
+        // Provide matching cookie
+        Cookie sessionCookie = new Cookie(TokenResource.SESSIONID_COOKIE_NAME, sessionId);
+
+        Response response = callGetToken("refresh_token", null, null, "test-client", refreshToken, null, false,
+                sessionCookie);
+
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void refreshTokenGrantWithMissingSessionCookieFails() {
+        String refreshToken = UUID.randomUUID().toString().replace("-", "");
+        String sessionId = UUID.randomUUID().toString();
+        ManagedUser user = createUserWithSession("testuser", refreshToken, sessionId, "test-client",
+                "http://localhost/callback", "admin");
+        // Mark session as requiring cookie
+        user.getSessions().get(0).setSessionCookie(true);
+        when(userRegistryMock.getAll()).thenReturn(List.of(user));
+
+        // No cookie provided
+        Response response = callGetToken("refresh_token", null, null, "test-client", refreshToken, null, false, null);
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    public void refreshTokenGrantWithWrongSessionCookieFails() {
+        String refreshToken = UUID.randomUUID().toString().replace("-", "");
+        String sessionId = UUID.randomUUID().toString();
+        ManagedUser user = createUserWithSession("testuser", refreshToken, sessionId, "test-client",
+                "http://localhost/callback", "admin");
+        user.getSessions().get(0).setSessionCookie(true);
+        when(userRegistryMock.getAll()).thenReturn(List.of(user));
+
+        // Wrong cookie value
+        Cookie wrongCookie = new Cookie(TokenResource.SESSIONID_COOKIE_NAME, "wrong-session-id");
+
+        Response response = callGetToken("refresh_token", null, null, "test-client", refreshToken, null, false,
+                wrongCookie);
+
+        assertEquals(400, response.getStatus());
+    }
+
+    // --- Unsupported Grant Type ---
+
+    @Test
+    public void unsupportedGrantTypeReturns400() {
+        Response response = callGetToken("client_credentials", null, null, "test-client", null, null, false, null);
+
+        assertEquals(400, response.getStatus());
+    }
+
+    // --- Sessions Endpoint ---
+
+    @Test
+    public void getSessionsUnauthenticatedReturns401() {
+        when(securityContextMock.getUserPrincipal()).thenReturn(null);
+
+        Response response = tokenResource.getSessions(securityContextMock);
+
+        assertEquals(401, response.getStatus());
+    }
+
+    @Test
+    public void getSessionsUserNotFoundReturns404() {
+        Principal principal = mock(Principal.class);
+        when(principal.getName()).thenReturn("nonexistent");
+        when(securityContextMock.getUserPrincipal()).thenReturn(principal);
+        when(userRegistryMock.get("nonexistent")).thenReturn(null);
+
+        Response response = tokenResource.getSessions(securityContextMock);
+
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void getSessionsForAuthenticatedUserReturns200() {
+        Principal principal = mock(Principal.class);
+        when(principal.getName()).thenReturn("testuser");
+        when(securityContextMock.getUserPrincipal()).thenReturn(principal);
+        ManagedUser user = new ManagedUser("testuser", "salt", "hash");
+        user.setRoles(new HashSet<>(Set.of(Role.ADMIN)));
+        UserSession session = new UserSession(UUID.randomUUID().toString(), "rt", "cid", "http://localhost/callback",
+                "admin");
+        user.setSessions(new ArrayList<>(List.of(session)));
+        when(userRegistryMock.get("testuser")).thenReturn(user);
+
+        Response response = tokenResource.getSessions(securityContextMock);
+
+        assertEquals(200, response.getStatus());
+    }
+
+    // --- API Tokens Endpoint ---
+
+    @Test
+    public void getApiTokensUnauthenticatedReturns401() {
+        when(securityContextMock.getUserPrincipal()).thenReturn(null);
+
+        Response response = tokenResource.getApiTokens(securityContextMock);
+
+        assertEquals(401, response.getStatus());
+    }
+
+    @Test
+    public void getApiTokensUserNotFoundReturns404() {
+        Principal principal = mock(Principal.class);
+        when(principal.getName()).thenReturn("nonexistent");
+        when(securityContextMock.getUserPrincipal()).thenReturn(principal);
+        when(userRegistryMock.get("nonexistent")).thenReturn(null);
+
+        Response response = tokenResource.getApiTokens(securityContextMock);
+
+        assertEquals(404, response.getStatus());
+    }
+
+    // --- Remove API Token Endpoint ---
+
+    @Test
+    public void removeApiTokenUnauthenticatedReturns401() {
+        when(securityContextMock.getUserPrincipal()).thenReturn(null);
+
+        Response response = tokenResource.removeApiToken(securityContextMock, "tokenname");
+
+        assertEquals(401, response.getStatus());
+    }
+
+    @Test
+    public void removeApiTokenNotFoundReturns404() {
+        Principal principal = mock(Principal.class);
+        when(principal.getName()).thenReturn("testuser");
+        when(securityContextMock.getUserPrincipal()).thenReturn(principal);
+        ManagedUser user = new ManagedUser("testuser", "salt", "hash");
+        user.setRoles(new HashSet<>(Set.of(Role.ADMIN)));
+        when(userRegistryMock.get("testuser")).thenReturn(user);
+
+        Response response = tokenResource.removeApiToken(securityContextMock, "nonexistent");
+
+        assertEquals(404, response.getStatus());
+    }
+
+    // --- Logout Endpoint ---
+
+    @Test
+    public void logoutByRefreshTokenSucceeds() {
+        String refreshToken = UUID.randomUUID().toString().replace("-", "");
+        String sessionId = UUID.randomUUID().toString();
+        Principal principal = mock(Principal.class);
+        when(principal.getName()).thenReturn("testuser");
+        when(securityContextMock.getUserPrincipal()).thenReturn(principal);
+        ManagedUser user = createUserWithSession("testuser", refreshToken, sessionId, "test-client",
+                "http://localhost/callback", "admin");
+        when(userRegistryMock.get("testuser")).thenReturn(user);
+
+        Response response = callDeleteSession(refreshToken, null, null, securityContextMock);
+
+        assertEquals(200, response.getStatus());
+        verify(userRegistryMock).removeUserSession(eq(user), any(UserSession.class));
+    }
+
+    @Test
+    public void logoutBySessionIdSucceeds() {
+        String refreshToken = UUID.randomUUID().toString().replace("-", "");
+        String sessionId = UUID.randomUUID().toString();
+        Principal principal = mock(Principal.class);
+        when(principal.getName()).thenReturn("testuser");
+        when(securityContextMock.getUserPrincipal()).thenReturn(principal);
+        ManagedUser user = createUserWithSession("testuser", refreshToken, sessionId, "test-client",
+                "http://localhost/callback", "admin");
+        when(userRegistryMock.get("testuser")).thenReturn(user);
+
+        // The id parameter matches the prefix of the session ID (before first '-')
+        String sessionPrefix = sessionId.split("-")[0];
+        Response response = callDeleteSession(null, sessionPrefix, null, securityContextMock);
+
+        assertEquals(200, response.getStatus());
+        verify(userRegistryMock).removeUserSession(eq(user), any(UserSession.class));
+    }
+
+    @Test
+    public void logoutUnauthenticatedReturns401() {
+        when(securityContextMock.getUserPrincipal()).thenReturn(null);
+
+        Response response = callDeleteSession("some-token", null, null, securityContextMock);
+
+        assertEquals(401, response.getStatus());
+    }
+
+    @Test
+    public void logoutSessionNotFoundReturns404() {
+        Principal principal = mock(Principal.class);
+        when(principal.getName()).thenReturn("testuser");
+        when(securityContextMock.getUserPrincipal()).thenReturn(principal);
+        ManagedUser user = new ManagedUser("testuser", "salt", "hash");
+        user.setRoles(new HashSet<>(Set.of(Role.ADMIN)));
+        when(userRegistryMock.get("testuser")).thenReturn(user);
+
+        Response response = callDeleteSession("nonexistent-token", null, null, securityContextMock);
+
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void logoutWithMatchingSessionCookieReplacesIt() {
+        String refreshToken = UUID.randomUUID().toString().replace("-", "");
+        String sessionId = UUID.randomUUID().toString();
+        Principal principal = mock(Principal.class);
+        when(principal.getName()).thenReturn("testuser");
+        when(securityContextMock.getUserPrincipal()).thenReturn(principal);
+        ManagedUser user = createUserWithSession("testuser", refreshToken, sessionId, "test-client",
+                "http://localhost/callback", "admin");
+        when(userRegistryMock.get("testuser")).thenReturn(user);
+
+        Cookie sessionCookie = new Cookie(TokenResource.SESSIONID_COOKIE_NAME, sessionId);
+
+        Response response = callDeleteSession(refreshToken, null, sessionCookie, securityContextMock);
+
+        assertEquals(200, response.getStatus());
+        // The cookie should be replaced with a new random value
+        assertNotNull(response.getHeaders().get("Set-Cookie"));
+    }
+
+    // --- Session Cookie for Root Redirect URIs ---
+
+    @Test
+    public void authCodeGrantWithCookieForRootUri() {
+        String authCode = UUID.randomUUID().toString();
+        ManagedUser user = createUserWithPendingToken("testuser", authCode, "test-client", "http://localhost/",
+                "admin");
+        when(userRegistryMock.getAll()).thenReturn(List.of(user));
+
+        Response response = callGetToken("authorization_code", authCode, "http://localhost/", "test-client", null, null,
+                true, null);
+
+        assertEquals(200, response.getStatus());
+        // Should have Set-Cookie header for root URI
+        assertNotNull(response.getHeaders().get("Set-Cookie"));
+        // Session should be marked with cookie flag
+        assertTrue(user.getSessions().get(0).hasSessionCookie());
+    }
+
+    @Test
+    public void authCodeGrantWithCookieForNonRootUriReturns400() {
+        String authCode = UUID.randomUUID().toString();
+        ManagedUser user = createUserWithPendingToken("testuser", authCode, "test-client", "http://localhost/some/path",
+                "admin");
+        when(userRegistryMock.getAll()).thenReturn(List.of(user));
+
+        Response response = callGetToken("authorization_code", authCode, "http://localhost/some/path", "test-client",
+                null, null, true, null);
+
+        // Non-root redirect URI with useCookie should fail
+        assertEquals(400, response.getStatus());
+    }
+}

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/auth/UserRegistryImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/auth/UserRegistryImplTest.java
@@ -26,7 +26,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.auth.Authentication;
+import org.openhab.core.auth.AuthenticationException;
 import org.openhab.core.auth.ManagedUser;
+import org.openhab.core.auth.Role;
 import org.openhab.core.auth.User;
 import org.openhab.core.auth.UserApiTokenCredentials;
 import org.openhab.core.auth.UserSession;
@@ -38,6 +41,7 @@ import org.osgi.framework.ServiceReference;
 
 /**
  * @author Yannick Schaus - Initial contribution
+ * @author Gabor Bicskei - Added regression tests for role and auth behavior
  */
 @ExtendWith(MockitoExtension.class)
 @NonNullByDefault
@@ -123,5 +127,212 @@ public class UserRegistryImplTest {
         registry.removeUserApiToken(user,
                 user.getApiTokens().stream().filter(t -> "token3".equals(t.getName())).findAny().get());
         assertEquals(0, user.getApiTokens().size());
+    }
+
+    // --- Custom Role Strings ---
+
+    @Test
+    public void customRoleStringsAccepted() throws Exception {
+        // The registry does not validate role strings — any string is accepted
+        User user = registry.register("roleuser", "password", Set.of("custom_role", "another_role"));
+        registry.added(managedProviderMock, user);
+
+        assertNotNull(user);
+        assertTrue(user.getRoles().contains("custom_role"));
+        assertTrue(user.getRoles().contains("another_role"));
+    }
+
+    @Test
+    public void standardRolesAccepted() throws Exception {
+        User user = registry.register("stduser", "password", Set.of(Role.ADMIN, Role.USER));
+        registry.added(managedProviderMock, user);
+
+        assertTrue(user.getRoles().contains(Role.ADMIN));
+        assertTrue(user.getRoles().contains(Role.USER));
+    }
+
+    @Test
+    public void rolesPreservedAfterAuthentication() throws Exception {
+        Set<String> roles = Set.of(Role.ADMIN, "custom_role");
+        User user = registry.register("roleuser", "password", roles);
+        registry.added(managedProviderMock, user);
+
+        Authentication auth = registry.authenticate(new UsernamePasswordCredentials("roleuser", "password"));
+
+        assertEquals("roleuser", auth.getUsername());
+        assertTrue(auth.getRoles().contains(Role.ADMIN));
+        assertTrue(auth.getRoles().contains("custom_role"));
+    }
+
+    @Test
+    public void rolesSurviveRoundTripViaSetRoles() throws Exception {
+        ManagedUser user = (ManagedUser) registry.register("roleuser", "password", Set.of(Role.ADMIN, Role.USER));
+        registry.added(managedProviderMock, user);
+
+        // Verify initial roles
+        assertEquals(2, user.getRoles().size());
+        assertTrue(user.getRoles().contains(Role.ADMIN));
+        assertTrue(user.getRoles().contains(Role.USER));
+
+        // Modify roles directly on ManagedUser (simulating addRole)
+        user.getRoles().add("custom_role");
+        assertEquals(3, user.getRoles().size());
+
+        // Authenticate and verify all roles come back
+        Authentication auth = registry.authenticate(new UsernamePasswordCredentials("roleuser", "password"));
+        assertTrue(auth.getRoles().contains(Role.ADMIN));
+        assertTrue(auth.getRoles().contains(Role.USER));
+        assertTrue(auth.getRoles().contains("custom_role"));
+    }
+
+    @Test
+    public void removeRoleFromUser() throws Exception {
+        ManagedUser user = (ManagedUser) registry.register("roleuser", "password",
+                Set.of(Role.ADMIN, Role.USER, "extra_role"));
+        registry.added(managedProviderMock, user);
+
+        assertEquals(3, user.getRoles().size());
+
+        // Remove a role
+        user.getRoles().remove("extra_role");
+        assertEquals(2, user.getRoles().size());
+        assertFalse(user.getRoles().contains("extra_role"));
+
+        // Verify removed role does not appear in authentication
+        Authentication auth = registry.authenticate(new UsernamePasswordCredentials("roleuser", "password"));
+        assertFalse(auth.getRoles().contains("extra_role"));
+        assertTrue(auth.getRoles().contains(Role.ADMIN));
+        assertTrue(auth.getRoles().contains(Role.USER));
+    }
+
+    @Test
+    public void emptyRolesAccepted() throws Exception {
+        User user = registry.register("noroleuser", "password", Set.of());
+        registry.added(managedProviderMock, user);
+
+        assertTrue(user.getRoles().isEmpty());
+
+        Authentication auth = registry.authenticate(new UsernamePasswordCredentials("noroleuser", "password"));
+        assertTrue(auth.getRoles().isEmpty());
+    }
+
+    // --- Authentication Error Cases ---
+
+    @Test
+    public void authenticateUnknownUserThrowsException() {
+        assertThrows(AuthenticationException.class,
+                () -> registry.authenticate(new UsernamePasswordCredentials("nonexistent", "password")));
+    }
+
+    @Test
+    public void authenticateWrongPasswordThrowsException() throws Exception {
+        User user = registry.register("testuser", "correct_password", Set.of(Role.USER));
+        registry.added(managedProviderMock, user);
+
+        assertThrows(AuthenticationException.class,
+                () -> registry.authenticate(new UsernamePasswordCredentials("testuser", "wrong_password")));
+    }
+
+    @Test
+    public void oldPasswordFailsAfterChangePassword() throws Exception {
+        User user = registry.register("testuser", "oldpass", Set.of(Role.USER));
+        registry.added(managedProviderMock, user);
+
+        registry.authenticate(new UsernamePasswordCredentials("testuser", "oldpass"));
+        registry.changePassword(user, "newpass");
+
+        assertThrows(AuthenticationException.class,
+                () -> registry.authenticate(new UsernamePasswordCredentials("testuser", "oldpass")));
+
+        // New password works
+        registry.authenticate(new UsernamePasswordCredentials("testuser", "newpass"));
+    }
+
+    // --- API Token Format and Validation ---
+
+    @Test
+    public void apiTokenHasCorrectFormat() throws Exception {
+        ManagedUser user = (ManagedUser) registry.register("testuser", "password", Set.of(Role.USER));
+        registry.added(managedProviderMock, user);
+
+        String token = registry.addUserApiToken(user, "mytoken", "scope");
+
+        // Format: oh.{name}.{random}
+        assertTrue(token.startsWith("oh.mytoken."));
+        String[] parts = token.split("\\.");
+        assertEquals(3, parts.length);
+        assertEquals("oh", parts[0]);
+        assertEquals("mytoken", parts[1]);
+        assertFalse(parts[2].isEmpty());
+    }
+
+    @Test
+    public void apiTokenNonAlphanumericNameRejected() throws Exception {
+        ManagedUser user = (ManagedUser) registry.register("testuser", "password", Set.of(Role.USER));
+        registry.added(managedProviderMock, user);
+
+        assertThrows(IllegalArgumentException.class, () -> registry.addUserApiToken(user, "invalid-name", "scope"));
+        assertThrows(IllegalArgumentException.class, () -> registry.addUserApiToken(user, "invalid_name", "scope"));
+        assertThrows(IllegalArgumentException.class, () -> registry.addUserApiToken(user, "invalid name", "scope"));
+    }
+
+    @Test
+    public void apiTokenInvalidFormatThrowsException() throws Exception {
+        ManagedUser user = (ManagedUser) registry.register("testuser", "password", Set.of(Role.USER));
+        registry.added(managedProviderMock, user);
+
+        // Wrong prefix
+        assertThrows(AuthenticationException.class,
+                () -> registry.authenticate(new UserApiTokenCredentials("bad.token.value")));
+        // Too few parts
+        assertThrows(AuthenticationException.class,
+                () -> registry.authenticate(new UserApiTokenCredentials("oh.onlytwoparts")));
+        // Too many parts
+        assertThrows(AuthenticationException.class,
+                () -> registry.authenticate(new UserApiTokenCredentials("oh.token.value.extra")));
+    }
+
+    @Test
+    public void apiTokenWithUnknownNameThrowsException() throws Exception {
+        ManagedUser user = (ManagedUser) registry.register("testuser", "password", Set.of(Role.USER));
+        registry.added(managedProviderMock, user);
+        registry.addUserApiToken(user, "realtoken", "scope");
+
+        assertThrows(AuthenticationException.class,
+                () -> registry.authenticate(new UserApiTokenCredentials("oh.faketoken.randomvalue")));
+    }
+
+    @Test
+    public void apiTokenAuthenticationReturnsCorrectScope() throws Exception {
+        ManagedUser user = (ManagedUser) registry.register("testuser", "password", Set.of(Role.ADMIN));
+        registry.added(managedProviderMock, user);
+
+        String token = registry.addUserApiToken(user, "scopedtoken", "items:read");
+
+        Authentication auth = registry.authenticate(new UserApiTokenCredentials(token));
+        assertEquals("items:read", auth.getScope());
+        assertEquals("testuser", auth.getUsername());
+    }
+
+    // --- Session Management Edge Cases ---
+
+    @Test
+    public void addSessionToNonAuthenticatedUserThrows() {
+        // GenericUser does not implement AuthenticatedUser, so this should fail
+        // We test with a mock User that is not AuthenticatedUser
+        org.openhab.core.auth.GenericUser genericUser = new org.openhab.core.auth.GenericUser("testuser",
+                Set.of(Role.USER));
+        // We can't add genericUser to the registry easily, but we can test the method directly
+        // by first adding it as a known user
+        // Instead, test that the method validates the type
+        UserSession session = new UserSession(UUID.randomUUID().toString(), "rt", "cid", "uri", "scope");
+        assertThrows(IllegalArgumentException.class, () -> registry.addUserSession(genericUser, session));
+    }
+
+    @Test
+    public void changePasswordOnNonManagedUserThrows() {
+        org.openhab.core.auth.GenericUser genericUser = new org.openhab.core.auth.GenericUser("testuser",
+                Set.of(Role.USER));
+        assertThrows(IllegalArgumentException.class, () -> registry.changePassword(genericUser, "newpass"));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -430,6 +430,9 @@ Import-Package: \
               -Xshare:off</argLine>
             <systemPropertyVariables>
               <junit.jupiter.execution.timeout.default>15 m</junit.jupiter.execution.timeout.default>
+              <openhab.conf>${project.build.directory}/openhab/conf</openhab.conf>
+              <openhab.runtime>${project.build.directory}/openhab/runtime</openhab.runtime>
+              <openhab.userdata>${project.build.directory}/openhab/userdata</openhab.userdata>
             </systemPropertyVariables>
           </configuration>
         </plugin>


### PR DESCRIPTION
Improve test coverage for existing authentication and authorization behavior.

Part of #5809

- AuthFilter: JWT bearer, API token, Basic Auth, X-OPENHAB-TOKEN, query token, credential order, caching
- JwtHelper: token creation, verification, claims, key persistence
- RolesAllowedDynamicFeatureImpl: @RolesAllowed enforcement, 401/403, class/method level
- TokenResource: auth code exchange, PKCE, refresh token, session cookie, logout
- UserRegistryImpl: custom roles, API token format/validation, auth error cases