### PR TITLE
Fail safely on unresolved Thing configuration

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
@@ -174,9 +174,8 @@ public abstract class BaseThingHandler implements ThingHandler {
         try {
             resolvedConfiguration = ConfigUtil.resolveVariables(thing.getConfiguration());
         } catch (IllegalArgumentException e) {
-            logger.warn("Updated thing '{}' with a thing containing invalid configuration '{}': {}", thing.getUID(),
-                    thing.getConfiguration(), e.getMessage());
-            resolvedConfiguration = thing.getConfiguration();
+            handleConfigurationResolutionFailure(thing);
+            throw e;
         }
         synchronized (this) {
             this.thing = thing;
@@ -293,9 +292,8 @@ public abstract class BaseThingHandler implements ThingHandler {
                     try {
                         this.resolvedConfig = resolvedConfig = ConfigUtil.resolveVariables(getRawConfig());
                     } catch (IllegalArgumentException e) {
-                        logger.warn("Failed to resolve variables for configuration '{}' of thing '{}': {}",
-                                getRawConfig(), getThing().getUID(), e.getMessage());
-                        return new Configuration(getRawConfig());
+                        handleConfigurationResolutionFailure(getThing());
+                        throw e;
                     }
                 }
             }
@@ -312,6 +310,12 @@ public abstract class BaseThingHandler implements ThingHandler {
      */
     protected <T> T getConfigAs(Class<T> configurationClass) {
         return getConfig().as(configurationClass);
+    }
+
+    private void handleConfigurationResolutionFailure(Thing thing) {
+        logger.warn("Failed to resolve configuration variables for thing '{}'.", thing.getUID());
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                "Failed to resolve configuration variables.");
     }
 
     /**

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/BaseThingHandlerTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/BaseThingHandlerTest.java
@@ -13,6 +13,7 @@
 package org.openhab.core.thing.binding;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 import java.util.Map;
@@ -30,6 +31,8 @@ import org.openhab.core.config.core.ConfigUtil;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
@@ -167,5 +170,34 @@ class BaseThingHandlerTest {
 
         assertEquals("resolved-var_suffix", handler.getConfig().get("p1"));
         assertEquals("resolved-foo", handler.getConfig().get("p2"));
+    }
+
+    @Test
+    public void testMissingEnvironmentVariableFailsSafelyAndPreservesRawConfiguration() {
+        String placeholder = "${ENV:MISSING_SECRET}";
+        Thing thing = ThingBuilder.create(THING_TYPE_UID, THING_UID.getId())
+                .withConfiguration(new Configuration(Map.of("password", placeholder))).build();
+        TestThingHandler testHandler = new TestThingHandler(thing);
+        testHandler.setCallback(callback);
+        ConfigUtilAccessor.setEnv(Map.of());
+        assertThrows(IllegalArgumentException.class, testHandler::getConfig);
+        assertEquals(placeholder, thing.getConfiguration().get("password"));
+        verify(callback).statusUpdated(eq(thing), argThat(status -> status.getStatus() == ThingStatus.OFFLINE
+                && status.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR));
+    }
+
+    @Test
+    public void testSetThingRejectsUnresolvedConfigurationAndKeepsCurrentThing() {
+        Thing currentThing = handler.getThing();
+        Thing replacementThing = ThingBuilder.create(THING_TYPE_UID, "replacement")
+                .withConfiguration(new Configuration(Map.of("password", "${ENV:MISSING_SECRET}"))).build();
+        ConfigUtilAccessor.setEnv(Map.of());
+
+        assertThrows(IllegalArgumentException.class, () -> handler.replaceThing(replacementThing));
+
+        assertEquals(currentThing, handler.getThing());
+        assertEquals("${ENV:MISSING_SECRET}", replacementThing.getConfiguration().get("password"));
+        verify(callback).statusUpdated(eq(currentThing), argThat(status -> status.getStatus() == ThingStatus.OFFLINE
+                && status.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR));
     }
 }


### PR DESCRIPTION
## Description

Prevent unresolved configuration variables from falling back to raw Thing configuration values.

When variable resolution fails, `BaseThingHandler` now:

- reports `OFFLINE` with `CONFIGURATION_ERROR`
- throws the resolution exception instead of exposing unresolved raw configuration
- avoids logging configuration values or exception details
- leaves the currently managed Thing unchanged when a replacement Thing has invalid configuration

## Tests

Added regression coverage confirming that:

- a missing environment variable causes configuration access to fail safely
- the raw placeholder remains in canonical Thing configuration
- the handler reports `OFFLINE / CONFIGURATION_ERROR`
- an invalid replacement Thing is rejected
- the existing managed Thing remains assigned
- replacement failure status is reported against the currently managed Thing

Validation:

`BaseThingHandlerTest`
