### PR TITLE
Add RBAC data model, AuthorizationService, and console commands (Phase 0)

### DIFF
--- a/bundles/org.openhab.core.auth.authorization/.classpath
+++ b/bundles/org.openhab.core.auth.authorization/.classpath
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="annotationpath" value="target/dependency"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="annotationpath" value="target/dependency"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/org.openhab.core.auth.authorization/.project
+++ b/bundles/org.openhab.core.auth.authorization/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.core.auth.authorization</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.openhab.core.auth.authorization/NOTICE
+++ b/bundles/org.openhab.core.auth.authorization/NOTICE
@@ -1,0 +1,13 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-core

--- a/bundles/org.openhab.core.auth.authorization/pom.xml
+++ b/bundles/org.openhab.core.auth.authorization/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.core.bundles</groupId>
+    <artifactId>org.openhab.core.reactor.bundles</artifactId>
+    <version>5.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.core.auth.authorization</artifactId>
+
+  <name>openHAB Core :: Bundles :: Authorization Service</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.config.core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/bundles/org.openhab.core.auth.authorization/src/main/java/org/openhab/core/auth/authorization/internal/AuthorizationServiceImpl.java
+++ b/bundles/org.openhab.core.auth.authorization/src/main/java/org/openhab/core/auth/authorization/internal/AuthorizationServiceImpl.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth.authorization.internal;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.auth.Action;
+import org.openhab.core.auth.Authentication;
+import org.openhab.core.auth.AuthorizationService;
+import org.openhab.core.auth.Permission;
+import org.openhab.core.auth.PermissionEvaluator;
+import org.openhab.core.auth.ResourceType;
+import org.openhab.core.auth.Role;
+import org.openhab.core.auth.RoleDefinition;
+import org.openhab.core.auth.RoleRegistry;
+import org.openhab.core.common.registry.RegistryChangeListener;
+import org.openhab.core.common.registry.RegistryChangedRunnableListener;
+import org.openhab.core.config.core.ConfigParser;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of {@link AuthorizationService} that checks permissions against
+ * {@link RoleDefinition}s from the {@link RoleRegistry} and delegates evaluation
+ * to registered {@link PermissionEvaluator}s.
+ * <p>
+ * When disabled ({@code enabled=false}, the default), all permission checks return
+ * {@code true}. When enabled, the administrator role short-circuits to allow-all,
+ * and other roles are evaluated against their permissions.
+ * <p>
+ * To enable RBAC, create {@code $OPENHAB_CONF/services/org.openhab.authorization.cfg}
+ * with {@code enabled=true}.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = AuthorizationService.class, immediate = true, configurationPid = "org.openhab.authorization", property = Constants.SERVICE_PID
+        + "=org.openhab.authorization")
+public class AuthorizationServiceImpl implements AuthorizationService {
+
+    private static final String CONFIG_ENABLED = "enabled";
+    private static final int MAX_CACHE_SIZE = 10_000;
+
+    private final Logger logger = LoggerFactory.getLogger(AuthorizationServiceImpl.class);
+
+    private final RoleRegistry roleRegistry;
+
+    private final Map<ResourceType, PermissionEvaluator> evaluators = new ConcurrentHashMap<>();
+
+    // Cache: ConcurrentHashMap for thread safety (REST requests are concurrent).
+    // Key format: "username\0RESOURCE_TYPE\0resourceId\0action" (NUL separator — cannot appear in any field).
+    // Bounded: cleared entirely when exceeding MAX_CACHE_SIZE to prevent unbounded growth.
+    // Also cleared on: config change, role registry change, evaluator add/remove.
+    private final Map<String, Boolean> permissionCache = new ConcurrentHashMap<>();
+
+    private final RegistryChangeListener<RoleDefinition> registryChangeListener = new RegistryChangedRunnableListener<>(
+            () -> permissionCache.clear());
+
+    private volatile boolean enabled = false;
+
+    @Activate
+    public AuthorizationServiceImpl(@Reference RoleRegistry roleRegistry) {
+        this.roleRegistry = roleRegistry;
+    }
+
+    @Activate
+    protected void activate(Map<String, Object> config) {
+        roleRegistry.addRegistryChangeListener(registryChangeListener);
+        modified(config);
+    }
+
+    @Modified
+    protected void modified(@Nullable Map<String, Object> properties) {
+        if (properties != null) {
+            enabled = ConfigParser.valueAsOrElse(properties.get(CONFIG_ENABLED), Boolean.class, false);
+            permissionCache.clear();
+        }
+    }
+
+    @Deactivate
+    protected void deactivate() {
+        roleRegistry.removeRegistryChangeListener(registryChangeListener);
+        permissionCache.clear();
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    protected void addPermissionEvaluator(PermissionEvaluator evaluator) {
+        evaluators.put(evaluator.getResourceType(), evaluator);
+        permissionCache.clear();
+    }
+
+    protected void removePermissionEvaluator(PermissionEvaluator evaluator) {
+        evaluators.remove(evaluator.getResourceType());
+        permissionCache.clear();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public boolean hasPermission(Authentication auth, ResourceType type, String resourceId, Action action) {
+        if (!enabled) {
+            return true;
+        }
+        if (auth.getRoles().contains(Role.ADMIN)) {
+            return true;
+        }
+        String cacheKey = buildCacheKey(auth.getUsername(), type, resourceId, action);
+        Boolean cached = permissionCache.get(cacheKey);
+        if (cached != null) {
+            return cached;
+        }
+        boolean result = evaluatePermission(auth, type, resourceId, action);
+        if (permissionCache.size() >= MAX_CACHE_SIZE) {
+            permissionCache.clear();
+        }
+        permissionCache.put(cacheKey, result);
+        return result;
+    }
+
+    @Override
+    public <T> Collection<T> filterAuthorized(Authentication auth, Collection<T> resources, ResourceType type,
+            Action action, Function<T, String> idExtractor) {
+        if (!enabled) {
+            return resources;
+        }
+        if (auth.getRoles().contains(Role.ADMIN)) {
+            return resources;
+        }
+        return resources.stream().filter(r -> hasPermission(auth, type, idExtractor.apply(r), action)).toList();
+    }
+
+    private String buildCacheKey(String username, ResourceType type, String resourceId, Action action) {
+        return username + "\0" + type.name() + "\0" + resourceId + "\0" + action.name();
+    }
+
+    private boolean evaluatePermission(Authentication auth, ResourceType type, String resourceId, Action action) {
+        PermissionEvaluator evaluator = evaluators.get(type);
+        if (evaluator == null) {
+            logger.debug("Access denied for user '{}': no PermissionEvaluator registered for resource type {}",
+                    auth.getUsername(), type);
+            return false;
+        }
+        for (String roleName : auth.getRoles()) {
+            RoleDefinition roleDef = roleRegistry.get(roleName);
+            if (roleDef == null) {
+                logger.trace("Skipping unknown role '{}' for user '{}'", roleName, auth.getUsername());
+                continue;
+            }
+            for (Permission permission : roleDef.getPermissions()) {
+                if (permission.resourceType() == type && evaluator.evaluate(permission, resourceId, action)) {
+                    return true;
+                }
+            }
+        }
+        logger.debug("Access denied for user '{}': no permission grants {} on {} '{}'", auth.getUsername(),
+                action.name(), type, resourceId);
+        return false;
+    }
+}

--- a/bundles/org.openhab.core.auth.authorization/src/main/java/org/openhab/core/auth/authorization/internal/NoOpItemPermissionEvaluator.java
+++ b/bundles/org.openhab.core.auth.authorization/src/main/java/org/openhab/core/auth/authorization/internal/NoOpItemPermissionEvaluator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth.authorization.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.auth.Action;
+import org.openhab.core.auth.Permission;
+import org.openhab.core.auth.PermissionEvaluator;
+import org.openhab.core.auth.ResourceType;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * No-op {@link PermissionEvaluator} for {@link ResourceType#ITEM}. Always allows access.
+ * This stub will be replaced by a real evaluator in Phase 1.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = PermissionEvaluator.class, immediate = true)
+public class NoOpItemPermissionEvaluator implements PermissionEvaluator {
+
+    @Override
+    public ResourceType getResourceType() {
+        return ResourceType.ITEM;
+    }
+
+    @Override
+    public boolean evaluate(Permission permission, String resourceId, Action action) {
+        return true;
+    }
+}

--- a/bundles/org.openhab.core.auth.authorization/src/main/java/org/openhab/core/auth/authorization/internal/NoOpPagePermissionEvaluator.java
+++ b/bundles/org.openhab.core.auth.authorization/src/main/java/org/openhab/core/auth/authorization/internal/NoOpPagePermissionEvaluator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth.authorization.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.auth.Action;
+import org.openhab.core.auth.Permission;
+import org.openhab.core.auth.PermissionEvaluator;
+import org.openhab.core.auth.ResourceType;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * No-op {@link PermissionEvaluator} for {@link ResourceType#PAGE}. Always allows access.
+ * This stub will be replaced by a real evaluator in Phase 1.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = PermissionEvaluator.class, immediate = true)
+public class NoOpPagePermissionEvaluator implements PermissionEvaluator {
+
+    @Override
+    public ResourceType getResourceType() {
+        return ResourceType.PAGE;
+    }
+
+    @Override
+    public boolean evaluate(Permission permission, String resourceId, Action action) {
+        return true;
+    }
+}

--- a/bundles/org.openhab.core.auth.authorization/src/main/java/org/openhab/core/auth/authorization/internal/NoOpSitemapPermissionEvaluator.java
+++ b/bundles/org.openhab.core.auth.authorization/src/main/java/org/openhab/core/auth/authorization/internal/NoOpSitemapPermissionEvaluator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth.authorization.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.auth.Action;
+import org.openhab.core.auth.Permission;
+import org.openhab.core.auth.PermissionEvaluator;
+import org.openhab.core.auth.ResourceType;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * No-op {@link PermissionEvaluator} for {@link ResourceType#SITEMAP}. Always allows access.
+ * This stub will be replaced by a real evaluator in Phase 1.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = PermissionEvaluator.class, immediate = true)
+public class NoOpSitemapPermissionEvaluator implements PermissionEvaluator {
+
+    @Override
+    public ResourceType getResourceType() {
+        return ResourceType.SITEMAP;
+    }
+
+    @Override
+    public boolean evaluate(Permission permission, String resourceId, Action action) {
+        return true;
+    }
+}

--- a/bundles/org.openhab.core.auth.authorization/src/test/java/org/openhab/core/auth/authorization/internal/AuthorizationServiceImplTest.java
+++ b/bundles/org.openhab.core.auth.authorization/src/test/java/org/openhab/core/auth/authorization/internal/AuthorizationServiceImplTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth.authorization.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.auth.AllSelector;
+import org.openhab.core.auth.Authentication;
+import org.openhab.core.auth.ItemAction;
+import org.openhab.core.auth.Permission;
+import org.openhab.core.auth.PermissionEvaluator;
+import org.openhab.core.auth.ResourceType;
+import org.openhab.core.auth.Role;
+import org.openhab.core.auth.RoleDefinition;
+import org.openhab.core.auth.RoleRegistry;
+
+/**
+ * Tests for {@link AuthorizationServiceImpl}.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@NonNullByDefault
+public class AuthorizationServiceImplTest {
+
+    private @Mock @NonNullByDefault({}) RoleRegistry roleRegistryMock;
+    private @Mock @NonNullByDefault({}) PermissionEvaluator itemEvaluatorMock;
+
+    private @NonNullByDefault({}) AuthorizationServiceImpl service;
+
+    private static final Map<String, Object> ENABLED_CONFIG = Map.of("enabled", true);
+    private static final Map<String, Object> DISABLED_CONFIG = Map.of("enabled", false);
+
+    @BeforeEach
+    public void setup() {
+        service = new AuthorizationServiceImpl(roleRegistryMock);
+    }
+
+    private void addItemEvaluator() {
+        when(itemEvaluatorMock.getResourceType()).thenReturn(ResourceType.ITEM);
+        service.addPermissionEvaluator(itemEvaluatorMock);
+    }
+
+    // --- Disabled state ---
+
+    @Test
+    public void testDisabledByDefault() {
+        service.activate(DISABLED_CONFIG);
+        assertFalse(service.isEnabled());
+    }
+
+    @Test
+    public void testDisabledHasPermissionReturnsTrue() {
+        service.activate(DISABLED_CONFIG);
+        Authentication auth = new Authentication("alice", Role.USER);
+        assertTrue(service.hasPermission(auth, ResourceType.ITEM, "MyItem", ItemAction.READ));
+    }
+
+    @Test
+    public void testDisabledFilterAuthorizedReturnsSameInstance() {
+        service.activate(DISABLED_CONFIG);
+        Authentication auth = new Authentication("alice", Role.USER);
+        List<String> items = List.of("item1", "item2", "item3");
+        Collection<String> result = service.filterAuthorized(auth, items, ResourceType.ITEM, ItemAction.READ, s -> s);
+        assertSame(items, result);
+    }
+
+    // --- Enabled state ---
+
+    @Test
+    public void testEnabled() {
+        service.activate(ENABLED_CONFIG);
+        assertTrue(service.isEnabled());
+    }
+
+    @Test
+    public void testAdminShortCircuitsToAllowAll() {
+        service.activate(ENABLED_CONFIG);
+        Authentication adminAuth = new Authentication("admin", Role.ADMIN);
+        assertTrue(service.hasPermission(adminAuth, ResourceType.ITEM, "AnyItem", ItemAction.READ));
+    }
+
+    @Test
+    public void testAdminFilterAuthorizedReturnsSameInstance() {
+        service.activate(ENABLED_CONFIG);
+        Authentication adminAuth = new Authentication("admin", Role.ADMIN);
+        List<String> items = List.of("item1", "item2");
+        Collection<String> result = service.filterAuthorized(adminAuth, items, ResourceType.ITEM, ItemAction.READ,
+                s -> s);
+        assertSame(items, result);
+    }
+
+    @Test
+    public void testUserWithMatchingPermissionIsAllowed() {
+        service.activate(ENABLED_CONFIG);
+        addItemEvaluator();
+
+        Permission itemPermission = new Permission(ResourceType.ITEM, new AllSelector(), ItemAction.READ);
+        RoleDefinition userRole = new RoleDefinition("user", "Standard user", Set.of(itemPermission), true);
+        when(roleRegistryMock.get(eq("user"))).thenReturn(userRole);
+        when(itemEvaluatorMock.evaluate(eq(itemPermission), eq("LivingRoom_Light"), eq(ItemAction.READ)))
+                .thenReturn(true);
+
+        Authentication auth = new Authentication("alice", Role.USER);
+        assertTrue(service.hasPermission(auth, ResourceType.ITEM, "LivingRoom_Light", ItemAction.READ));
+    }
+
+    @Test
+    public void testUserWithoutMatchingPermissionIsDenied() {
+        service.activate(ENABLED_CONFIG);
+        addItemEvaluator();
+
+        Permission itemPermission = new Permission(ResourceType.ITEM, new AllSelector(), ItemAction.READ);
+        RoleDefinition userRole = new RoleDefinition("user", "Standard user", Set.of(itemPermission), true);
+        when(roleRegistryMock.get(eq("user"))).thenReturn(userRole);
+        when(itemEvaluatorMock.evaluate(eq(itemPermission), eq("LivingRoom_Light"), eq(ItemAction.COMMAND)))
+                .thenReturn(false);
+
+        Authentication auth = new Authentication("alice", Role.USER);
+        assertFalse(service.hasPermission(auth, ResourceType.ITEM, "LivingRoom_Light", ItemAction.COMMAND));
+    }
+
+    @Test
+    public void testUnknownRoleIsDenied() {
+        service.activate(ENABLED_CONFIG);
+        addItemEvaluator();
+
+        when(roleRegistryMock.get(eq("unknown_role"))).thenReturn(null);
+
+        Authentication auth = new Authentication("alice", "unknown_role");
+        assertFalse(service.hasPermission(auth, ResourceType.ITEM, "MyItem", ItemAction.READ));
+    }
+
+    @Test
+    public void testNoEvaluatorRegisteredIsDenied() {
+        service.activate(ENABLED_CONFIG);
+
+        Authentication auth = new Authentication("alice", Role.USER);
+        assertFalse(service.hasPermission(auth, ResourceType.ITEM, "MyItem", ItemAction.READ));
+    }
+
+    @Test
+    public void testFilterAuthorizedReturnsOnlyPermittedResources() {
+        service.activate(ENABLED_CONFIG);
+        addItemEvaluator();
+
+        Permission itemPermission = new Permission(ResourceType.ITEM, new AllSelector(), ItemAction.READ);
+        RoleDefinition userRole = new RoleDefinition("user", "Standard user", Set.of(itemPermission), true);
+        when(roleRegistryMock.get(eq("user"))).thenReturn(userRole);
+        when(itemEvaluatorMock.evaluate(eq(itemPermission), eq("allowed"), eq(ItemAction.READ))).thenReturn(true);
+        when(itemEvaluatorMock.evaluate(eq(itemPermission), eq("denied"), eq(ItemAction.READ))).thenReturn(false);
+
+        Authentication auth = new Authentication("alice", Role.USER);
+        List<String> items = List.of("allowed", "denied");
+        Collection<String> result = service.filterAuthorized(auth, items, ResourceType.ITEM, ItemAction.READ, s -> s);
+        assertEquals(List.of("allowed"), List.copyOf(result));
+    }
+
+    // --- Cache behavior ---
+
+    @Test
+    public void testCacheAvoidsRepeatedEvaluation() {
+        service.activate(ENABLED_CONFIG);
+        addItemEvaluator();
+
+        Permission itemPermission = new Permission(ResourceType.ITEM, new AllSelector(), ItemAction.READ);
+        RoleDefinition userRole = new RoleDefinition("user", "Standard user", Set.of(itemPermission), true);
+        when(roleRegistryMock.get(eq("user"))).thenReturn(userRole);
+        when(itemEvaluatorMock.evaluate(any(), any(), any())).thenReturn(true);
+
+        Authentication auth = new Authentication("alice", Role.USER);
+        service.hasPermission(auth, ResourceType.ITEM, "MyItem", ItemAction.READ);
+        service.hasPermission(auth, ResourceType.ITEM, "MyItem", ItemAction.READ);
+
+        verify(itemEvaluatorMock, times(1)).evaluate(any(), eq("MyItem"), eq(ItemAction.READ));
+    }
+
+    @Test
+    public void testModifiedClearsCache() {
+        service.activate(ENABLED_CONFIG);
+        addItemEvaluator();
+
+        Permission itemPermission = new Permission(ResourceType.ITEM, new AllSelector(), ItemAction.READ);
+        RoleDefinition userRole = new RoleDefinition("user", "Standard user", Set.of(itemPermission), true);
+        when(roleRegistryMock.get(eq("user"))).thenReturn(userRole);
+        when(itemEvaluatorMock.evaluate(any(), any(), any())).thenReturn(true);
+
+        Authentication auth = new Authentication("alice", Role.USER);
+        service.hasPermission(auth, ResourceType.ITEM, "MyItem", ItemAction.READ);
+
+        service.modified(ENABLED_CONFIG);
+
+        service.hasPermission(auth, ResourceType.ITEM, "MyItem", ItemAction.READ);
+
+        verify(itemEvaluatorMock, times(2)).evaluate(any(), eq("MyItem"), eq(ItemAction.READ));
+    }
+
+    // --- Evaluator wiring ---
+
+    @Test
+    public void testAddEvaluatorClearsCache() {
+        service.activate(ENABLED_CONFIG);
+
+        PermissionEvaluator firstEvaluator = mock(PermissionEvaluator.class);
+        when(firstEvaluator.getResourceType()).thenReturn(ResourceType.ITEM);
+        when(firstEvaluator.evaluate(any(), any(), any())).thenReturn(true);
+        service.addPermissionEvaluator(firstEvaluator);
+
+        Permission itemPermission = new Permission(ResourceType.ITEM, new AllSelector(), ItemAction.READ);
+        RoleDefinition userRole = new RoleDefinition("user", "Standard user", Set.of(itemPermission), true);
+        when(roleRegistryMock.get(eq("user"))).thenReturn(userRole);
+
+        Authentication auth = new Authentication("alice", Role.USER);
+        assertTrue(service.hasPermission(auth, ResourceType.ITEM, "MyItem", ItemAction.READ));
+
+        PermissionEvaluator secondEvaluator = mock(PermissionEvaluator.class);
+        when(secondEvaluator.getResourceType()).thenReturn(ResourceType.ITEM);
+        when(secondEvaluator.evaluate(any(), any(), any())).thenReturn(false);
+        service.addPermissionEvaluator(secondEvaluator);
+
+        assertFalse(service.hasPermission(auth, ResourceType.ITEM, "MyItem", ItemAction.READ));
+    }
+
+    @Test
+    public void testRemoveEvaluatorClearsCache() {
+        service.activate(ENABLED_CONFIG);
+        addItemEvaluator();
+
+        Permission itemPermission = new Permission(ResourceType.ITEM, new AllSelector(), ItemAction.READ);
+        RoleDefinition userRole = new RoleDefinition("user", "Standard user", Set.of(itemPermission), true);
+        when(roleRegistryMock.get(eq("user"))).thenReturn(userRole);
+        when(itemEvaluatorMock.evaluate(any(), any(), any())).thenReturn(true);
+
+        Authentication auth = new Authentication("alice", Role.USER);
+        assertTrue(service.hasPermission(auth, ResourceType.ITEM, "MyItem", ItemAction.READ));
+
+        service.removePermissionEvaluator(itemEvaluatorMock);
+
+        assertFalse(service.hasPermission(auth, ResourceType.ITEM, "MyItem", ItemAction.READ));
+    }
+
+    // --- Lifecycle ---
+
+    @Test
+    public void testActivateRegistersRegistryChangeListener() {
+        service.activate(DISABLED_CONFIG);
+        verify(roleRegistryMock).addRegistryChangeListener(any());
+    }
+
+    @Test
+    public void testDeactivateUnregistersRegistryChangeListener() {
+        service.activate(DISABLED_CONFIG);
+        service.deactivate();
+        verify(roleRegistryMock).removeRegistryChangeListener(any());
+    }
+}

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/RoleConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/RoleConsoleCommandExtension.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.io.console.internal.extension;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.auth.Action;
+import org.openhab.core.auth.Actions;
+import org.openhab.core.auth.Permission;
+import org.openhab.core.auth.ResourceType;
+import org.openhab.core.auth.RoleDefinition;
+import org.openhab.core.auth.RoleRegistry;
+import org.openhab.core.auth.Selector;
+import org.openhab.core.auth.SelectorParser;
+import org.openhab.core.io.console.Console;
+import org.openhab.core.io.console.extensions.AbstractConsoleCommandExtension;
+import org.openhab.core.io.console.extensions.ConsoleCommandExtension;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * Console command extension to manage roles and permissions.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@Component(service = ConsoleCommandExtension.class)
+@NonNullByDefault
+public class RoleConsoleCommandExtension extends AbstractConsoleCommandExtension {
+
+    private static final String SUBCMD_LIST = "list";
+    private static final String SUBCMD_ADD = "add";
+    private static final String SUBCMD_REMOVE = "remove";
+    private static final String SUBCMD_ADDPERMISSION = "addPermission";
+    private static final String SUBCMD_REMOVEPERMISSION = "removePermission";
+    private static final String SUBCMD_SHOW = "show";
+
+    private final RoleRegistry roleRegistry;
+
+    @Activate
+    public RoleConsoleCommandExtension(final @Reference RoleRegistry roleRegistry) {
+        super("roles", "Manage roles and permissions.");
+        this.roleRegistry = roleRegistry;
+    }
+
+    @Override
+    public List<String> getUsages() {
+        return List.of(buildCommandUsage(SUBCMD_LIST, "lists all roles with their permissions"),
+                buildCommandUsage(SUBCMD_ADD + " <name> [description]", "creates a custom role"),
+                buildCommandUsage(SUBCMD_REMOVE + " <name>", "removes a custom role"),
+                buildCommandUsage(SUBCMD_ADDPERMISSION + " <role> <resourceType> <selector> <action>",
+                        "adds a permission to a role"),
+                buildCommandUsage(SUBCMD_REMOVEPERMISSION + " <role> <resourceType> <selector> <action>",
+                        "removes a permission from a role"),
+                buildCommandUsage(SUBCMD_SHOW + " <role>", "shows role details with all permissions"));
+    }
+
+    @Override
+    public void execute(String[] args, Console console) {
+        if (args.length > 0) {
+            String subCommand = args[0];
+            switch (subCommand) {
+                case SUBCMD_LIST:
+                    listRoles(console);
+                    break;
+                case SUBCMD_ADD:
+                    addRole(args, console);
+                    break;
+                case SUBCMD_REMOVE:
+                    removeRole(args, console);
+                    break;
+                case SUBCMD_ADDPERMISSION:
+                    addPermission(args, console);
+                    break;
+                case SUBCMD_REMOVEPERMISSION:
+                    removePermission(args, console);
+                    break;
+                case SUBCMD_SHOW:
+                    showRole(args, console);
+                    break;
+                default:
+                    console.println("Unknown command '" + subCommand + "'");
+                    printUsage(console);
+                    break;
+            }
+        } else {
+            printUsage(console);
+        }
+    }
+
+    private void listRoles(Console console) {
+        for (RoleDefinition role : roleRegistry.getAll()) {
+            printRoleWithPermissions(role, console);
+        }
+    }
+
+    private void addRole(String[] args, Console console) {
+        if (args.length >= 2) {
+            String roleName = args[1];
+            String description = args.length >= 3 ? args[2] : "";
+            RoleDefinition newRole = new RoleDefinition(roleName, description, Set.of(), false);
+            try {
+                roleRegistry.add(newRole);
+                console.println("Role '" + roleName + "' created.");
+            } catch (IllegalArgumentException e) {
+                console.println("A role with name '" + roleName + "' already exists.");
+            }
+        } else {
+            console.printUsage(findUsage(SUBCMD_ADD));
+        }
+    }
+
+    private void removeRole(String[] args, Console console) {
+        if (args.length == 2) {
+            String roleName = args[1];
+            RoleDefinition role = roleRegistry.get(roleName);
+            if (role == null) {
+                console.println("Role not found.");
+                return;
+            }
+            if (roleRegistry.isDefault(role)) {
+                console.println("Cannot remove built-in role '" + roleName + "'.");
+                return;
+            }
+            roleRegistry.remove(roleName);
+            console.println("Role '" + roleName + "' removed.");
+        } else {
+            console.printUsage(findUsage(SUBCMD_REMOVE));
+        }
+    }
+
+    private void addPermission(String[] args, Console console) {
+        if (args.length == 5) {
+            String roleName = args[1];
+            RoleDefinition role = roleRegistry.get(roleName);
+            if (role == null) {
+                console.println("Role not found.");
+                return;
+            }
+            if (!roleRegistry.isEditable(role)) {
+                console.println("Cannot modify built-in role '" + roleName + "'.");
+                return;
+            }
+            ResourceType type;
+            try {
+                type = ResourceType.valueOf(args[2].toUpperCase());
+            } catch (IllegalArgumentException e) {
+                console.println("Unknown resource type: " + args[2] + ". Valid types: "
+                        + Arrays.toString(ResourceType.values()));
+                return;
+            }
+            Selector selector;
+            try {
+                selector = SelectorParser.parse(args[3]);
+            } catch (IllegalArgumentException e) {
+                console.println("Invalid selector: " + e.getMessage());
+                return;
+            }
+            Action action;
+            try {
+                action = Actions.parse(type, args[4]);
+            } catch (IllegalArgumentException e) {
+                console.println("Invalid action '" + args[4] + "' for resource type " + type + ".");
+                return;
+            }
+            Permission permission = new Permission(type, selector, action);
+            Set<Permission> newPermissions = new HashSet<>(role.getPermissions());
+            newPermissions.add(permission);
+            RoleDefinition updated = new RoleDefinition(role.getName(), role.getDescription(), newPermissions, false);
+            roleRegistry.update(updated);
+            console.println("Permission added to role '" + roleName + "'.");
+        } else {
+            console.printUsage(findUsage(SUBCMD_ADDPERMISSION));
+        }
+    }
+
+    private void removePermission(String[] args, Console console) {
+        if (args.length == 5) {
+            String roleName = args[1];
+            RoleDefinition role = roleRegistry.get(roleName);
+            if (role == null) {
+                console.println("Role not found.");
+                return;
+            }
+            if (!roleRegistry.isEditable(role)) {
+                console.println("Cannot modify built-in role '" + roleName + "'.");
+                return;
+            }
+            ResourceType type;
+            try {
+                type = ResourceType.valueOf(args[2].toUpperCase());
+            } catch (IllegalArgumentException e) {
+                console.println("Unknown resource type: " + args[2] + ". Valid types: "
+                        + Arrays.toString(ResourceType.values()));
+                return;
+            }
+            Selector selector;
+            try {
+                selector = SelectorParser.parse(args[3]);
+            } catch (IllegalArgumentException e) {
+                console.println("Invalid selector: " + e.getMessage());
+                return;
+            }
+            Action action;
+            try {
+                action = Actions.parse(type, args[4]);
+            } catch (IllegalArgumentException e) {
+                console.println("Invalid action '" + args[4] + "' for resource type " + type + ".");
+                return;
+            }
+            Permission target = new Permission(type, selector, action);
+            Set<Permission> newPermissions = new HashSet<>(role.getPermissions());
+            if (newPermissions.remove(target)) {
+                RoleDefinition updated = new RoleDefinition(role.getName(), role.getDescription(), newPermissions,
+                        false);
+                roleRegistry.update(updated);
+                console.println("Permission removed from role '" + roleName + "'.");
+            } else {
+                console.println("Permission not found on role '" + roleName + "'.");
+            }
+        } else {
+            console.printUsage(findUsage(SUBCMD_REMOVEPERMISSION));
+        }
+    }
+
+    private void showRole(String[] args, Console console) {
+        if (args.length == 2) {
+            String roleName = args[1];
+            RoleDefinition role = roleRegistry.get(roleName);
+            if (role == null) {
+                console.println("Role not found.");
+                return;
+            }
+            printRoleWithPermissions(role, console);
+        } else {
+            console.printUsage(findUsage(SUBCMD_SHOW));
+        }
+    }
+
+    private void printRoleWithPermissions(RoleDefinition role, Console console) {
+        String label = role.isBuiltIn() ? "built-in" : "custom";
+        console.println(role.getName() + " (" + label + ") — " + role.getDescription());
+        if (role.getPermissions().isEmpty()) {
+            if (role.isBuiltIn()) {
+                console.println("  (no explicit permissions — allow-all)");
+            } else {
+                console.println("  (no permissions)");
+            }
+        } else {
+            for (Permission p : role.getPermissions()) {
+                console.println("  " + p.resourceType() + " " + p.selector().expression() + " " + p.action().name());
+            }
+        }
+    }
+
+    private String findUsage(String cmd) {
+        return getUsages().stream().filter(u -> u.contains(cmd)).findAny().get();
+    }
+}

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/UserConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/UserConsoleCommandExtension.java
@@ -12,12 +12,14 @@
  */
 package org.openhab.core.io.console.internal.extension;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.auth.ManagedUser;
+import org.openhab.core.auth.RoleRegistry;
 import org.openhab.core.auth.User;
 import org.openhab.core.auth.UserApiToken;
 import org.openhab.core.auth.UserRegistry;
@@ -45,13 +47,18 @@ public class UserConsoleCommandExtension extends AbstractConsoleCommandExtension
     private static final String SUBCMD_ADDAPITOKEN = "addApiToken";
     private static final String SUBCMD_RMAPITOKEN = "rmApiToken";
     private static final String SUBCMD_CLEARSESSIONS = "clearSessions";
+    private static final String SUBCMD_ADDROLE = "addRole";
+    private static final String SUBCMD_REMOVEROLE = "removeRole";
 
     private final UserRegistry userRegistry;
+    private final RoleRegistry roleRegistry;
 
     @Activate
-    public UserConsoleCommandExtension(final @Reference UserRegistry userRegistry) {
+    public UserConsoleCommandExtension(final @Reference UserRegistry userRegistry,
+            final @Reference RoleRegistry roleRegistry) {
         super("users", "Access the user registry.");
         this.userRegistry = userRegistry;
+        this.roleRegistry = roleRegistry;
     }
 
     @Override
@@ -67,7 +74,9 @@ public class UserConsoleCommandExtension extends AbstractConsoleCommandExtension
                 buildCommandUsage(SUBCMD_RMAPITOKEN + " <userId> <tokenName>",
                         "removes (revokes) the specified API token"),
                 buildCommandUsage(SUBCMD_CLEARSESSIONS + " <userId>",
-                        "clear the refresh tokens associated with the user (will sign the user out of all sessions)"));
+                        "clear the refresh tokens associated with the user (will sign the user out of all sessions)"),
+                buildCommandUsage(SUBCMD_ADDROLE + " <userId> <role>", "assigns a role to a user"),
+                buildCommandUsage(SUBCMD_REMOVEROLE + " <userId> <role>", "removes a role from a user"));
     }
 
     @Override
