### PR TITLE
Document X-Atmosphere-Transport header for sitemap/page polling endpoints

### DIFF
--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
@@ -409,6 +409,7 @@ public class SitemapResource
             @ApiResponse(responseCode = "400", description = "Invalid subscription id has been provided.") })
     public Response getSitemapData(@Context HttpHeaders headers,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
+            @HeaderParam("X-Atmosphere-Transport") @Parameter(description = "X-Atmosphere-Transport for long polling") @Nullable String xAtmosphereTransport,
             @PathParam("sitemapname") @Parameter(description = "sitemap name") String sitemapname,
             @QueryParam("subscriptionid") @Parameter(description = "subscriptionid") @Nullable String subscriptionId,
             @QueryParam("includeHidden") @Parameter(description = "include hidden widgets") boolean includeHiddenWidgets) {
@@ -424,7 +425,7 @@ public class SitemapResource
         }
 
         boolean timeout = false;
-        if (headers.getRequestHeader("X-Atmosphere-Transport") != null) {
+        if (xAtmosphereTransport != null) {
             timeout = blockUntilChangeOccurs(sitemapname, null);
         }
         SitemapDTO responseObject = getSitemapBean(sitemapname, uriInfo.getBaseUriBuilder().build(), locale,
@@ -441,6 +442,7 @@ public class SitemapResource
             @ApiResponse(responseCode = "400", description = "Invalid subscription id has been provided.") })
     public Response getPageData(@Context HttpHeaders headers,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
+            @HeaderParam("X-Atmosphere-Transport") @Parameter(description = "X-Atmosphere-Transport for long polling") @Nullable String xAtmosphereTransport,
             @PathParam("sitemapname") @Parameter(description = "sitemap name") String sitemapname,
             @PathParam("pageid") @Parameter(description = "page id") String pageId,
             @QueryParam("subscriptionid") @Parameter(description = "subscriptionid") @Nullable String subscriptionId,
@@ -457,7 +459,7 @@ public class SitemapResource
         }
 
         boolean timeout = false;
