### PR TITLE
Sitemap subscriptions: avoid index out of bound exception

### DIFF
--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/SitemapSubscriptionService.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/SitemapSubscriptionService.java
@@ -221,8 +221,11 @@ public class SitemapSubscriptionService implements RegistryChangeListener<Sitema
         return sitemapWithPageId.contains(SITEMAP_PAGE_SEPARATOR);
     }
 
-    private String extractPageId(String sitemapWithPageId) {
-        return sitemapWithPageId.split(SITEMAP_PAGE_SEPARATOR)[1];
+    private @Nullable String extractPageId(String sitemapWithPageId) {
+        if (isPageListener(sitemapWithPageId)) {
+            return sitemapWithPageId.split(SITEMAP_PAGE_SEPARATOR)[1];
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
Sitemap SSE subscriptions to all pages in a sitemap lead to an index out of bound exception.
While it is not recommended to create a subscription to all pages, there is an endpoint for it, and it should work.