@@ -176,6 +185,50 @@ public class UserConsoleCommandExtension extends AbstractConsoleCommandExtension
                         }
                     } else {
                         console.printUsage(findUsage(SUBCMD_CLEARSESSIONS));
+                    }
+                    break;
+                case SUBCMD_ADDROLE:
+                    if (args.length == 3) {
+                        User user = userRegistry.get(args[1]);
+                        if (user instanceof ManagedUser managedUser) {
+                            String roleName = args[2];
+                            if (roleRegistry.get(roleName) == null) {
+                                console.println(
+                                        "Warning: role '" + roleName + "' is not defined in the role registry.");
+                            }
+                            Set<String> roles = new HashSet<>(managedUser.getRoles());
+                            if (roles.add(roleName)) {
+                                managedUser.setRoles(roles);
+                                userRegistry.update(managedUser);
+                                console.println("Role '" + roleName + "' added to user '" + args[1] + "'.");
+                            } else {
+                                console.println("User already has role '" + roleName + "'.");
+                            }
+                        } else {
+                            console.println("User not found.");
+                        }
+                    } else {
+                        console.printUsage(findUsage(SUBCMD_ADDROLE));
+                    }
+                    break;
+                case SUBCMD_REMOVEROLE:
+                    if (args.length == 3) {
+                        User user = userRegistry.get(args[1]);
+                        if (user instanceof ManagedUser managedUser) {
+                            String roleName = args[2];
+                            Set<String> roles = new HashSet<>(managedUser.getRoles());
+                            if (roles.remove(roleName)) {
+                                managedUser.setRoles(roles);
+                                userRegistry.update(managedUser);
+                                console.println("Role '" + roleName + "' removed from user '" + args[1] + "'.");
+                            } else {
+                                console.println("User does not have role '" + roleName + "'.");
+                            }
+                        } else {
+                            console.println("User not found.");
+                        }
+                    } else {
+                        console.printUsage(findUsage(SUBCMD_REMOVEROLE));
                     }
                     break;
                 default:

