### PR TITLE
Fix missing recursive widgets property in WidgetDTO OpenAPI schema

### DIFF
--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
@@ -19,6 +19,7 @@ import org.openhab.core.io.rest.core.item.EnrichedItemDTO;
 import org.openhab.core.sitemap.dto.AbstractWidgetDTO;
 import org.openhab.core.sitemap.dto.MappingDTO;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
@@ -57,8 +58,9 @@ public class WidgetDTO extends AbstractWidgetDTO {
     // Legacy sitemap clients expect a non-empty widgets and mappings array, even if the widget has no child widgets and
     // no mappings. This should be considered a workaround and should be removed in the future when legacy sitemap
     // clients are no longer supported.
-    public final List<WidgetDTO> widgets = new ArrayList<>(); // only for frames and button grids, other linkable
-                                                              // widgets link to a page
+    // only for frames and button grids, other linkable widgets link to a page
+    @ArraySchema(schema = @Schema(implementation = WidgetDTO.class))
+    public final List<WidgetDTO> widgets = new ArrayList<>();
     public final List<MappingDTO> mappings = new ArrayList<>();
 
     public WidgetDTO() {


### PR DESCRIPTION
## Summary
- `WidgetDTO.widgets` (`List<WidgetDTO>`) is silently dropped by Swagger-core when generating the OpenAPI schema, even though the field exists in the Java class. Comparison with sibling fields on `WidgetDTO`/`PageDTO` shows the omission is specific to a collection field whose item type equals the enclosing class:
  - `WidgetDTO.mappings` (`List<MappingDTO>`, different type) → rendered fine
  - `PageDTO.parent` (`PageDTO`, scalar self-reference) → rendered fine
  - `PageDTO.widgets` (`List<WidgetDTO>`, different type) → rendered fine
  - `WidgetDTO.widgets` (`List<WidgetDTO>`, **same type, collection**) → dropped
- Adds an explicit `@ArraySchema(schema = @Schema(implementation = WidgetDTO.class))` on the field to force correct resolution instead of relying on automatic inference.
- Relates to #4340 (item 1: "openAPI schema for WidgetDTO is missing the recursive use of widgets").

## Caveat
Not verified against a live server build/regenerated spec in this environment — diagnosis is based on structural comparison of the generated schema vs. the Java source, not a confirmed before/after diff from actually running the annotation processor.

## Test plan
- [ ] Build openhab-core and hit `/rest/spec`, confirm `SitemapWidget.widgets` (or `WidgetDTO` in this branch's version) now appears with a `$ref` back to itself
- [ ] Regenerate the iOS app's Swift types against the updated spec and confirm no unexpected changes