-        if (headers.getRequestHeader("X-Atmosphere-Transport") != null) {
+        if (xAtmosphereTransport != null) {
             // Make the REST-API pseudo-compatible with openHAB 1.x
             // The client asks Atmosphere for server push functionality,
             // so we do a simply listening for changes on the appropriate items

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
@@ -170,6 +170,7 @@ public class SitemapResource
     public static final String PATH_SITEMAPS = "sitemaps";
     private static final String SEGMENT_EVENTS = "events";
     private static final String X_ACCEL_BUFFERING_HEADER = "X-Accel-Buffering";
+    private static final String X_ATMOSPHERE_TRANSPORT_HEADER = "X-Atmosphere-Transport";
 
     private static final long TIMEOUT_IN_MS = 30000;
 
@@ -409,7 +410,7 @@ public class SitemapResource
             @ApiResponse(responseCode = "400", description = "Invalid subscription id has been provided.") })
     public Response getSitemapData(@Context HttpHeaders headers,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
-            @HeaderParam("X-Atmosphere-Transport") @Parameter(description = "X-Atmosphere-Transport for long polling") @Nullable String xAtmosphereTransport,
+            @HeaderParam(X_ATMOSPHERE_TRANSPORT_HEADER) @Parameter(description = "X-Atmosphere-Transport for long polling") @Nullable String xAtmosphereTransport,
             @PathParam("sitemapname") @Parameter(description = "sitemap name") String sitemapname,
             @QueryParam("subscriptionid") @Parameter(description = "subscriptionid") @Nullable String subscriptionId,
             @QueryParam("includeHidden") @Parameter(description = "include hidden widgets") boolean includeHiddenWidgets) {
@@ -442,7 +443,7 @@ public class SitemapResource
             @ApiResponse(responseCode = "400", description = "Invalid subscription id has been provided.") })
     public Response getPageData(@Context HttpHeaders headers,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
-            @HeaderParam("X-Atmosphere-Transport") @Parameter(description = "X-Atmosphere-Transport for long polling") @Nullable String xAtmosphereTransport,
+            @HeaderParam(X_ATMOSPHERE_TRANSPORT_HEADER) @Parameter(description = "X-Atmosphere-Transport for long polling") @Nullable String xAtmosphereTransport,
             @PathParam("sitemapname") @Parameter(description = "sitemap name") String sitemapname,
             @PathParam("pageid") @Parameter(description = "page id") String pageId,
             @QueryParam("subscriptionid") @Parameter(description = "subscriptionid") @Nullable String subscriptionId,

--- a/bundles/org.openhab.core.io.rest.sitemap/src/test/java/org/openhab/core/io/rest/sitemap/internal/SitemapResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/test/java/org/openhab/core/io/rest/sitemap/internal/SitemapResourceTest.java
@@ -283,7 +283,8 @@ public class SitemapResourceTest extends JavaTest {
         // non-null is sufficient here.
         when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(List.of());
 
-        Response response = sitemapResource.getSitemapData(headersMock, null, SITEMAP_NAME, null, false);
+        Response response = sitemapResource.getSitemapData(headersMock, null, "long-polling", SITEMAP_NAME, null,
+                false);
 
         SitemapDTO sitemapDTO = (SitemapDTO) response.getEntity();
         // assert that the item state change did trigger the blocking method to return
@@ -303,7 +304,8 @@ public class SitemapResourceTest extends JavaTest {
         // non-null is sufficient here.
         when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(List.of());
 
-        Response response = sitemapResource.getPageData(headersMock, null, SITEMAP_NAME, SITEMAP_NAME, null, false);
+        Response response = sitemapResource.getPageData(headersMock, null, "long-polling", SITEMAP_NAME, SITEMAP_NAME,
+                null, false);
 
         PageDTO pageDTO = (PageDTO) response.getEntity();
         // assert that the item state change did trigger the blocking method to return
@@ -319,7 +321,8 @@ public class SitemapResourceTest extends JavaTest {
         // non-null is sufficient here.
         when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(List.of());
 
-        Response response = sitemapResource.getPageData(headersMock, null, SITEMAP_NAME, SITEMAP_NAME, null, false);
+        Response response = sitemapResource.getPageData(headersMock, null, "long-polling", SITEMAP_NAME, SITEMAP_NAME,
+                null, false);
 
         PageDTO pageDTO = (PageDTO) response.getEntity();
         // assert that the item state change did trigger the blocking method to return
@@ -335,7 +338,8 @@ public class SitemapResourceTest extends JavaTest {
         // non-null is sufficient here.
         when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(List.of());
 
-        Response response = sitemapResource.getPageData(headersMock, null, SITEMAP_NAME, SITEMAP_NAME, null, false);
+        Response response = sitemapResource.getPageData(headersMock, null, "long-polling", SITEMAP_NAME, SITEMAP_NAME,
+                null, false);
 
         PageDTO pageDTO = (PageDTO) response.getEntity();
         // assert that the item state change did trigger the blocking method to return
@@ -351,7 +355,8 @@ public class SitemapResourceTest extends JavaTest {
         // non-null is sufficient here.
         when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(List.of());
 
-        Response response = sitemapResource.getPageData(headersMock, null, SITEMAP_NAME, SITEMAP_NAME, null, false);
+        Response response = sitemapResource.getPageData(headersMock, null, "long-polling", SITEMAP_NAME, SITEMAP_NAME,
+                null, false);
 
         PageDTO pageDTO = (PageDTO) response.getEntity();
         // assert that the item state change did trigger the blocking method to return
@@ -367,7 +372,8 @@ public class SitemapResourceTest extends JavaTest {
         // non-null is sufficient here.
         when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(List.of());
 
-        Response response = sitemapResource.getPageData(headersMock, null, SITEMAP_NAME, SITEMAP_NAME, null, false);
+        Response response = sitemapResource.getPageData(headersMock, null, "long-polling", SITEMAP_NAME, SITEMAP_NAME,
+                null, false);
 
         PageDTO pageDTO = (PageDTO) response.getEntity();
         assertThat(pageDTO.timeout, is(false)); // assert that the item state change did trigger the blocking method to
@@ -383,7 +389,8 @@ public class SitemapResourceTest extends JavaTest {
         // non-null is sufficient here.
         when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(List.of());
 
-        Response response = sitemapResource.getPageData(headersMock, null, SITEMAP_NAME, SITEMAP_NAME, null, false);
+        Response response = sitemapResource.getPageData(headersMock, null, "long-polling", SITEMAP_NAME, SITEMAP_NAME,
+                null, false);
 
         PageDTO pageDTO = (PageDTO) response.getEntity();
         assertThat(pageDTO.timeout, is(false)); // assert that the item state change did trigger the blocking method to
@@ -399,7 +406,8 @@ public class SitemapResourceTest extends JavaTest {
         // non-null is sufficient here.
         when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(List.of());
 
-        Response response = sitemapResource.getPageData(headersMock, null, SITEMAP_NAME, SITEMAP_NAME, null, false);
+        Response response = sitemapResource.getPageData(headersMock, null, "long-polling", SITEMAP_NAME, SITEMAP_NAME,
+                null, false);
 
         PageDTO pageDTO = (PageDTO) response.getEntity();
         // assert that the item state change did trigger the blocking method to return
@@ -425,7 +433,8 @@ public class SitemapResourceTest extends JavaTest {
         // Disable long polling
         when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(null);
 
-        Response response = sitemapResource.getPageData(headersMock, null, SITEMAP_NAME, SITEMAP_NAME, null, false);
+        Response response = sitemapResource.getPageData(headersMock, null, null, SITEMAP_NAME, SITEMAP_NAME, null,
+                false);
 
         PageDTO pageDTO = (PageDTO) response.getEntity();
         assertThat(pageDTO.id, is(SITEMAP_NAME));

--- a/bundles/org.openhab.core.io.rest.sitemap/src/test/java/org/openhab/core/io/rest/sitemap/internal/SitemapResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/test/java/org/openhab/core/io/rest/sitemap/internal/SitemapResourceTest.java
@@ -78,7 +78,6 @@ public class SitemapResourceTest extends JavaTest {
 
     private static final int STATE_UPDATE_WAIT_TIME = 100;
 
-    private static final String HTTP_HEADER_X_ATMOSPHERE_TRANSPORT = "X-Atmosphere-Transport";
     private static final String ITEM_NAME = "itemName";
 
     private static final String ITEM_LABEL = "item label";
@@ -158,9 +157,6 @@ public class SitemapResourceTest extends JavaTest {
 
         widgets = initSitemapWidgetsWithSubpages();
         configureItemUIRegistry(PercentType.HUNDRED, OnOffType.ON);
-
-        // Disable long polling
-        when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(null);
     }
 
     @Test
@@ -280,9 +276,6 @@ public class SitemapResourceTest extends JavaTest {
         when(itemEvent.getItemName()).thenReturn(item.getName());
         executeWithDelay(() -> sitemapResource.receive(itemEvent));
 
-        // non-null is sufficient here.
-        when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(List.of());
-
         Response response = sitemapResource.getSitemapData(headersMock, null, "long-polling", SITEMAP_NAME, null,
                 false);
 
@@ -301,9 +294,6 @@ public class SitemapResourceTest extends JavaTest {
         when(itemEvent.getItemName()).thenReturn(item.getName());
         executeWithDelay(() -> sitemapResource.receive(itemEvent));
 
-        // non-null is sufficient here.
-        when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(List.of());
-
         Response response = sitemapResource.getPageData(headersMock, null, "long-polling", SITEMAP_NAME, SITEMAP_NAME,
                 null, false);
 
@@ -317,9 +307,6 @@ public class SitemapResourceTest extends JavaTest {
         ItemEvent itemEvent = mock(ItemEvent.class);
         when(itemEvent.getItemName()).thenReturn(item.getName());
         executeWithDelay(() -> sitemapResource.receive(itemEvent));
-
-        // non-null is sufficient here.
-        when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(List.of());
 
         Response response = sitemapResource.getPageData(headersMock, null, "long-polling", SITEMAP_NAME, SITEMAP_NAME,
                 null, false);
@@ -335,9 +322,6 @@ public class SitemapResourceTest extends JavaTest {
         when(itemEvent.getItemName()).thenReturn(visibilityRuleItem.getName());
         executeWithDelay(() -> sitemapResource.receive(itemEvent));
 
-        // non-null is sufficient here.
-        when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(List.of());
-
         Response response = sitemapResource.getPageData(headersMock, null, "long-polling", SITEMAP_NAME, SITEMAP_NAME,
                 null, false);
 
@@ -351,9 +335,6 @@ public class SitemapResourceTest extends JavaTest {
         ItemEvent itemEvent = mock(ItemEvent.class);
         when(itemEvent.getItemName()).thenReturn(labelColorItem.getName());
         executeWithDelay(() -> sitemapResource.receive(itemEvent));
-
-        // non-null is sufficient here.
-        when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(List.of());
 
         Response response = sitemapResource.getPageData(headersMock, null, "long-polling", SITEMAP_NAME, SITEMAP_NAME,
                 null, false);
@@ -369,9 +350,6 @@ public class SitemapResourceTest extends JavaTest {
         when(itemEvent.getItemName()).thenReturn(valueColorItem.getName());
         executeWithDelay(() -> sitemapResource.receive(itemEvent));
 
-        // non-null is sufficient here.
-        when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(List.of());
-
         Response response = sitemapResource.getPageData(headersMock, null, "long-polling", SITEMAP_NAME, SITEMAP_NAME,
                 null, false);
 
@@ -386,9 +364,6 @@ public class SitemapResourceTest extends JavaTest {
         when(itemEvent.getItemName()).thenReturn(iconColorItem.getName());
         executeWithDelay(() -> sitemapResource.receive(itemEvent));
 
-        // non-null is sufficient here.
-        when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(List.of());
-
         Response response = sitemapResource.getPageData(headersMock, null, "long-polling", SITEMAP_NAME, SITEMAP_NAME,
                 null, false);
 
@@ -402,9 +377,6 @@ public class SitemapResourceTest extends JavaTest {
         ItemEvent itemEvent = mock(ItemEvent.class);
         when(itemEvent.getItemName()).thenReturn(iconItem.getName());
         executeWithDelay(() -> sitemapResource.receive(itemEvent));
-
-        // non-null is sufficient here.
-        when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(List.of());
 
         Response response = sitemapResource.getPageData(headersMock, null, "long-polling", SITEMAP_NAME, SITEMAP_NAME,
                 null, false);
@@ -429,9 +401,6 @@ public class SitemapResourceTest extends JavaTest {
     public void whenGetPageDataShouldReturnPageBean() throws ItemNotFoundException {
         item.setState(new PercentType(50));
         configureItemUIRegistry(item.getState(), OnOffType.ON);
-
-        // Disable long polling
-        when(headersMock.getRequestHeader(HTTP_HEADER_X_ATMOSPHERE_TRANSPORT)).thenReturn(null);
 
         Response response = sitemapResource.getPageData(headersMock, null, null, SITEMAP_NAME, SITEMAP_NAME, null,
                 false);


### PR DESCRIPTION
## Summary
- `pollDataForSitemap` (`getSitemapData`) and `pollDataForPage` (`getPageData`) in `SitemapResource.java` both check for the `X-Atmosphere-Transport` header to decide whether to long-poll, but read it via raw `HttpHeaders.getRequestHeader(...)` instead of an annotated `@HeaderParam`. Swagger-core only documents parameters it can see on the method signature, so this header is currently missing from the generated OpenAPI spec for both operations.
- Adds `@HeaderParam("X-Atmosphere-Transport") @Parameter(...) @Nullable String xAtmosphereTransport` to both method signatures (matching the existing pattern used for `Accept-Language` right above it in each), and swaps the body's header lookup for the new parameter. No behavior change.
- Addresses #4340 item 3. Note: the issue names the header `X-Atmosphere-Framework`, which doesn't exist anywhere in this codebase — appears to be a typo for `X-Atmosphere-Transport`, the header actually read by this code.

## Caveat
Not verified against a live server build/regenerated spec in this environment.

## Test plan
- [ ] Build openhab-core and hit `/rest/spec`, confirm `X-Atmosphere-Transport` now appears as a header parameter for `pollDataForSitemap` and `pollDataForPage`
- [ ] Confirm long-polling behavior is unchanged (existing `SitemapResourceTest` coverage for `X-Atmosphere-Transport` should still pass)