--- a/bundles/org.openhab.core.io.console/src/test/java/org/openhab/core/io/console/internal/extension/RoleConsoleCommandExtensionTest.java
+++ b/bundles/org.openhab.core.io.console/src/test/java/org/openhab/core/io/console/internal/extension/RoleConsoleCommandExtensionTest.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.io.console.internal.extension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.auth.AllSelector;
+import org.openhab.core.auth.ItemAction;
+import org.openhab.core.auth.Permission;
+import org.openhab.core.auth.ResourceType;
+import org.openhab.core.auth.RoleDefinition;
+import org.openhab.core.auth.RoleRegistry;
+import org.openhab.core.io.console.Console;
+
+/**
+ * Tests for {@link RoleConsoleCommandExtension}.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@NonNullByDefault
+public class RoleConsoleCommandExtensionTest {
+
+    private @Mock @NonNullByDefault({}) RoleRegistry roleRegistryMock;
+    private @Mock @NonNullByDefault({}) Console consoleMock;
+    private @NonNullByDefault({}) RoleConsoleCommandExtension command;
+
+    @BeforeEach
+    public void setup() {
+        command = new RoleConsoleCommandExtension(roleRegistryMock);
+    }
+
+    // --- list ---
+
+    @Test
+    public void testListPrintsAllRoles() {
+        RoleDefinition admin = new RoleDefinition("administrator", "Full system access", Set.of(), true);
+        RoleDefinition user = new RoleDefinition("user", "Standard user",
+                Set.of(new Permission(ResourceType.ITEM, new AllSelector(), ItemAction.COMMAND)), true);
+        when(roleRegistryMock.getAll()).thenReturn(List.of(admin, user));
+
+        command.execute(new String[] { "list" }, consoleMock);
+
+        verify(consoleMock).println(contains("administrator"));
+        verify(consoleMock).println(contains("user (built-in)"));
+        verify(consoleMock).println(contains("ITEM * COMMAND"));
+    }
+
+    // --- add ---
+
+    @Test
+    public void testAddCreatesCustomRole() {
+        command.execute(new String[] { "add", "viewer", "Read-only viewer" }, consoleMock);
+
+        verify(roleRegistryMock).add(argThat(role -> "viewer".equals(role.getUID())
+                && "Read-only viewer".equals(role.getDescription()) && !role.isBuiltIn()));
+        verify(consoleMock).println(contains("created"));
+    }
+
+    @Test
+    public void testAddWithoutDescriptionUsesEmpty() {
+        command.execute(new String[] { "add", "viewer" }, consoleMock);
+
+        verify(roleRegistryMock)
+                .add(argThat(role -> "viewer".equals(role.getUID()) && "".equals(role.getDescription())));
+        verify(consoleMock).println(contains("created"));
+    }
+
+    @Test
+    public void testAddWithMissingArgsPrintsUsage() {
+        command.execute(new String[] { "add" }, consoleMock);
+
+        verify(roleRegistryMock, never()).add(any());
+        verify(consoleMock).printUsage(anyString());
+    }
+
+    @Test
+    public void testAddWithExistingNamePrintsError() {
+        doThrow(new IllegalArgumentException("exists")).when(roleRegistryMock).add(any());
+
+        command.execute(new String[] { "add", "administrator" }, consoleMock);
+
+        verify(consoleMock).println(contains("already exists"));
+    }
+
+    // --- remove ---
+
+    @Test
+    public void testRemoveCustomRole() {
+        RoleDefinition customRole = new RoleDefinition("viewer", "Read-only", Set.of(), false);
+        when(roleRegistryMock.get(eq("viewer"))).thenReturn(customRole);
+        when(roleRegistryMock.isDefault(customRole)).thenReturn(false);
+
+        command.execute(new String[] { "remove", "viewer" }, consoleMock);
+
+        verify(roleRegistryMock).remove(eq("viewer"));
+        verify(consoleMock).println(contains("removed"));
+    }
+
+    @Test
+    public void testRemoveBuiltInRolePrintsError() {
+        RoleDefinition admin = new RoleDefinition("administrator", "Full system access", Set.of(), true);
+        when(roleRegistryMock.get(eq("administrator"))).thenReturn(admin);
+        when(roleRegistryMock.isDefault(admin)).thenReturn(true);
+
+        command.execute(new String[] { "remove", "administrator" }, consoleMock);
+
+        verify(roleRegistryMock, never()).remove(anyString());
+        verify(consoleMock).println(contains("Cannot remove built-in"));
+    }
+
+    @Test
+    public void testRemoveNonexistentRolePrintsError() {
+        when(roleRegistryMock.get(eq("nonexistent"))).thenReturn(null);
+
+        command.execute(new String[] { "remove", "nonexistent" }, consoleMock);
+
+        verify(roleRegistryMock, never()).remove(anyString());
+        verify(consoleMock).println("Role not found.");
+    }
+
+    // --- addPermission ---
+
+    @Test
+    public void testAddPermissionToEditableRole() {
+        RoleDefinition customRole = new RoleDefinition("viewer", "Read-only", Set.of(), false);
+        when(roleRegistryMock.get(eq("viewer"))).thenReturn(customRole);
+        when(roleRegistryMock.isEditable(customRole)).thenReturn(true);
+
+        command.execute(new String[] { "addPermission", "viewer", "ITEM", "*", "READ" }, consoleMock);
+
+        verify(roleRegistryMock).update(argThat(role -> role.getPermissions().size() == 1 && role.getPermissions()
+                .contains(new Permission(ResourceType.ITEM, new AllSelector(), ItemAction.READ))));
+        verify(consoleMock).println(contains("Permission added"));
+    }
+
+    @Test
+    public void testAddPermissionToBuiltInRolePrintsError() {
+        RoleDefinition admin = new RoleDefinition("administrator", "Full system access", Set.of(), true);
+        when(roleRegistryMock.get(eq("administrator"))).thenReturn(admin);
+        when(roleRegistryMock.isEditable(admin)).thenReturn(false);
+
+        command.execute(new String[] { "addPermission", "administrator", "ITEM", "*", "READ" }, consoleMock);
+
+        verify(roleRegistryMock, never()).update(any());
+        verify(consoleMock).println(contains("Cannot modify built-in"));
+    }
+
+    @Test
+    public void testAddPermissionWithInvalidResourceTypePrintsError() {
+        RoleDefinition customRole = new RoleDefinition("viewer", "Read-only", Set.of(), false);
+        when(roleRegistryMock.get(eq("viewer"))).thenReturn(customRole);
+        when(roleRegistryMock.isEditable(customRole)).thenReturn(true);
+
+        command.execute(new String[] { "addPermission", "viewer", "INVALID", "*", "READ" }, consoleMock);
+
+        verify(roleRegistryMock, never()).update(any());
+        verify(consoleMock).println(contains("Unknown resource type"));
+    }
+
+    @Test
+    public void testAddPermissionResourceTypeCaseInsensitive() {
+        RoleDefinition customRole = new RoleDefinition("viewer", "Read-only", Set.of(), false);
+        when(roleRegistryMock.get(eq("viewer"))).thenReturn(customRole);
+        when(roleRegistryMock.isEditable(customRole)).thenReturn(true);
+
+        command.execute(new String[] { "addPermission", "viewer", "item", "*", "read" }, consoleMock);
+
+        verify(roleRegistryMock).update(argThat(role -> role.getPermissions()
+                .contains(new Permission(ResourceType.ITEM, new AllSelector(), ItemAction.READ))));
+    }
+
+    @Test
+    public void testAddPermissionWithInvalidActionPrintsError() {
+        RoleDefinition customRole = new RoleDefinition("viewer", "Read-only", Set.of(), false);
+        when(roleRegistryMock.get(eq("viewer"))).thenReturn(customRole);
+        when(roleRegistryMock.isEditable(customRole)).thenReturn(true);
+
+        command.execute(new String[] { "addPermission", "viewer", "ITEM", "*", "BOGUS" }, consoleMock);
+
+        verify(roleRegistryMock, never()).update(any());
+        verify(consoleMock).println(contains("Invalid action"));
+    }
+
+    @Test
+    public void testAddPermissionWithInvalidSelectorPrintsError() {
+        RoleDefinition customRole = new RoleDefinition("viewer", "Read-only", Set.of(), false);
+        when(roleRegistryMock.get(eq("viewer"))).thenReturn(customRole);
+        when(roleRegistryMock.isEditable(customRole)).thenReturn(true);
+
+        command.execute(new String[] { "addPermission", "viewer", "ITEM", "invalid_no_colon", "READ" }, consoleMock);
+
+        verify(roleRegistryMock, never()).update(any());
+        verify(consoleMock).println(contains("Invalid selector"));
+    }
+
+    @Test
+    public void testAddPermissionToNonexistentRolePrintsError() {
+        when(roleRegistryMock.get(eq("nonexistent"))).thenReturn(null);
+
+        command.execute(new String[] { "addPermission", "nonexistent", "ITEM", "*", "READ" }, consoleMock);
+
+        verify(roleRegistryMock, never()).update(any());
+        verify(consoleMock).println("Role not found.");
+    }
+
+    // --- removePermission ---
+
+    @Test
+    public void testRemovePermissionFromRole() {
+        Permission existing = new Permission(ResourceType.ITEM, new AllSelector(), ItemAction.READ);
+        RoleDefinition customRole = new RoleDefinition("viewer", "Read-only", Set.of(existing), false);
+        when(roleRegistryMock.get(eq("viewer"))).thenReturn(customRole);
+        when(roleRegistryMock.isEditable(customRole)).thenReturn(true);
+
+        command.execute(new String[] { "removePermission", "viewer", "ITEM", "*", "READ" }, consoleMock);
+
+        verify(roleRegistryMock).update(argThat(role -> role.getPermissions().isEmpty()));
+        verify(consoleMock).println(contains("Permission removed"));
+    }
+
+    @Test
+    public void testRemovePermissionFromBuiltInRolePrintsError() {
+        RoleDefinition admin = new RoleDefinition("administrator", "Full system access", Set.of(), true);
+        when(roleRegistryMock.get(eq("administrator"))).thenReturn(admin);
+        when(roleRegistryMock.isEditable(admin)).thenReturn(false);
+
+        command.execute(new String[] { "removePermission", "administrator", "ITEM", "*", "READ" }, consoleMock);
+
+        verify(roleRegistryMock, never()).update(any());
+        verify(consoleMock).println(contains("Cannot modify built-in"));
+    }
+
+    @Test
+    public void testRemoveNonexistentPermissionPrintsError() {
+        RoleDefinition customRole = new RoleDefinition("viewer", "Read-only", Set.of(), false);
+        when(roleRegistryMock.get(eq("viewer"))).thenReturn(customRole);
+        when(roleRegistryMock.isEditable(customRole)).thenReturn(true);
+
+        command.execute(new String[] { "removePermission", "viewer", "ITEM", "*", "READ" }, consoleMock);
+
+        verify(roleRegistryMock, never()).update(any());
+        verify(consoleMock).println(contains("Permission not found"));
+    }
+
+    // --- show ---
+
+    @Test
+    public void testShowRole() {
+        Permission perm = new Permission(ResourceType.ITEM, new AllSelector(), ItemAction.COMMAND);
+        RoleDefinition user = new RoleDefinition("user", "Standard user", Set.of(perm), true);
+        when(roleRegistryMock.get(eq("user"))).thenReturn(user);
+
+        command.execute(new String[] { "show", "user" }, consoleMock);
+
+        verify(consoleMock).println(contains("user (built-in)"));
+        verify(consoleMock).println(contains("ITEM * COMMAND"));
+    }
+
+    @Test
+    public void testShowNonexistentRolePrintsError() {
+        when(roleRegistryMock.get(eq("nonexistent"))).thenReturn(null);
+
+        command.execute(new String[] { "show", "nonexistent" }, consoleMock);
+
+        verify(consoleMock).println("Role not found.");
+    }
+
+    // --- edge cases ---
+
+    @Test
+    public void testNoArgsPrintsUsage() {
+        command.execute(new String[] {}, consoleMock);
+
+        verify(consoleMock, atLeastOnce()).printUsage(anyString());
+    }
+
+    @Test
+    public void testUnknownSubcommandPrintsError() {
+        command.execute(new String[] { "bogus" }, consoleMock);
+
+        verify(consoleMock).println(contains("Unknown command"));
+        verify(consoleMock, atLeastOnce()).printUsage(anyString());
+    }
+}

--- a/bundles/org.openhab.core.io.console/src/test/java/org/openhab/core/io/console/internal/extension/UserConsoleCommandExtensionTest.java
+++ b/bundles/org.openhab.core.io.console/src/test/java/org/openhab/core/io/console/internal/extension/UserConsoleCommandExtensionTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.io.console.internal.extension;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.auth.ManagedUser;
+import org.openhab.core.auth.RoleDefinition;
+import org.openhab.core.auth.RoleRegistry;
+import org.openhab.core.auth.UserRegistry;
+import org.openhab.core.io.console.Console;
+
+/**
+ * Tests for the addRole/removeRole subcommands in {@link UserConsoleCommandExtension}.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@NonNullByDefault
+public class UserConsoleCommandExtensionTest {
+
+    private @Mock @NonNullByDefault({}) UserRegistry userRegistryMock;
+    private @Mock @NonNullByDefault({}) RoleRegistry roleRegistryMock;
+    private @Mock @NonNullByDefault({}) Console consoleMock;
+    private @NonNullByDefault({}) UserConsoleCommandExtension command;
+
+    @BeforeEach
+    public void setup() {
+        command = new UserConsoleCommandExtension(userRegistryMock, roleRegistryMock);
+    }
+
+    // --- addRole ---
+
+    @Test
+    public void testAddRoleToUser() {
+        ManagedUser user = new ManagedUser("alice", "salt", "hash");
+        user.setRoles(new HashSet<>(Set.of("user")));
+        when(userRegistryMock.get(eq("alice"))).thenReturn(user);
+        when(roleRegistryMock.get(eq("viewer"))).thenReturn(new RoleDefinition("viewer", "", Set.of(), false));
+
+        command.execute(new String[] { "addRole", "alice", "viewer" }, consoleMock);
+
+        verify(userRegistryMock).update(user);
+        verify(consoleMock).println(contains("added to user"));
+    }
+
+    @Test
+    public void testAddRoleWithUndefinedRolePrintsWarningButAdds() {
+        ManagedUser user = new ManagedUser("alice", "salt", "hash");
+        user.setRoles(new HashSet<>(Set.of("user")));
+        when(userRegistryMock.get(eq("alice"))).thenReturn(user);
+        when(roleRegistryMock.get(eq("undefined_role"))).thenReturn(null);
+
+        command.execute(new String[] { "addRole", "alice", "undefined_role" }, consoleMock);
+
+        verify(consoleMock).println(contains("Warning"));
+        verify(userRegistryMock).update(user);
+        verify(consoleMock).println(contains("added to user"));
+    }
+
+    @Test
+    public void testAddRoleUserAlreadyHasRolePrintsMessage() {
+        ManagedUser user = new ManagedUser("alice", "salt", "hash");
+        user.setRoles(new HashSet<>(Set.of("user", "viewer")));
+        when(userRegistryMock.get(eq("alice"))).thenReturn(user);
+
+        command.execute(new String[] { "addRole", "alice", "viewer" }, consoleMock);
+
+        verify(userRegistryMock, never()).update(user);
+        verify(consoleMock).println(contains("already has role"));
+    }
+
+    @Test
+    public void testAddRoleUserNotFoundPrintsError() {
+        when(userRegistryMock.get(eq("nonexistent"))).thenReturn(null);
+
+        command.execute(new String[] { "addRole", "nonexistent", "viewer" }, consoleMock);
+
+        verify(userRegistryMock, never()).update(any());
+        verify(consoleMock).println("User not found.");
+    }
+
+    @Test
+    public void testAddRoleMissingArgsPrintsUsage() {
+        command.execute(new String[] { "addRole", "alice" }, consoleMock);
+
+        verify(consoleMock).printUsage(anyString());
+    }
+
+    // --- removeRole ---
+
+    @Test
+    public void testRemoveRoleFromUser() {
+        ManagedUser user = new ManagedUser("alice", "salt", "hash");
+        user.setRoles(new HashSet<>(Set.of("user", "viewer")));
+        when(userRegistryMock.get(eq("alice"))).thenReturn(user);
+
+        command.execute(new String[] { "removeRole", "alice", "viewer" }, consoleMock);
+
+        verify(userRegistryMock).update(user);
+        verify(consoleMock).println(contains("removed from user"));
+    }
+
+    @Test
+    public void testRemoveRoleUserDoesNotHaveRolePrintsError() {
+        ManagedUser user = new ManagedUser("alice", "salt", "hash");
+        user.setRoles(new HashSet<>(Set.of("user")));
+        when(userRegistryMock.get(eq("alice"))).thenReturn(user);
+
+        command.execute(new String[] { "removeRole", "alice", "viewer" }, consoleMock);
+
+        verify(userRegistryMock, never()).update(user);
+        verify(consoleMock).println(contains("does not have role"));
+    }
+
+    @Test
+    public void testRemoveRoleUserNotFoundPrintsError() {
+        when(userRegistryMock.get(eq("nonexistent"))).thenReturn(null);
+
+        command.execute(new String[] { "removeRole", "nonexistent", "viewer" }, consoleMock);
+
+        verify(userRegistryMock, never()).update(any());
+        verify(consoleMock).println("User not found.");
+    }
+
+    @Test
+    public void testRemoveRoleMissingArgsPrintsUsage() {
+        command.execute(new String[] { "removeRole" }, consoleMock);
+
+        verify(consoleMock).printUsage(anyString());
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/Action.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/Action.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Marker interface for typed permission actions. Each {@link ResourceType} has its
+ * own enum implementing this interface (e.g., {@link ItemAction}, {@link PageAction}).
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public interface Action {
+
+    /**
+     * The action name as used in serialization and display.
+     *
+     * @return the action name
+     */
+    String name();
+
+    /**
+     * The resource type this action belongs to.
+     *
+     * @return the resource type
+     */
+    ResourceType resourceType();
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/Actions.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/Actions.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import java.util.Arrays;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Factory for resolving {@link Action} instances from string names and {@link ResourceType}s.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public final class Actions {
+
+    private Actions() {
+    }
+
+    /**
+     * Parses an action name for the given resource type.
+     *
+     * @param type the resource type
+     * @param name the action name (case-insensitive)
+     * @return the typed action
+     * @throws IllegalArgumentException if the name is not valid for the resource type
+     */
+    public static Action parse(ResourceType type, String name) {
+        String upper = name.toUpperCase();
+        try {
+            return switch (type) {
+                case ITEM -> ItemAction.valueOf(upper);
+                case PAGE -> PageAction.valueOf(upper);
+                case SITEMAP -> SitemapAction.valueOf(upper);
+            };
+        } catch (IllegalArgumentException e) {
+            Action[] valid = switch (type) {
+                case ITEM -> ItemAction.values();
+                case PAGE -> PageAction.values();
+                case SITEMAP -> SitemapAction.values();
+            };
+            throw new IllegalArgumentException("Unknown action '" + name + "' for resource type " + type
+                    + ". Valid actions: " + Arrays.toString(valid));
+        }
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/AllSelector.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/AllSelector.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * A {@link Selector} that matches all resources. Expression: {@code "*"}
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public record AllSelector() implements Selector {
+
+    /** Shared instance — all {@code AllSelector}s are equal (no fields). */
+    public static final AllSelector INSTANCE = new AllSelector();
+
+    @Override
+    public boolean matches(String resourceId) {
+        return true;
+    }
+
+    @Override
+    public String expression() {
+        return "*";
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/AuthorizationService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/AuthorizationService.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import java.util.Collection;
+import java.util.function.Function;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Service for checking whether an authenticated user has permission to perform
+ * an action on a resource. When RBAC enforcement is disabled, all checks return
+ * {@code true} (allow-all).
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public interface AuthorizationService {
+
+    /**
+     * Returns whether RBAC enforcement is enabled.
+     * When disabled, all permission checks return {@code true} (allow-all).
+     *
+     * @return {@code true} if RBAC enforcement is active
+     */
+    boolean isEnabled();
+
+    /**
+     * Checks whether the authenticated user has permission to perform the given
+     * action on the specified resource.
+     *
+     * @param auth the authentication context (username + roles)
+     * @param type the resource type
+     * @param resourceId the specific resource identifier
+     * @param action the action being performed
+     * @return {@code true} if access is granted
+     */
+    boolean hasPermission(Authentication auth, ResourceType type, String resourceId, Action action);
+
+    /**
+     * Filters a collection, returning only resources the user is authorized to access.
+     * When RBAC is disabled, returns the input collection unchanged (no copy).
+     *
+     * @param <T> the element type
+     * @param auth the authentication context
+     * @param resources the full collection of resources
+     * @param type the resource type
+     * @param action the action being performed
+     * @param idExtractor extracts the resource ID from each element
+     * @return a collection containing only authorized resources (may be the input itself if unfiltered)
+     */
+    <T> Collection<T> filterAuthorized(Authentication auth, Collection<T> resources, ResourceType type, Action action,
+            Function<T, String> idExtractor);
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/ByGroupSelector.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/ByGroupSelector.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * A {@link Selector} that matches items belonging to a group. Expression: {@code "group:<groupName>"}
+ * <p>
+ * The simple {@link #matches(String)} always returns {@code false} — group membership
+ * requires entity access, resolved by the {@code ItemPermissionEvaluator} in Phase 1.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ *
+ * @param group the group name
+ */
+@NonNullByDefault
+public record ByGroupSelector(String group) implements Selector {
+
+    @Override
+    public boolean matches(String resourceId) {
+        return false;
+    }
+
+    @Override
+    public String expression() {
+        return "group:" + group;
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/ByIdSelector.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/ByIdSelector.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * A {@link Selector} that matches a specific resource by ID. Expression: {@code "id:<value>"}
+ *
+ * @author Gabor Bicskei - Initial contribution
+ *
+ * @param id the resource identifier to match
+ */
+@NonNullByDefault
+public record ByIdSelector(String id) implements Selector {
+
+    @Override
+    public boolean matches(String resourceId) {
+        return id.equals(resourceId);
+    }
+
+    @Override
+    public String expression() {
+        return "id:" + id;
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/ByLocationSelector.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/ByLocationSelector.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * A {@link Selector} that matches items by semantic location. Expression: {@code "location:<locationName>"}
+ * <p>
+ * The simple {@link #matches(String)} always returns {@code false} — location matching
+ * requires entity access, resolved by the {@code ItemPermissionEvaluator} in Phase 1.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ *
+ * @param location the location name
+ */
+@NonNullByDefault
+public record ByLocationSelector(String location) implements Selector {
+
+    @Override
+    public boolean matches(String resourceId) {
+        return false;
+    }
+
+    @Override
+    public String expression() {
+        return "location:" + location;
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/ByTagSelector.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/ByTagSelector.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * A {@link Selector} that matches items by tag. Expression: {@code "tag:<tagName>"}
+ * <p>
+ * The simple {@link #matches(String)} always returns {@code false} — tag matching
+ * requires entity access, resolved by the {@code ItemPermissionEvaluator} in Phase 1.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ *
+ * @param tag the tag name
+ */
+@NonNullByDefault
+public record ByTagSelector(String tag) implements Selector {
+
+    @Override
+    public boolean matches(String resourceId) {
+        return false;
+    }
+
+    @Override
+    public String expression() {
+        return "tag:" + tag;
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/ItemAction.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/ItemAction.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Actions applicable to {@link ResourceType#ITEM} resources.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public enum ItemAction implements Action {
+    READ,
+    COMMAND,
+    EDIT;
+
+    @Override
+    public ResourceType resourceType() {
+        return ResourceType.ITEM;
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/PageAction.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/PageAction.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Actions applicable to {@link ResourceType#PAGE} resources.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public enum PageAction implements Action {
+    READ,
+    EDIT,
+    MANAGE;
+
+    @Override
+    public ResourceType resourceType() {
+        return ResourceType.PAGE;
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/Permission.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/Permission.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * A permission grants access to perform a specific {@link Action} on resources of a given
+ * {@link ResourceType} matching the {@link Selector} expression.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ *
+ * @param resourceType the type of resource this permission applies to
+ * @param selector a selector determining which resources are covered
+ * @param action the action that is permitted
+ */
+@NonNullByDefault
+public record Permission(ResourceType resourceType, Selector selector, Action action) {
+
+    /**
+     * Validates that the action's resource type matches the permission's resource type.
+     */
+    public Permission {
+        if (action.resourceType() != resourceType) {
+            throw new IllegalArgumentException(
+                    "Action " + action.name() + " is not valid for resource type " + resourceType);
+        }
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/PermissionEvaluator.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/PermissionEvaluator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Evaluates whether a specific {@link Permission} grants access to a resource.
+ * One evaluator is registered per {@link ResourceType}. The
+ * {@link AuthorizationService} delegates to the appropriate evaluator when
+ * checking permissions.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public interface PermissionEvaluator {
+
+    /**
+     * Returns the resource type this evaluator handles.
+     *
+     * @return the resource type
+     */
+    ResourceType getResourceType();
+
+    /**
+     * Checks if the given permission grants access to the specified resource and action.
+     *
+     * @param permission the permission to evaluate
+     * @param resourceId the resource identifier to check against the permission's selector
+     * @param action the action to check against the permission's action
+     * @return {@code true} if the permission grants the requested access
+     */
+    boolean evaluate(Permission permission, String resourceId, Action action);
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/ResourceType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/ResourceType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Defines the types of resources that can be protected by permissions.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public enum ResourceType {
+    ITEM,
+    PAGE,
+    SITEMAP
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/RoleDefinition.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/RoleDefinition.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.common.registry.Identifiable;
+
+/**
+ * A {@link RoleDefinition} represents a named role with a set of {@link Permission}s.
+ * Roles can be built-in (provided by the system) or user-created (managed via the
+ * {@link RoleRegistry}).
+ * <p>
+ * This is a plain POJO persisted via JSON DB using Gson's default reflection-based
+ * serialization. Field names map directly to JSON property names.
+ * <p>
+ * Note: {@code equals}/{@code hashCode} are intentionally not overridden — the registry
+ * framework uses {@link #getUID()} for identity-based lookups, matching the
+ * {@link ManagedUser} convention.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public class RoleDefinition implements Identifiable<String> {
+
+    private final String name;
+    private final String description;
+    private final Set<Permission> permissions;
+    private final boolean builtIn;
+
+    /**
+     * Constructs a new role definition.
+     *
+     * @param name the unique name of the role (serves as the UID)
+     * @param description a human-readable description of the role
+     * @param permissions the set of permissions granted by this role
+     * @param builtIn whether this role is a built-in system role
+     */
+    public RoleDefinition(String name, String description, Set<Permission> permissions, boolean builtIn) {
+        this.name = name;
+        this.description = description;
+        this.permissions = Set.copyOf(permissions);
+        this.builtIn = builtIn;
+    }
+
+    @Override
+    public String getUID() {
+        return name;
+    }
+
+    /**
+     * Gets the name of this role.
+     *
+     * @return the role name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Gets the description of this role.
+     *
+     * @return the role description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Gets the set of permissions granted by this role.
+     *
+     * @return the permissions
+     */
+    public Set<Permission> getPermissions() {
+        return permissions;
+    }
+
+    /**
+     * Returns whether this role is a built-in system role.
+     *
+     * @return {@code true} if this is a built-in role
+     */
+    public boolean isBuiltIn() {
+        return builtIn;
+    }
+
+    @Override
+    public String toString() {
+        return name + " (" + (builtIn ? "built-in" : "custom") + ")";
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/RoleProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/RoleProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.common.registry.Provider;
+
+/**
+ * An interface for a {@link Provider} of {@link RoleDefinition} entities.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public interface RoleProvider extends Provider<RoleDefinition> {
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/RoleRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/RoleRegistry.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.common.registry.Registry;
+
+/**
+ * A {@link Registry} for {@link RoleDefinition} entities. Aggregates roles from all
+ * {@link RoleProvider}s (both built-in and user-managed).
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public interface RoleRegistry extends Registry<RoleDefinition, String> {
+
+    /**
+     * Returns whether the given role can be edited (i.e., it is managed by a
+     * {@link org.openhab.core.common.registry.ManagedProvider}).
+     *
+     * @param role the role to check
+     * @return {@code true} if the role is editable
+     */
+    boolean isEditable(RoleDefinition role);
+
+    /**
+     * Returns whether the given role is a default (built-in) role.
+     *
+     * @param role the role to check
+     * @return {@code true} if the role is a built-in default role
+     */
+    boolean isDefault(RoleDefinition role);
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/Selector.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/Selector.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * A selector determines which resources a {@link Permission} applies to.
+ * <p>
+ * Simple selectors ({@link AllSelector}, {@link ByIdSelector}) can resolve
+ * purely by resource ID. Entity-aware selectors ({@link ByGroupSelector},
+ * {@link ByTagSelector}, {@link ByLocationSelector}) require access to the
+ * full entity and are resolved by the {@link PermissionEvaluator} — their
+ * {@link #matches(String)} method returns {@code false} by design.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public interface Selector {
+
+    /**
+     * Tests whether this selector matches the given resource identifier.
+     * Entity-aware selectors (group, tag, location) return {@code false} here —
+     * they require the full entity, resolved in the {@link PermissionEvaluator}.
+     *
+     * @param resourceId the resource identifier
+     * @return {@code true} if this selector covers the resource by ID alone
+     */
+    boolean matches(String resourceId);
+
+    /**
+     * Returns the string expression form of this selector for serialization and display.
+     * <p>
+     * Format: {@code "*"} | {@code "id:value"} | {@code "group:value"} |
+     * {@code "tag:value"} | {@code "location:value"}
+     *
+     * @return the expression string
+     */
+    String expression();
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/SelectorParser.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/SelectorParser.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Factory that parses selector expression strings into typed {@link Selector} instances.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public final class SelectorParser {
+
+    private SelectorParser() {
+    }
+
+    /**
+     * Parses a selector expression string into a typed {@link Selector}.
+     * <p>
+     * Note: Selector expressions are <b>case-sensitive</b> — item names, group names, tag names, and
+     * location names must match exactly. This contrasts with resource types and actions, which are
+     * case-insensitive.
+     *
+     * @param expression the expression (e.g., {@code "*"}, {@code "id:LivingRoom_Light"}, {@code "group:gLights"})
+     * @return the parsed selector
+     * @throws IllegalArgumentException if the expression is not recognized
+     */
+    public static Selector parse(String expression) {
+        if ("*".equals(expression)) {
+            return AllSelector.INSTANCE;
+        }
+        int colon = expression.indexOf(':');
+        if (colon < 0) {
+            throw new IllegalArgumentException("Invalid selector expression: " + expression);
+        }
+        String prefix = expression.substring(0, colon);
+        String value = expression.substring(colon + 1);
+        return switch (prefix) {
+            case "id" -> new ByIdSelector(value);
+            case "group" -> new ByGroupSelector(value);
+            case "tag" -> new ByTagSelector(value);
+            case "location" -> new ByLocationSelector(value);
+            default -> throw new IllegalArgumentException(
+                    "Unknown selector prefix: " + prefix + ". Valid prefixes: id, group, tag, location");
+        };
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/SitemapAction.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/SitemapAction.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Actions applicable to {@link ResourceType#SITEMAP} resources.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public enum SitemapAction implements Action {
+    READ;
+
+    @Override
+    public ResourceType resourceType() {
+        return ResourceType.SITEMAP;
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/auth/DefaultRoleProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/auth/DefaultRoleProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.internal.auth;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.auth.AllSelector;
+import org.openhab.core.auth.ItemAction;
+import org.openhab.core.auth.PageAction;
+import org.openhab.core.auth.Permission;
+import org.openhab.core.auth.ResourceType;
+import org.openhab.core.auth.RoleDefinition;
+import org.openhab.core.auth.RoleProvider;
+import org.openhab.core.auth.SitemapAction;
+import org.openhab.core.common.registry.ProviderChangeListener;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * A {@link RoleProvider} that supplies the built-in default roles. These roles are
+ * hardcoded and never change at runtime.
+ * <p>
+ * The {@code administrator} role has no explicit permissions — enforcement logic
+ * (in a future PR) will short-circuit to allow-all for this role.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+@Component(immediate = true, service = { RoleProvider.class, DefaultRoleProvider.class })
+public class DefaultRoleProvider implements RoleProvider {
+
+    private final List<RoleDefinition> roles;
+
+    public DefaultRoleProvider() {
+        roles = List.of(new RoleDefinition("administrator", "Full system access", Set.of(), true),
+                new RoleDefinition("user", "Standard user",
+                        Set.of(new Permission(ResourceType.ITEM, AllSelector.INSTANCE, ItemAction.COMMAND),
+                                new Permission(ResourceType.PAGE, AllSelector.INSTANCE, PageAction.READ),
+                                new Permission(ResourceType.SITEMAP, AllSelector.INSTANCE, SitemapAction.READ)),
+                        true));
+    }
+
+    @Override
+    public Collection<RoleDefinition> getAll() {
+        return roles;
+    }
+
+    @Override
+    public void addProviderChangeListener(ProviderChangeListener<RoleDefinition> listener) {
+        // Built-in roles never change — no-op
+    }
+
+    @Override
+    public void removeProviderChangeListener(ProviderChangeListener<RoleDefinition> listener) {
+        // Built-in roles never change — no-op
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/auth/ManagedRoleProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/auth/ManagedRoleProvider.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.internal.auth;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.auth.Actions;
+import org.openhab.core.auth.Permission;
+import org.openhab.core.auth.ResourceType;
+import org.openhab.core.auth.RoleDefinition;
+import org.openhab.core.auth.SelectorParser;
+import org.openhab.core.common.registry.AbstractManagedProvider;
+import org.openhab.core.storage.StorageService;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link org.openhab.core.common.registry.ManagedProvider} for user-created
+ * {@link RoleDefinition} entities, persisted in JSON DB.
+ * <p>
+ * Uses {@link PersistedRoleDefinition} as the storage DTO to avoid Gson interface
+ * deserialization issues with the typed {@link org.openhab.core.auth.Selector} and
+ * {@link org.openhab.core.auth.Action} fields in {@link Permission}.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = ManagedRoleProvider.class, immediate = true)
+public class ManagedRoleProvider extends AbstractManagedProvider<RoleDefinition, String, PersistedRoleDefinition> {
+
+    private final Logger logger = LoggerFactory.getLogger(ManagedRoleProvider.class);
+
+    @Activate
+    public ManagedRoleProvider(final @Reference StorageService storageService) {
+        super(storageService);
+    }
+
+    @Override
+    protected String getStorageName() {
+        return "roles";
+    }
+
+    @Override
+    protected String keyToString(String key) {
+        return key;
+    }
+
+    @Override
+    protected @Nullable RoleDefinition toElement(String key, PersistedRoleDefinition persisted) {
+        try {
+            Set<Permission> permissions = new HashSet<>();
+            for (PersistedPermission pp : persisted.permissions) {
+                ResourceType type = ResourceType.valueOf(pp.resourceType);
+                permissions
+                        .add(new Permission(type, SelectorParser.parse(pp.selector), Actions.parse(type, pp.action)));
+            }
+            return new RoleDefinition(persisted.name, persisted.description, permissions, persisted.builtIn);
+        } catch (IllegalArgumentException e) {
+            logger.warn("Failed to deserialize role '{}': {}", key, e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    protected PersistedRoleDefinition toPersistableElement(RoleDefinition role) {
+        return new PersistedRoleDefinition(role.getName(), role.getDescription(), role.getPermissions().stream().map(
+                p -> new PersistedPermission(p.resourceType().name(), p.selector().expression(), p.action().name()))
+                .collect(Collectors.toList()), role.isBuiltIn());
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/auth/PersistedPermission.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/auth/PersistedPermission.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.internal.auth;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * A Gson-serializable DTO for {@link org.openhab.core.auth.Permission}. Uses plain strings
+ * for the selector and action fields to avoid Gson interface deserialization issues.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public class PersistedPermission {
+
+    public String resourceType = "";
+    public String selector = "";
+    public String action = "";
+
+    public PersistedPermission() {
+    }
+
+    public PersistedPermission(String resourceType, String selector, String action) {
+        this.resourceType = resourceType;
+        this.selector = selector;
+        this.action = action;
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/auth/PersistedRoleDefinition.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/auth/PersistedRoleDefinition.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.internal.auth;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * A Gson-serializable DTO for {@link org.openhab.core.auth.RoleDefinition}. Uses
+ * {@link PersistedPermission} instances with plain string fields to avoid Gson
+ * interface deserialization issues.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public class PersistedRoleDefinition {
+
+    public String name = "";
+    public String description = "";
+    public List<PersistedPermission> permissions = new ArrayList<>();
+    public boolean builtIn;
+
+    public PersistedRoleDefinition() {
+    }
+
+    public PersistedRoleDefinition(String name, String description, List<PersistedPermission> permissions,
+            boolean builtIn) {
+        this.name = name;
+        this.description = description;
+        this.permissions = permissions;
+        this.builtIn = builtIn;
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/auth/RoleRegistryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/auth/RoleRegistryImpl.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.internal.auth;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.auth.RoleDefinition;
+import org.openhab.core.auth.RoleProvider;
+import org.openhab.core.auth.RoleRegistry;
+import org.openhab.core.common.registry.AbstractRegistry;
+import org.openhab.core.common.registry.Provider;
+import org.openhab.core.service.ReadyService;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The implementation of a {@link RoleRegistry} that aggregates {@link RoleDefinition} entities
+ * from both the {@link DefaultRoleProvider} (built-in roles) and the {@link ManagedRoleProvider}
+ * (user-created roles persisted in JSON DB).
+ * <p>
+ * Follows the {@code SemanticTagRegistryImpl} constructor-injection pattern: both providers are
+ * added eagerly in the constructor, and {@link #addProvider} is overridden to prevent
+ * double-registration by the OSGi service tracker.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = RoleRegistry.class, immediate = true)
+public class RoleRegistryImpl extends AbstractRegistry<RoleDefinition, String, RoleProvider> implements RoleRegistry {
+
+    private final DefaultRoleProvider defaultRoleProvider;
+    private final ManagedRoleProvider managedProvider;
+    private final Set<String> defaultRoleUIDs;
+
+    @Activate
+    public RoleRegistryImpl(@Reference DefaultRoleProvider defaultRoleProvider,
+            @Reference ManagedRoleProvider managedProvider, @Reference ReadyService readyService) {
+        super(RoleProvider.class);
+        this.defaultRoleProvider = defaultRoleProvider;
+        this.managedProvider = managedProvider;
+        // Capture built-in role UIDs for isDefault() checks — uses UID-based lookup
+        // since RoleDefinition does not override equals/hashCode (matches ManagedUser convention).
+        this.defaultRoleUIDs = defaultRoleProvider.getAll().stream().map(RoleDefinition::getUID)
+                .collect(Collectors.toUnmodifiableSet());
+        // Add the default roles provider first, before all others
+        super.addProvider(defaultRoleProvider);
+        super.setReadyService(readyService);
+        setManagedProvider(managedProvider);
+        super.addProvider(managedProvider);
+    }
+
+    @Override
+    protected void addProvider(Provider<RoleDefinition> provider) {
+        // Prevent double-registration by OSGi service tracker —
+        // both providers are already added in the constructor via super.addProvider().
+        if (!provider.equals(defaultRoleProvider) && !provider.equals(managedProvider)) {
+            super.addProvider(provider);
+        }
+    }
+
+    @Override
+    public @Nullable RoleDefinition remove(String key) {
+        RoleDefinition role = get(key);
+        if (role != null && isDefault(role)) {
+            throw new IllegalArgumentException("Built-in role '" + key + "' cannot be removed");
+        }
+        return super.remove(key);
+    }
+
+    @Override
+    public boolean isEditable(RoleDefinition role) {
+        return managedProvider.get(role.getUID()) != null;
+    }
+
+    @Override
+    public boolean isDefault(RoleDefinition role) {
+        return defaultRoleUIDs.contains(role.getUID());
+    }
+}

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/auth/ActionsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/auth/ActionsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link Actions}.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public class ActionsTest {
+
+    @Test
+    public void testParseItemActions() {
+        assertEquals(ItemAction.READ, Actions.parse(ResourceType.ITEM, "READ"));
+        assertEquals(ItemAction.COMMAND, Actions.parse(ResourceType.ITEM, "COMMAND"));
+        assertEquals(ItemAction.EDIT, Actions.parse(ResourceType.ITEM, "EDIT"));
+    }
+
+    @Test
+    public void testParsePageActions() {
+        assertEquals(PageAction.READ, Actions.parse(ResourceType.PAGE, "READ"));
+        assertEquals(PageAction.EDIT, Actions.parse(ResourceType.PAGE, "EDIT"));
+        assertEquals(PageAction.MANAGE, Actions.parse(ResourceType.PAGE, "MANAGE"));
+    }
+
+    @Test
+    public void testParseSitemapActions() {
+        assertEquals(SitemapAction.READ, Actions.parse(ResourceType.SITEMAP, "READ"));
+    }
+
+    @Test
+    public void testParseCaseInsensitive() {
+        assertEquals(ItemAction.READ, Actions.parse(ResourceType.ITEM, "read"));
+        assertEquals(PageAction.EDIT, Actions.parse(ResourceType.PAGE, "edit"));
+    }
+
+    @Test
+    public void testParseInvalidActionThrows() {
+        assertThrows(IllegalArgumentException.class, () -> Actions.parse(ResourceType.ITEM, "BOGUS"));
+    }
+
+    @Test
+    public void testParseActionWrongResourceTypeThrows() {
+        // COMMAND is valid for ITEM but not for PAGE
+        assertThrows(IllegalArgumentException.class, () -> Actions.parse(ResourceType.PAGE, "COMMAND"));
+    }
+
+    @Test
+    public void testActionResourceType() {
+        assertEquals(ResourceType.ITEM, ItemAction.READ.resourceType());
+        assertEquals(ResourceType.PAGE, PageAction.READ.resourceType());
+        assertEquals(ResourceType.SITEMAP, SitemapAction.READ.resourceType());
+    }
+
+    @Test
+    public void testActionName() {
+        assertEquals("READ", ItemAction.READ.name());
+        assertEquals("COMMAND", ItemAction.COMMAND.name());
+        assertEquals("MANAGE", PageAction.MANAGE.name());
+    }
+}

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/auth/PermissionTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/auth/PermissionTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the {@link Permission} record, including compact constructor validation.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public class PermissionTest {
+
+    @Test
+    public void testValidPermissionCreation() {
+        Permission p = new Permission(ResourceType.ITEM, AllSelector.INSTANCE, ItemAction.READ);
+        assertEquals(ResourceType.ITEM, p.resourceType());
+        assertSame(AllSelector.INSTANCE, p.selector());
+        assertEquals(ItemAction.READ, p.action());
+    }
+
+    @Test
+    public void testMismatchedActionResourceTypeThrows() {
+        // PageAction.READ is not valid for ResourceType.ITEM
+        assertThrows(IllegalArgumentException.class,
+                () -> new Permission(ResourceType.ITEM, AllSelector.INSTANCE, PageAction.READ));
+    }
+
+    @Test
+    public void testMismatchedSitemapActionOnItemThrows() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Permission(ResourceType.ITEM, AllSelector.INSTANCE, SitemapAction.READ));
+    }
+
+    @Test
+    public void testMismatchedItemActionOnPageThrows() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Permission(ResourceType.PAGE, AllSelector.INSTANCE, ItemAction.COMMAND));
+    }
+
+    @Test
+    public void testRecordEquality() {
+        Permission p1 = new Permission(ResourceType.ITEM, AllSelector.INSTANCE, ItemAction.READ);
+        Permission p2 = new Permission(ResourceType.ITEM, new AllSelector(), ItemAction.READ);
+        assertEquals(p1, p2);
+        assertEquals(p1.hashCode(), p2.hashCode());
+    }
+
+    @Test
+    public void testRecordInequalityDifferentAction() {
+        Permission p1 = new Permission(ResourceType.ITEM, AllSelector.INSTANCE, ItemAction.READ);
+        Permission p2 = new Permission(ResourceType.ITEM, AllSelector.INSTANCE, ItemAction.COMMAND);
+        assertNotEquals(p1, p2);
+    }
+
+    @Test
+    public void testRecordInequalityDifferentSelector() {
+        Permission p1 = new Permission(ResourceType.ITEM, AllSelector.INSTANCE, ItemAction.READ);
+        Permission p2 = new Permission(ResourceType.ITEM, new ByIdSelector("item1"), ItemAction.READ);
+        assertNotEquals(p1, p2);
+    }
+
+    @Test
+    public void testRecordInequalityDifferentResourceType() {
+        Permission p1 = new Permission(ResourceType.ITEM, AllSelector.INSTANCE, ItemAction.READ);
+        Permission p2 = new Permission(ResourceType.PAGE, AllSelector.INSTANCE, PageAction.READ);
+        assertNotEquals(p1, p2);
+    }
+
+    @Test
+    public void testAllResourceTypeActionCombinations() {
+        // Verify all valid combinations don't throw
+        assertDoesNotThrow(() -> new Permission(ResourceType.ITEM, AllSelector.INSTANCE, ItemAction.READ));
+        assertDoesNotThrow(() -> new Permission(ResourceType.ITEM, AllSelector.INSTANCE, ItemAction.COMMAND));
+        assertDoesNotThrow(() -> new Permission(ResourceType.ITEM, AllSelector.INSTANCE, ItemAction.EDIT));
+        assertDoesNotThrow(() -> new Permission(ResourceType.PAGE, AllSelector.INSTANCE, PageAction.READ));
+        assertDoesNotThrow(() -> new Permission(ResourceType.PAGE, AllSelector.INSTANCE, PageAction.EDIT));
+        assertDoesNotThrow(() -> new Permission(ResourceType.PAGE, AllSelector.INSTANCE, PageAction.MANAGE));
+        assertDoesNotThrow(() -> new Permission(ResourceType.SITEMAP, AllSelector.INSTANCE, SitemapAction.READ));
+    }
+
+    @Test
+    public void testPermissionWithByIdSelector() {
+        Permission p = new Permission(ResourceType.ITEM, new ByIdSelector("Light1"), ItemAction.COMMAND);
+        assertEquals("id:Light1", p.selector().expression());
+        assertTrue(p.selector().matches("Light1"));
+        assertFalse(p.selector().matches("Light2"));
+    }
+
+    @Test
+    public void testPermissionWithEntityAwareSelector() {
+        Permission p = new Permission(ResourceType.ITEM, new ByGroupSelector("gLights"), ItemAction.READ);
+        assertEquals("group:gLights", p.selector().expression());
+        // Entity-aware selectors return false from simple matches()
+        assertFalse(p.selector().matches("anyItem"));
+    }
+}

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/auth/SelectorParserTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/auth/SelectorParserTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link SelectorParser}.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@NonNullByDefault
+public class SelectorParserTest {
+
+    @Test
+    public void testParseWildcard() {
+        Selector selector = SelectorParser.parse("*");
+        assertInstanceOf(AllSelector.class, selector);
+        assertTrue(selector.matches("anything"));
+        assertEquals("*", selector.expression());
+    }
+
+    @Test
+    public void testParseById() {
+        Selector selector = SelectorParser.parse("id:LivingRoom_Light");
+        assertInstanceOf(ByIdSelector.class, selector);
+        assertTrue(selector.matches("LivingRoom_Light"));
+        assertFalse(selector.matches("Kitchen_Light"));
+        assertEquals("id:LivingRoom_Light", selector.expression());
+    }
+
+    @Test
+    public void testParseByGroup() {
+        Selector selector = SelectorParser.parse("group:gLights");
+        assertInstanceOf(ByGroupSelector.class, selector);
+        assertFalse(selector.matches("anything")); // requires entity access
+        assertEquals("group:gLights", selector.expression());
+        assertEquals("gLights", ((ByGroupSelector) selector).group());
+    }
+
+    @Test
+    public void testParseByTag() {
+        Selector selector = SelectorParser.parse("tag:Lighting");
+        assertInstanceOf(ByTagSelector.class, selector);
+        assertFalse(selector.matches("anything"));
+        assertEquals("tag:Lighting", selector.expression());
+        assertEquals("Lighting", ((ByTagSelector) selector).tag());
+    }
+
+    @Test
+    public void testParseByLocation() {
+        Selector selector = SelectorParser.parse("location:LivingRoom");
+        assertInstanceOf(ByLocationSelector.class, selector);
+        assertFalse(selector.matches("anything"));
+        assertEquals("location:LivingRoom", selector.expression());
+        assertEquals("LivingRoom", ((ByLocationSelector) selector).location());
+    }
+
+    @Test
+    public void testParseInvalidNoColonThrows() {
+        assertThrows(IllegalArgumentException.class, () -> SelectorParser.parse("invalid"));
+    }
+
+    @Test
+    public void testParseUnknownPrefixThrows() {
+        assertThrows(IllegalArgumentException.class, () -> SelectorParser.parse("unknown:value"));
+    }
+
+    @Test
+    public void testAllSelectorEquality() {
+        assertEquals(new AllSelector(), new AllSelector());
+    }
+
+    @Test
+    public void testByIdSelectorEquality() {
+        assertEquals(new ByIdSelector("item1"), new ByIdSelector("item1"));
+        assertNotEquals(new ByIdSelector("item1"), new ByIdSelector("item2"));
+    }
+
+    @Test
+    public void testByGroupSelectorEquality() {
+        assertEquals(new ByGroupSelector("gLights"), new ByGroupSelector("gLights"));
+        assertNotEquals(new ByGroupSelector("gLights"), new ByGroupSelector("gHeating"));
+    }
+
+    @Test
+    public void testByTagSelectorEquality() {
+        assertEquals(new ByTagSelector("Lighting"), new ByTagSelector("Lighting"));
+        assertNotEquals(new ByTagSelector("Lighting"), new ByTagSelector("Heating"));
+    }
+
+    @Test
+    public void testByLocationSelectorEquality() {
+        assertEquals(new ByLocationSelector("LivingRoom"), new ByLocationSelector("LivingRoom"));
+        assertNotEquals(new ByLocationSelector("LivingRoom"), new ByLocationSelector("Kitchen"));
+    }
+
+    @Test
+    public void testAllSelectorSingleton() {
+        assertSame(AllSelector.INSTANCE, SelectorParser.parse("*"));
+    }
+
+    @Test
+    public void testDifferentSelectorTypesNotEqual() {
+        assertNotEquals(new AllSelector(), new ByIdSelector("*"));
+        assertNotEquals(new ByIdSelector("gLights"), new ByGroupSelector("gLights"));
+        assertNotEquals(new ByTagSelector("tag"), new ByLocationSelector("tag"));
+    }
+}

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/auth/ManagedRoleProviderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/auth/ManagedRoleProviderTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.internal.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.auth.AllSelector;
+import org.openhab.core.auth.ByGroupSelector;
+import org.openhab.core.auth.ByIdSelector;
+import org.openhab.core.auth.ByLocationSelector;
+import org.openhab.core.auth.ByTagSelector;
+import org.openhab.core.auth.ItemAction;
+import org.openhab.core.auth.PageAction;
+import org.openhab.core.auth.Permission;
+import org.openhab.core.auth.ResourceType;
+import org.openhab.core.auth.RoleDefinition;
+import org.openhab.core.auth.SitemapAction;
+import org.openhab.core.storage.Storage;
+import org.openhab.core.storage.StorageService;
+
+/**
+ * Tests for {@link ManagedRoleProvider} DTO round-trip (toElement / toPersistableElement).
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@NonNullByDefault
+public class ManagedRoleProviderTest {
+
+    private @Mock @NonNullByDefault({}) StorageService storageServiceMock;
+    private @Mock @NonNullByDefault({}) Storage<Object> storageMock;
+    private @NonNullByDefault({}) ManagedRoleProvider provider;
+
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    public void setup() {
+        when(storageServiceMock.getStorage(eq("roles"), any())).thenReturn(storageMock);
+        provider = new ManagedRoleProvider(storageServiceMock);
+    }
+
+    @Test
+    public void testRoundTripWithAllSelectorAndItemAction() {
+        RoleDefinition original = new RoleDefinition("viewer", "Read-only viewer",
+                Set.of(new Permission(ResourceType.ITEM, AllSelector.INSTANCE, ItemAction.READ)), false);
+
+        PersistedRoleDefinition persisted = provider.toPersistableElement(original);
+        RoleDefinition restored = provider.toElement("viewer", persisted);
+
+        assertNotNull(restored);
+        assertEquals("viewer", restored.getUID());
+        assertEquals("Read-only viewer", restored.getDescription());
+        assertFalse(restored.isBuiltIn());
+        assertEquals(1, restored.getPermissions().size());
+        assertTrue(restored.getPermissions()
+                .contains(new Permission(ResourceType.ITEM, AllSelector.INSTANCE, ItemAction.READ)));
+    }
+
+    @Test
+    public void testRoundTripWithByIdSelector() {
+        RoleDefinition original = new RoleDefinition("custom", "Custom role",
+                Set.of(new Permission(ResourceType.ITEM, new ByIdSelector("LivingRoom_Light"), ItemAction.COMMAND)),
+                false);
+
+        PersistedRoleDefinition persisted = provider.toPersistableElement(original);
+        RoleDefinition restored = provider.toElement("custom", persisted);
+
+        assertNotNull(restored);
+        assertEquals(1, restored.getPermissions().size());
+        Permission perm = restored.getPermissions().iterator().next();
+        assertInstanceOf(ByIdSelector.class, perm.selector());
+        assertEquals("LivingRoom_Light", ((ByIdSelector) perm.selector()).id());
+        assertEquals(ItemAction.COMMAND, perm.action());
+    }
+
+    @Test
+    public void testRoundTripWithByGroupSelector() {
+        RoleDefinition original = new RoleDefinition("custom", "Custom role",
+                Set.of(new Permission(ResourceType.ITEM, new ByGroupSelector("gLights"), ItemAction.READ)), false);
+
+        PersistedRoleDefinition persisted = provider.toPersistableElement(original);
+        RoleDefinition restored = provider.toElement("custom", persisted);
+
+        assertNotNull(restored);
+        Permission perm = restored.getPermissions().iterator().next();
+        assertInstanceOf(ByGroupSelector.class, perm.selector());
+        assertEquals("gLights", ((ByGroupSelector) perm.selector()).group());
+    }
+
+    @Test
+    public void testRoundTripWithByTagSelector() {
+        RoleDefinition original = new RoleDefinition("custom", "Custom role",
+                Set.of(new Permission(ResourceType.ITEM, new ByTagSelector("Lighting"), ItemAction.READ)), false);
+
+        PersistedRoleDefinition persisted = provider.toPersistableElement(original);
+        RoleDefinition restored = provider.toElement("custom", persisted);
+
+        assertNotNull(restored);
+        Permission perm = restored.getPermissions().iterator().next();
+        assertInstanceOf(ByTagSelector.class, perm.selector());
+        assertEquals("Lighting", ((ByTagSelector) perm.selector()).tag());
+    }
+
+    @Test
+    public void testRoundTripWithByLocationSelector() {
+        RoleDefinition original = new RoleDefinition("custom", "Custom role",
+                Set.of(new Permission(ResourceType.ITEM, new ByLocationSelector("LivingRoom"), ItemAction.READ)),
+                false);
+
+        PersistedRoleDefinition persisted = provider.toPersistableElement(original);
+        RoleDefinition restored = provider.toElement("custom", persisted);
+
+        assertNotNull(restored);
+        Permission perm = restored.getPermissions().iterator().next();
+        assertInstanceOf(ByLocationSelector.class, perm.selector());
+        assertEquals("LivingRoom", ((ByLocationSelector) perm.selector()).location());
+    }
+
+    @Test
+    public void testRoundTripWithMultiplePermissions() {
+        RoleDefinition original = new RoleDefinition("user", "Standard user",
+                Set.of(new Permission(ResourceType.ITEM, AllSelector.INSTANCE, ItemAction.COMMAND),
+                        new Permission(ResourceType.PAGE, AllSelector.INSTANCE, PageAction.READ),
+                        new Permission(ResourceType.SITEMAP, AllSelector.INSTANCE, SitemapAction.READ)),
+                true);
+
+        PersistedRoleDefinition persisted = provider.toPersistableElement(original);
+        assertEquals(3, persisted.permissions.size());
+
+        RoleDefinition restored = provider.toElement("user", persisted);
+
+        assertNotNull(restored);
+        assertEquals("user", restored.getUID());
+        assertTrue(restored.isBuiltIn());
+        assertEquals(3, restored.getPermissions().size());
+        assertTrue(restored.getPermissions()
+                .contains(new Permission(ResourceType.ITEM, AllSelector.INSTANCE, ItemAction.COMMAND)));
+        assertTrue(restored.getPermissions()
+                .contains(new Permission(ResourceType.PAGE, AllSelector.INSTANCE, PageAction.READ)));
+        assertTrue(restored.getPermissions()
+                .contains(new Permission(ResourceType.SITEMAP, AllSelector.INSTANCE, SitemapAction.READ)));
+    }
+
+    @Test
+    public void testRoundTripWithEmptyPermissions() {
+        RoleDefinition original = new RoleDefinition("empty", "No permissions", Set.of(), false);
+
+        PersistedRoleDefinition persisted = provider.toPersistableElement(original);
+        assertEquals(0, persisted.permissions.size());
+
+        RoleDefinition restored = provider.toElement("empty", persisted);
+
+        assertNotNull(restored);
+        assertTrue(restored.getPermissions().isEmpty());
+    }
+
+    @Test
+    public void testToElementWithCorruptResourceTypeReturnsNull() {
+        PersistedRoleDefinition persisted = new PersistedRoleDefinition("bad", "Bad role",
+                java.util.List.of(new PersistedPermission("INVALID_TYPE", "*", "READ")), false);
+
+        RoleDefinition result = provider.toElement("bad", persisted);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void testToElementWithCorruptActionReturnsNull() {
+        PersistedRoleDefinition persisted = new PersistedRoleDefinition("bad", "Bad role",
+                java.util.List.of(new PersistedPermission("ITEM", "*", "BOGUS_ACTION")), false);
+
+        RoleDefinition result = provider.toElement("bad", persisted);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void testToElementWithCorruptSelectorReturnsNull() {
+        PersistedRoleDefinition persisted = new PersistedRoleDefinition("bad", "Bad role",
+                java.util.List.of(new PersistedPermission("ITEM", "invalid_no_colon", "READ")), false);
+
+        RoleDefinition result = provider.toElement("bad", persisted);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void testPersistedPermissionStringValues() {
+        Permission permission = new Permission(ResourceType.ITEM, new ByGroupSelector("gLights"), ItemAction.COMMAND);
+        RoleDefinition role = new RoleDefinition("test", "Test", Set.of(permission), false);
+
+        PersistedRoleDefinition persisted = provider.toPersistableElement(role);
+
+        assertEquals(1, persisted.permissions.size());
+        PersistedPermission pp = persisted.permissions.get(0);
+        assertEquals("ITEM", pp.resourceType);
+        assertEquals("group:gLights", pp.selector);
+        assertEquals("COMMAND", pp.action);
+    }
+
+    @Test
+    public void testStorageName() {
+        // Verify via the add method that it uses the correct storage
+        verify(storageServiceMock).getStorage(eq("roles"), any());
+    }
+}

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/auth/RoleRegistryImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/auth/RoleRegistryImplTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.internal.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.auth.AllSelector;
+import org.openhab.core.auth.ItemAction;
+import org.openhab.core.auth.PageAction;
+import org.openhab.core.auth.Permission;
+import org.openhab.core.auth.ResourceType;
+import org.openhab.core.auth.RoleDefinition;
+import org.openhab.core.auth.SitemapAction;
+import org.openhab.core.service.ReadyService;
+
+/**
+ * Tests for {@link RoleRegistryImpl}.
+ *
+ * @author Gabor Bicskei - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@NonNullByDefault
+public class RoleRegistryImplTest {
+
+    private @Mock @NonNullByDefault({}) ManagedRoleProvider managedRoleProviderMock;
+    private @Mock @NonNullByDefault({}) ReadyService readyServiceMock;
+    private @NonNullByDefault({}) RoleRegistryImpl registry;
+
+    @BeforeEach
+    public void setup() {
+        when(managedRoleProviderMock.getAll()).thenReturn(List.of());
+        registry = new RoleRegistryImpl(new DefaultRoleProvider(), managedRoleProviderMock, readyServiceMock);
+    }
+
+    @Test
+    public void testBuiltInRolesPresentOnStartup() {
+        assertNotNull(registry.get("administrator"));
+        assertNotNull(registry.get("user"));
+        assertEquals(2, registry.getAll().size());
+    }
+
+    @Test
+    public void testAdministratorRoleHasNoPermissions() {
+        RoleDefinition admin = Objects.requireNonNull(registry.get("administrator"));
+        assertEquals("administrator", admin.getUID());
+        assertEquals("Full system access", admin.getDescription());
+        assertTrue(admin.isBuiltIn());
+        assertTrue(admin.getPermissions().isEmpty());
+    }
+
+    @Test
+    public void testUserRoleHasExpectedPermissions() {
+        RoleDefinition user = Objects.requireNonNull(registry.get("user"));
+        assertEquals("user", user.getUID());
+        assertTrue(user.isBuiltIn());
+        Set<Permission> permissions = user.getPermissions();
+        assertEquals(3, permissions.size());
+        assertTrue(permissions.contains(new Permission(ResourceType.ITEM, new AllSelector(), ItemAction.COMMAND)));
+        assertTrue(permissions.contains(new Permission(ResourceType.PAGE, new AllSelector(), PageAction.READ)));
+        assertTrue(permissions.contains(new Permission(ResourceType.SITEMAP, new AllSelector(), SitemapAction.READ)));
+    }
+
+    @Test
+    public void testBuiltInRolesCannotBeRemoved() {
+        assertThrows(IllegalArgumentException.class, () -> registry.remove("administrator"));
+        assertThrows(IllegalArgumentException.class, () -> registry.remove("user"));
+    }
+
+    @Test
+    public void testRemoveNonExistentKeyReturnsNull() {
+        assertNull(registry.remove("nonexistent"));
+    }
+
+    @Test
+    public void testIsDefaultForBuiltInRoles() {
+        RoleDefinition admin = Objects.requireNonNull(registry.get("administrator"));
+        RoleDefinition user = Objects.requireNonNull(registry.get("user"));
+        assertTrue(registry.isDefault(admin));
+        assertTrue(registry.isDefault(user));
+    }
+
+    @Test
+    public void testIsDefaultForCustomRole() {
+        RoleDefinition customRole = new RoleDefinition("custom", "Custom role", Set.of(), false);
+        assertFalse(registry.isDefault(customRole));
+    }
+
+    @Test
+    public void testIsEditableForBuiltInRoles() {
+        when(managedRoleProviderMock.get(eq("administrator"))).thenReturn(null);
+        when(managedRoleProviderMock.get(eq("user"))).thenReturn(null);
+
+        RoleDefinition admin = Objects.requireNonNull(registry.get("administrator"));
+        RoleDefinition user = Objects.requireNonNull(registry.get("user"));
+        assertFalse(registry.isEditable(admin));
+        assertFalse(registry.isEditable(user));
+    }
+
+    @Test
+    public void testIsEditableForManagedRole() {
+        RoleDefinition customRole = new RoleDefinition("custom", "Custom role", Set.of(), false);
+        when(managedRoleProviderMock.get(eq("custom"))).thenReturn(customRole);
+
+        assertTrue(registry.isEditable(customRole));
+    }
+
+    @Test
+    public void testPermissionRecordBasics() {
+        Permission permission = new Permission(ResourceType.ITEM, new AllSelector(), ItemAction.COMMAND);
+        assertEquals(ResourceType.ITEM, permission.resourceType());
+        assertEquals("*", permission.selector().expression());
+        assertEquals("COMMAND", permission.action().name());
+    }
+
+    @Test
+    public void testPermissionRecordEquality() {
+        Permission p1 = new Permission(ResourceType.ITEM, new AllSelector(), ItemAction.COMMAND);
+        Permission p2 = new Permission(ResourceType.ITEM, new AllSelector(), ItemAction.COMMAND);
+        Permission p3 = new Permission(ResourceType.PAGE, new AllSelector(), PageAction.READ);
+        assertEquals(p1, p2);
+        assertNotEquals(p1, p3);
+    }
+
+    @Test
+    public void testPermissionValidatesActionResourceType() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Permission(ResourceType.ITEM, new AllSelector(), PageAction.READ));
+    }
+
+    @Test
+    public void testResourceTypeValues() {
+        assertEquals(3, ResourceType.values().length);
+        assertNotNull(ResourceType.valueOf("ITEM"));
+        assertNotNull(ResourceType.valueOf("PAGE"));
+        assertNotNull(ResourceType.valueOf("SITEMAP"));
+    }
+
+    @Test
+    public void testRoleDefinitionToString() {
+        RoleDefinition builtIn = Objects.requireNonNull(registry.get("administrator"));
+        assertEquals("administrator (built-in)", builtIn.toString());
+
+        RoleDefinition custom = new RoleDefinition("viewer", "Read-only", Set.of(), false);
+        assertEquals("viewer (custom)", custom.toString());
+    }
+
+    @Test
+    public void testAddCustomRoleDelegatesToManagedProvider() {
+        RoleDefinition customRole = new RoleDefinition("viewer", "Read-only viewer", Set.of(), false);
+        registry.add(customRole);
+        verify(managedRoleProviderMock).add(customRole);
+    }
+
+    @Test
+    public void testUpdateCustomRoleDelegatesToManagedProvider() {
+        RoleDefinition customRole = new RoleDefinition("viewer", "Read-only viewer", Set.of(), false);
+        registry.update(customRole);
+        verify(managedRoleProviderMock).update(customRole);
+    }
+
+    @Test
+    public void testAddedCustomRoleIsRetrievable() {
+        RoleDefinition customRole = new RoleDefinition("viewer", "Read-only viewer",
+                Set.of(new Permission(ResourceType.ITEM, new AllSelector(), ItemAction.READ)), false);
+
+        registry.added(managedRoleProviderMock, customRole);
+
+        RoleDefinition retrieved = registry.get("viewer");
+        assertNotNull(retrieved);
+        assertEquals("viewer", retrieved.getUID());
+        assertEquals("Read-only viewer", retrieved.getDescription());
+        assertFalse(retrieved.isBuiltIn());
+        assertEquals(1, retrieved.getPermissions().size());
+    }
+
+    @Test
+    public void testRemovedCustomRoleIsNoLongerRetrievable() {
+        RoleDefinition customRole = new RoleDefinition("viewer", "Read-only viewer", Set.of(), false);
+
+        registry.added(managedRoleProviderMock, customRole);
+        assertNotNull(registry.get("viewer"));
+
+        registry.removed(managedRoleProviderMock, customRole);
+        assertNull(registry.get("viewer"));
+    }
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -21,6 +21,7 @@
     <module>org.openhab.core.addon.eclipse</module>
     <module>org.openhab.core.addon.marketplace</module>
     <module>org.openhab.core.addon.marketplace.karaf</module>
+    <module>org.openhab.core.auth.authorization</module>
     <module>org.openhab.core.auth.jaas</module>
     <module>org.openhab.core.auth.oauth2client</module>
     <module>org.openhab.core.automation</module>

--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -127,6 +127,11 @@
 		<feature dependency="true">openhab-core-ui</feature>
 	</feature>
 
+	<feature name="openhab-core-auth-authorization" version="${project.version}">
+		<feature>openhab-core-base</feature>
+		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.auth.authorization/${project.version}</bundle>
+	</feature>
+
 	<feature name="openhab-core-auth-jaas" version="${project.version}">
 		<feature>openhab-core-base</feature>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.auth.jaas/${project.version}</bundle>


### PR DESCRIPTION
Phase 0 foundation for RBAC. No enforcement yet (Phase 1).

Part of #5809

**Data model** (`org.openhab.core`):
- `RoleDefinition`, `RoleRegistry` with built-in + managed provider pattern
- Typed `Action` enums per ResourceType (`ItemAction`, `PageAction`, `SitemapAction`)
- `Selector` interface with implementations (`AllSelector`, `ByIdSelector`, `ByGroupSelector`, `ByTagSelector`, `ByLocationSelector`)
- `Permission` record with action/resourceType validation

**AuthorizationService** (new `org.openhab.core.auth.authorization` bundle):
- Disabled by default, admin short-circuit, `ConcurrentHashMap` cache
- No-op evaluators for ITEM, PAGE, SITEMAP

**Console commands** (`org.openhab.core.io.console`):
- `openhab:roles` — list, add, remove, addPermission, removePermission, show
- `openhab:users` — addRole, removeRole

Looking for feedback on the interface design.