### PR TITLE
MQTT transport websocket path

### DIFF
--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnection.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnection.java
@@ -59,6 +59,7 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
  * @author Jan N. Klug - changed from PAHO to HiveMQ client
  * @author Mark Herwege - Added flag for hostname validation
  * @author Mark Herwege - Added parameter for cleanSession/cleanStart
+ * @author Mark Herwege - Added parameter for WebSocket path
  */
 @NonNullByDefault
 public class MqttBrokerConnection {
@@ -92,6 +93,7 @@ public class MqttBrokerConnection {
     protected final boolean hostnameValidated;
     protected final MqttVersion mqttVersion;
     private boolean cleanSessionStart = true;
+    private String webSocketPath = "";
 
     private @Nullable TrustManagerFactory trustManagerFactory = InsecureTrustManagerFactory.INSTANCE;
     protected final String clientId;
@@ -524,6 +526,28 @@ public class MqttBrokerConnection {
     }
 
     /**
+     * Sets the server path used for the WebSocket handshake when {@link #protocol} is {@link Protocol#WEBSOCKETS}.
+     * Only takes effect on the next connection attempt (i.e. call this before {@link #start()}, or before a
+     * reconnect if changing it at runtime). Has no effect for {@link Protocol#TCP} connections.
+     * <p>
+     * Defaults to an empty path, matching the previous, fixed behaviour of this class.
+     *
+     * @param webSocketPath the server path to use, e.g. {@code /mqtt}; an empty string uses the default (unspecified)
+     *            path
+     */
+    public void setWebSocketPath(String webSocketPath) {
+        this.webSocketPath = webSocketPath;
+    }
+
+    /**
+     * Return the WebSocket server path configured via {@link #setWebSocketPath(String)}, or an empty string if none was
+     * set.
+     */
+    public String getWebSocketPath() {
+        return webSocketPath;
+    }
+
+    /**
      * Return true if there are subscribers registered via {@link #subscribe(String, MqttMessageSubscriber)}.
      * Call {@link #unsubscribe(String, MqttMessageSubscriber)} or {@link #unsubscribeAll()} if necessary.
      */
@@ -732,10 +756,10 @@ public class MqttBrokerConnection {
 
     protected MqttAsyncClientWrapper createClient() {
         if (mqttVersion == MqttVersion.V3) {
-            return new Mqtt3AsyncClientWrapper(host, port, clientId, protocol, secure, hostnameValidated,
+            return new Mqtt3AsyncClientWrapper(host, port, clientId, protocol, webSocketPath, secure, hostnameValidated,
                     connectionCallback, trustManagerFactory);
         } else {
-            return new Mqtt5AsyncClientWrapper(host, port, clientId, protocol, secure, hostnameValidated,
+            return new Mqtt5AsyncClientWrapper(host, port, clientId, protocol, webSocketPath, secure, hostnameValidated,
                     connectionCallback, trustManagerFactory);
         }
     }

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/client/Mqtt3AsyncClientWrapper.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/client/Mqtt3AsyncClientWrapper.java
@@ -39,19 +39,24 @@ import com.hivemq.client.mqtt.mqtt3.message.unsubscribe.Mqtt3Unsubscribe;
  * @author Jan N. Klug - Initial contribution
  * @author Mark Herwege - Added flag for hostname validation
  * @author Mark Herwege - Added parameter for cleanSession
+ * @author Mark Herwege - Added parameter for WebSocket path
  */
 @NonNullByDefault
 public class Mqtt3AsyncClientWrapper extends MqttAsyncClientWrapper {
     private final Mqtt3AsyncClient client;
 
-    public Mqtt3AsyncClientWrapper(String host, int port, String clientId, Protocol protocol, boolean secure,
-            boolean hostnameValidated, ConnectionCallback connectionCallback,
+    public Mqtt3AsyncClientWrapper(String host, int port, String clientId, Protocol protocol, String webSocketPath,
+            boolean secure, boolean hostnameValidated, ConnectionCallback connectionCallback,
             @Nullable TrustManagerFactory trustManagerFactory) {
         Mqtt3ClientBuilder clientBuilder = Mqtt3Client.builder().serverHost(host).serverPort(port).identifier(clientId)
                 .addConnectedListener(connectionCallback).addDisconnectedListener(connectionCallback);
 
         if (protocol == Protocol.WEBSOCKETS) {
-            clientBuilder.webSocketWithDefaultConfig();
+            if (webSocketPath.isEmpty()) {
+                clientBuilder.webSocketWithDefaultConfig();
+            } else {
+                clientBuilder.webSocketConfig().serverPath(webSocketPath).applyWebSocketConfig();
+            }
         }
         if (secure) {
             if (hostnameValidated) {

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/client/Mqtt5AsyncClientWrapper.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/client/Mqtt5AsyncClientWrapper.java
@@ -40,19 +40,24 @@ import com.hivemq.client.mqtt.mqtt5.message.unsubscribe.Mqtt5Unsubscribe;
  * @author Jan N. Klug - Initial contribution
  * @author Mark Herwege - Added flag for hostname validation
  * @author Mark Herwege - Added parameter for cleanStart
+ * @author Mark Herwege - Added parameter for WebSocket path
  */
 @NonNullByDefault
 public class Mqtt5AsyncClientWrapper extends MqttAsyncClientWrapper {
     private final Mqtt5AsyncClient client;
 
-    public Mqtt5AsyncClientWrapper(String host, int port, String clientId, Protocol protocol, boolean secure,
-            boolean hostnameValidated, ConnectionCallback connectionCallback,
+    public Mqtt5AsyncClientWrapper(String host, int port, String clientId, Protocol protocol, String webSocketPath,
+            boolean secure, boolean hostnameValidated, ConnectionCallback connectionCallback,
             @Nullable TrustManagerFactory trustManagerFactory) {
         Mqtt5ClientBuilder clientBuilder = Mqtt5Client.builder().serverHost(host).serverPort(port).identifier(clientId)
                 .addConnectedListener(connectionCallback).addDisconnectedListener(connectionCallback);
 
         if (protocol == Protocol.WEBSOCKETS) {
-            clientBuilder.webSocketWithDefaultConfig();
+            if (webSocketPath.isEmpty()) {
+                clientBuilder.webSocketWithDefaultConfig();
+            } else {
+                clientBuilder.webSocketConfig().serverPath(webSocketPath).applyWebSocketConfig();
+            }
         }
         if (secure) {
             if (hostnameValidated) {


### PR DESCRIPTION
MQTT using websockets can connect to a server at a specific path.

The MQTT transport so far did not support this.

I am working on a binding that does require setting a specific path. Not having this in the transport would make it impossible to use the transport for this.